### PR TITLE
Treat returned error tuples as a job failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   deleted on each prune iteration. This prevents locking the database when there
   are a large number of jobs to delete.
 
+### Changed
+
+- [Oban.Worker] Treat `{:error, reason}` tuples returned from `perform/1` as a
+  failure. The `:kind` value reported in telemetry events is now differentiated,
+  where a rescued exception has the kind `:exception`, and an error tuple has
+  the kind `:error`.
+
 ### Fixed
 
 - [Oban.Testing] Only check `available` and `scheduled` jobs with the

--- a/README.md
+++ b/README.md
@@ -244,9 +244,10 @@ defmodule MyApp.Workers.Business do
 end
 ```
 
-The return value of `perform/1` doesn't matter and is entirely ignored. If the
-job raises an exception or throws an exit then the error will be reported and
-the job will be retried (provided there are attempts remaining).
+The value returned from `perform/1` is ignored, unless it returns an `{:error,
+reason}` tuple. With an error return or when perform has an uncaught exception
+or throw then the error will be reported and the job will be retried (provided
+there are attempts remaining).
 
 #### Enqueueing Jobs
 

--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -2,8 +2,8 @@ defmodule Oban.Telemetry do
   @moduledoc """
   Telemetry integration for event metrics, logging and error reporting.
 
-  Oban currently emits an event when a job has exeucted: `[:oban, :success]` if the job
-  succeeded or `[:oban, :failure]` if there was an error or the process crashed.
+  Oban currently emits an event when a job has exeucted: `[:oban, :success]` if the job succeeded
+  or `[:oban, :failure]` if there was an error or the process crashed.
 
   All job events share the same details about the job that was executed. In addition, failed jobs
   provide the error type, the error itself, and the stacktrace. The following chart shows which
@@ -13,6 +13,16 @@ defmodule Oban.Telemetry do
   | ---------- | ---------------------------------------------------------------------------- |
   | `:success` | `:id, :args, :queue, :worker, :attempt, :max_attempt`                        |
   | `:failure` | `:id, :args, :queue, :worker, :attempt, :max_attempt, :kind, :error, :stack` |
+
+  For `:failure` events the metadata will include details about what caused the failure. The
+  `:kind` value is determined by how an error occurred. Here are the possible kinds:
+
+  * `:error` — from an `{:error, error}` return value. Some Erlang functions may also throw an
+    `:error` tuple, which will be reported as `:error`.
+  * `:exception` — from a rescued exception
+  * `:exit` — from a caught process exit
+  * `:throw` — from a caught value, this doesn't necessarily mean that an error occurred and the
+    error value is unpredictable
 
   ## Default Logger
 

--- a/lib/oban/worker.ex
+++ b/lib/oban/worker.ex
@@ -18,9 +18,32 @@ defmodule Oban.Worker do
         end
       end
 
-  The `perform/1` function will always receive the jobs `args` map. In this example the worker
-  will simply inspect any arguments that are provided. Note that the return value isn't important.
-  If `perform/1` returns without raising an exception the job is considered complete.
+  The `perform/1` function will always receive a job's `args` map. In this example the worker will
+  simply inspect any arguments that are provided. A job is considered complete if `perform/1`
+  returns a non-error value, and it doesn't raise an exception or have an unhandled exit.
+
+  Any of these return values or error events will fail the job:
+
+  * return `{:error, error}`
+  * return `:error`
+  * an unhandled exception
+  * an unhandled exit or throw
+
+  As an example of error tuple handling, this worker may return an error tuple when the value is
+  less than one:
+
+      defmodule MyApp.Workers.ErrorExample do
+        use Oban.Worker
+
+        @impl true
+        def perform(%{value: value}) do
+          if value > 1 do
+            :ok
+          else
+            {:error, "invalid value given: " <> inspect(value)"}
+          end
+        end
+      end
 
   ## Enqueuing Jobs
 

--- a/test/integration/executing_test.exs
+++ b/test/integration/executing_test.exs
@@ -67,7 +67,7 @@ defmodule Oban.Integration.ExecutingTest do
   end
 
   def action do
-    oneof(~w(OK FAIL EXIT))
+    oneof(~w(OK FAIL ERROR EXIT))
   end
 
   # Helpers

--- a/test/integration/telemetry_test.exs
+++ b/test/integration/telemetry_test.exs
@@ -18,32 +18,50 @@ defmodule Oban.Integration.TelemetryTest do
 
     {:ok, _} = start_supervised({Oban, @oban_opts})
 
-    %Job{id: succ_id} = insert_job!(%{ref: 1, action: "OK"})
-    %Job{id: fail_id} = insert_job!(%{ref: 2, action: "FAIL"})
+    %Job{id: success_id} = insert_job!(%{ref: 1, action: "OK"})
+    %Job{id: exception_id} = insert_job!(%{ref: 2, action: "FAIL"})
+    %Job{id: error_id} = insert_job!(%{ref: 2, action: "ERROR"})
 
-    assert_receive {:executed, :success, succ_duration, succ_meta}
-    assert_receive {:executed, :failure, fail_duration, fail_meta}
+    assert_receive {:executed, :success, success_duration, success_meta}
+    assert_receive {:executed, :failure, exception_duration, %{kind: :exception} = exception_meta}
+    assert_receive {:executed, :failure, error_duration, %{kind: :error} = error_meta}
 
-    assert succ_duration > 0
-    assert fail_duration > 0
+    assert success_duration > 0
+    assert exception_duration > 0
+    assert error_duration > 0
 
     assert %{
-             id: ^succ_id,
+             id: ^success_id,
              args: %{},
              queue: "zeta",
              worker: "Oban.Integration.Worker",
              attempt: 1,
              max_attempts: 20
-           } = succ_meta
+           } = success_meta
 
     assert %{
-             id: ^fail_id,
+             id: ^exception_id,
              args: %{},
              queue: "zeta",
              worker: "Oban.Integration.Worker",
              attempt: 1,
-             max_attempts: 20
-           } = fail_meta
+             max_attempts: 20,
+             kind: :exception,
+             error: _,
+             stack: [_ | _]
+           } = exception_meta
+
+    assert %{
+             id: ^error_id,
+             args: %{},
+             queue: "zeta",
+             worker: "Oban.Integration.Worker",
+             attempt: 1,
+             max_attempts: 20,
+             kind: :error,
+             error: "ERROR",
+             stack: [_ | _]
+           } = error_meta
 
     :ok = stop_supervised(Oban)
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -20,6 +20,11 @@ defmodule Oban.Integration.Worker do
 
         raise RuntimeError, "FAILED"
 
+      "ERROR" ->
+        send(pid, {:error, ref})
+
+        {:error, "ERROR"}
+
       "EXIT" ->
         send(pid, {:exit, ref})
 


### PR DESCRIPTION
This changes `safe_call` to treat error tuples as a failure. The job will be retried just as if there was an exception or an exit, but the telemetry kind is different. Now telemetry events differentiate between a manual error and an exception.

Closes #17

@lucasmazza Would you mind taking a look at this?