### PR TITLE
Fix typo in scheduling example

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,11 +269,11 @@ The worker's defaults may be overridden by passing options:
 |> MyApp.Repo.insert()
 ```
 
-Jobs may be scheduled down to the second any time in the future:
+Jobs may be scheduled or delayed down to the second any time in the future:
 
 ```elixir
 %{id: 1}
-|> MyApp.Workers.Business.new(schedule_in: 5)
+|> MyApp.Workers.Business.new(scheduled_in: 5)
 |> MyApp.Repo.insert()
 ```
 


### PR DESCRIPTION
What it say's on the tin!

I think the typo form is preferrable - `schedule_in`, however, updating the changeset field name would be a breaking change.. so perhaps a good candidate for the next major version release