### PR TITLE
Show available jobs when assert_enqueued fails

### DIFF
--- a/lib/oban/testing.ex
+++ b/lib/oban/testing.ex
@@ -170,10 +170,12 @@ defmodule Oban.Testing do
   end
 
   defp available_jobs(repo, opts) do
+    fields = Keyword.keys(opts)
+
     base_query([])
-    |> select(^Keyword.keys(opts))
+    |> select(^fields)
     |> repo.all()
-    |> Enum.map(&Map.take(&1, Keyword.keys(opts)))
+    |> Enum.map(&Map.take(&1, fields))
   end
 
   defp base_query(opts) do

--- a/lib/oban/testing.ex
+++ b/lib/oban/testing.ex
@@ -144,7 +144,10 @@ defmodule Oban.Testing do
   @doc since: "0.3.0"
   @spec assert_enqueued(repo :: module(), opts :: Keyword.t()) :: true
   def assert_enqueued(repo, [_ | _] = opts) do
-    assert get_job(repo, opts), "Expected a job matching #{inspect(opts)} to be enqueued"
+    assert get_job(repo, opts),
+           "Expected a job matching #{inspect(opts)} to be enqueued. Found: #{
+             inspect(available_jobs(repo))
+           }"
   end
 
   @doc """
@@ -164,6 +167,13 @@ defmodule Oban.Testing do
     |> limit(1)
     |> select([:id])
     |> repo.one()
+  end
+
+  defp available_jobs(repo) do
+    base_query([])
+    |> select([:worker, :args])
+    |> repo.all()
+    |> Enum.map(&Map.take(&1, [:worker, :args]))
   end
 
   defp base_query(opts) do

--- a/lib/oban/testing.ex
+++ b/lib/oban/testing.ex
@@ -146,7 +146,7 @@ defmodule Oban.Testing do
   def assert_enqueued(repo, [_ | _] = opts) do
     assert get_job(repo, opts),
            "Expected a job matching #{inspect(opts)} to be enqueued. Found: #{
-             inspect(available_jobs(repo))
+             inspect(available_jobs(repo, opts))
            }"
   end
 
@@ -169,11 +169,11 @@ defmodule Oban.Testing do
     |> repo.one()
   end
 
-  defp available_jobs(repo) do
+  defp available_jobs(repo, opts) do
     base_query([])
-    |> select([:worker, :args])
+    |> select(^Keyword.keys(opts))
     |> repo.all()
-    |> Enum.map(&Map.take(&1, [:worker, :args]))
+    |> Enum.map(&Map.take(&1, Keyword.keys(opts)))
   end
 
   defp base_query(opts) do


### PR DESCRIPTION
Hi there!

I was having some trouble figuring out why a job was not enqueued (a misspelling, it turns out), and I thought it was a good idea to print the available jobs in case it fails to match. Here's a print of the error message in my terminal:

![image](https://user-images.githubusercontent.com/4276593/61318474-8c000a00-a7db-11e9-9bef-a194ca11d614.png)

Thanks!