### PR TITLE
Raise on test run so `mix ci` alias chain does not report false pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,5 +365,5 @@ following commands:
 
 * Check formatting (`mix format --check-formatted`)
 * Lint with Credo (`mix credo --strict`)
-* Run all tests (`mix test`)
+* Run all tests (`mix test --raise`)
 * Run Dialyzer (`mix dialyzer --halt-exit-status`)

--- a/mix.exs
+++ b/mix.exs
@@ -67,6 +67,13 @@ defmodule Oban.MixProject do
   end
 
   defp aliases do
-    [ci: ["format --check-formatted", "credo --strict", "test", "dialyzer --halt-exit-status"]]
+    [
+      ci: [
+        "format --check-formatted",
+        "credo --strict",
+        "test --raise",
+        "dialyzer --halt-exit-status"
+      ]
+    ]
   end
 end


### PR DESCRIPTION
As seen here on CircleCI 👉 https://circleci.com/gh/sorentwo/oban/57

`mix test` is currently exiting with a non zero code, but given how alias chains work, CircleCI still believes the task completes successfully given Dialyzer exits with 0.

This change will raise on failure so we actually know if a test is failing on CI

EDIT: Apologies for not actually fixing the failing tests, I will loop back and do just that if someone else doesn't get to it first :)