### PR TITLE
Accept a job struct as the argument to perform/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   an `ArgumentError` and halt startup. This prevents misconfiguration through
   typos and passing unsupported options.
 
+- [Oban.Worker] The `perform/1` function now receives an `Oban.Job` struct as
+  the sole argument, calling `perform/1` again with only the `args` map if no
+  clause catches the struct. This allows workers to use any attribute of the job
+  to customize behaviour, e.g. the number of attempts or when a job was inserted
+  into the database.
+
+  The implementation is entirely backward compatible, provided workers are
+  defined with the `use` macro. Workers that implement the `Oban.Worker`
+  behaviour manually will need to change the signature of `perform/1` to accept
+  a job struct.
+
 ## [0.5.0] — 2019-06-27
 
 ### Added

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -52,10 +52,11 @@ defmodule Oban do
     The BEAM ensures that the system stays responsive under load, but those guarantees don't apply
     when using ports or shelling out commands.
 
-  ### Creating Workers
+  ### Defining Workers
 
   Worker modules do the work of processing a job. At a minimum they must define a `perform/1`
-  function, which is called with an `args` map.
+  function, which is called first with the full `Oban.Job` struct, and subsequently with the
+  `args` map if no clause matches.
 
   Define a worker to process jobs in the `events` queue:
 
@@ -63,7 +64,6 @@ defmodule Oban do
   defmodule MyApp.Workers.Business do
     use Oban.Worker, queue: "events", max_attempts: 10
 
-    @impl Oban.Worker
     def perform(%{"id" => id}) do
       model = MyApp.Repo.get(MyApp.Business.Man, id)
 

--- a/lib/oban/queue/executor.ex
+++ b/lib/oban/queue/executor.ex
@@ -36,10 +36,10 @@ defmodule Oban.Queue.Executor do
   end
 
   @doc false
-  def safe_call(%Job{args: args, worker: worker} = job) do
+  def safe_call(%Job{worker: worker} = job) do
     worker
     |> to_module()
-    |> apply(:perform, [args])
+    |> apply(:perform, [job])
     |> case do
       {:error, error} ->
         {:current_stacktrace, stacktrace} = Process.info(self(), :current_stacktrace)


### PR DESCRIPTION
The `perform/1` function now receives an `Oban.Job` struct as the sole argument, calling `perform/1` again with only the `args` map if no clause catches the struct. This allows workers to use any attribute of the job to customize behaviour, e.g. the number of attempts or when a job was inserted into the database.

The implementation is entirely backward compatible, provided workers are defined with the `use` macro. Workers that implement the `Oban.Worker` behaviour manually will need to change the signature of `perform/1` to accept a job struct.

Addresses the first part of #27 

---

I'm opening this as a PR to get some feedback on the implementation and documentation.

/cc @andykent