### PR TITLE
Add `Oban.drain_queue/1` for integration testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   of `%{timing: timing}`. This aligns with the `telemetry` standard of using
   `duration` for the time to execute something.
 
+- [Oban] Add `Oban.drain_queue/1` to help with integration testing. Draining a
+  queue synchronously executes all available jobs in the queue from within the
+  calling process. This avoids any sandbox based database connection issues and
+  prevents race conditions from asynchronous processing.
+
 ## [0.3.0] - 2019-05-29
 
 **Migration Required (V2)**

--- a/README.md
+++ b/README.md
@@ -311,6 +311,34 @@ refute_enqueued queue: "special", args: %{id: 2}
 
 See the `Oban.Testing` module for more details.
 
+## Integration Testing
+
+During integration testing it may be necessary to run jobs because they do work
+essential for the test to complete, i.e. sending an email, processing media,
+etc. You can execute all available jobs in a particular queue by calling
+`Oban.drain_queue/1` directly from your tests.
+
+For example, to process all pending jobs in the "mailer" queue while testing
+some business logic:
+
+```elixir
+defmodule MyApp.BusinessTest do
+  use MyApp.DataCase, async: true
+
+  alias MyApp.{Business, Worker}
+
+  test "we stay in the business of doing business" do
+    :ok = Business.schedule_a_meeting(%{email: "monty@brewster.com"})
+
+    assert 1 == Oban.drain_queue(:mailer)
+
+    # Now, make an assertion about the email delivery
+  end
+end
+```
+
+See `Oban.drain_queue/1` for additional details.
+
 ## Contributing
 
 To run the Oban test suite you must have PostgreSQL 10+ running locally with a

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ defmodule MyApp.BusinessTest do
   test "we stay in the business of doing business" do
     :ok = Business.schedule_a_meeting(%{email: "monty@brewster.com"})
 
-    assert 1 == Oban.drain_queue(:mailer)
+    assert %{success: 1, failure: 0} == Oban.drain_queue(:mailer)
 
     # Now, make an assertion about the email delivery
   end

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -157,7 +157,34 @@ defmodule Oban do
   refute_enqueued queue: "special", args: %{id: 2}
   ```
 
-  See the `Oban.Testing` module for more details.
+  See the `Oban.Testing` module for more details on making assertions.
+
+  ## Integration Testing
+
+  During integration testing it may be necessary to run jobs because they do work essential for
+  the test to complete, i.e. sending an email, processing media, etc. You can execute all
+  available jobs in a particular queue by calling `Oban.drain_queue/1` directly from your tests.
+
+  For example, to process all pending jobs in the "mailer" queue while testing some business
+  logic:
+
+  ```elixir
+  defmodule MyApp.BusinessTest do
+    use MyApp.DataCase, async: true
+
+    alias MyApp.{Business, Worker}
+
+    test "we stay in the business of doing business" do
+      :ok = Business.schedule_a_meeting(%{email: "monty@brewster.com"})
+
+      assert 1 == Oban.drain_queue(:mailer)
+
+      # Make an assertion about the email delivery
+    end
+  end
+  ```
+
+  See `Oban.drain_queue/1` for additional details.
 
   ## Error Handling
 
@@ -172,9 +199,9 @@ defmodule Oban do
   Execution errors are stored as a formatted exception along with metadata about when the failure
   ocurred and which attempt caused it. Each error is stored with the following keys:
 
-  - `at` The utc timestamp when the error occurred at
-  - `attempt` The attempt number when the error ocurred
-  - `error` A formatted error message and stacktrace
+  * `at` The utc timestamp when the error occurred at
+  * `attempt` The attempt number when the error ocurred
+  * `error` A formatted error message and stacktrace
 
   See the [Instrumentation](#module-instrumentation) docs below for an example of integrating with
   external error reporting systems.
@@ -261,6 +288,7 @@ defmodule Oban do
   use Supervisor
 
   alias Oban.{Config, Notifier, Pruner}
+  alias Oban.Queue.Producer
   alias Oban.Queue.Supervisor, as: QueueSupervisor
 
   @type option ::
@@ -352,6 +380,38 @@ defmodule Oban do
   Retreive the current config struct.
   """
   defdelegate config, to: Config, as: :get
+
+  @doc """
+  Synchronously execute all available jobs in a queue. All execution happens within the current
+  process and it is guaranteed not to raise an error or exit.
+
+  Draining a queue from within the current process is especially useful for testing. Jobs that are
+  enqueued by a process when Ecto is in sandbox mode are only visible to that process. Calling
+  `drain_queue/1` allows you to control when the jobs are executed and to wait synchronously for
+  all jobs to complete.
+
+  ## Failures & Retries
+
+  Draining a queue uses the same execution mechanism as regular job dispatch. That means that any
+  job failures or crashes will be captured and result in a retry. Failures are _not_ reported back
+  to the calling process. If you expect jobs to fail, would like to track failures, or need to
+  check for specific errors you can use one of these mechanisms:
+
+  * Check for side effects from job execution
+  * Use telemetry events to track success and failure
+  * Check the database for jobs with errors
+
+  ## Example
+
+  Drain a queue with three available jobs:
+
+      Oban.drain_queue(:default)
+      3
+  """
+  @spec drain_queue(queue :: atom() | binary()) :: non_neg_integer()
+  def drain_queue(queue) when is_atom(queue) or is_binary(queue) do
+    Producer.drain(to_string(queue), config())
+  end
 
   @doc """
   Pause a running queue, preventing it from executing any new jobs. All running jobs will remain

--- a/test/integration/draining_test.exs
+++ b/test/integration/draining_test.exs
@@ -1,0 +1,31 @@
+defmodule Oban.Integration.DrainingTest do
+  use Oban.Case
+
+  @moduletag :integration
+
+  @oban_opts repo: Repo, queues: false
+
+  test "all jobs in a queue can be drained and executed synchronously" do
+    start_supervised!({Oban, @oban_opts})
+
+    insert_job!(ref: 1, action: "OK")
+    insert_job!(ref: 2, action: "FAIL")
+    insert_job!(ref: 3, action: "OK")
+
+    assert 3 == Oban.drain_queue(:draining)
+
+    assert_received {:ok, 3}
+    assert_received {:fail, 2}
+    assert_received {:ok, 1}
+
+    stop_supervised(Oban)
+  end
+
+  defp insert_job!(args) do
+    args
+    |> Map.new()
+    |> Map.put(:bin_pid, Worker.pid_to_bin())
+    |> Job.new(worker: Worker, queue: :draining)
+    |> Repo.insert!()
+  end
+end

--- a/test/integration/draining_test.exs
+++ b/test/integration/draining_test.exs
@@ -12,7 +12,7 @@ defmodule Oban.Integration.DrainingTest do
     insert_job!(ref: 2, action: "FAIL")
     insert_job!(ref: 3, action: "OK")
 
-    assert 3 == Oban.drain_queue(:draining)
+    assert %{success: 2, failure: 1} = Oban.drain_queue(:draining)
 
     assert_received {:ok, 3}
     assert_received {:fail, 2}


### PR DESCRIPTION
Draining a queue synchronously executes all available jobs in the queue from within the calling process. This avoids any sandbox based database connection issues and prevents race conditions from asynchronous processing.

@josevalim @LostKobrakai would you mind taking a look?

Closes #7