### PR TITLE
Unique job support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- [Oban] Added `insert/2`, `insert!/2` and `insert/4` as a convenient and more
+  powerful way to insert jobs. Features such as unique jobs and the upcoming
+  prefix support only work with `insert`.
+
+- [Oban.Worker] Compile time validation of all passed options. Catch typos and
+  other invalid options when a worker is compiled rather than when a job is
+  inserted for the first time.
+
+- [Oban.Worker] Unique job support through the `unique` option. Set a unique
+  period, and optionally `fields` and `states`, to enforce uniqueness within a
+  window of time. For example, to make a job unique by args, queue and worker
+  for 2 minutes:
+
+  ```
+  use Oban.Worker, unique: [period: 120, fields: [:args, :queue, :worker]]
+  ```
+
+  Note, unique support relies on the use of `Oban.insert/2,4`.
+
 ### Changed
 
 - [Oban.Producer] Use `send_after/3` instead of `:timer.send_interval/2` to

--- a/README.md
+++ b/README.md
@@ -252,6 +252,14 @@ reason}` tuple. With an error return or when perform has an uncaught exception
 or throw then the error will be reported and the job will be retried (provided
 there are attempts remaining).
 
+The `Business` worker can also be configured to prevent duplicates for a period
+of time through the `:unique` option. Here we'll configure it to be unique for
+60 seconds:
+
+```elixir
+use Oban.Worker, queue: "events", max_attempts: 10, unique: [period: 60]
+```
+
 #### Enqueueing Jobs
 
 Jobs are simply Ecto structs and are enqueued by inserting them into the
@@ -327,7 +335,10 @@ Although Oban keeps all jobs in the database for durability and observability, i
 * Limit-based - Keeps the latest N records. Example: `{:maxlen, 100_000}`
 * Time-based - Keeps records for the last N seconds. Example for 7 days: `{:maxage, 60 * 60 * 24 * 7}`
 
-Important: pruning is only applied to jobs that are completed or discarded (has reached the maximum number of retries or has been manually killed). It'll never delete a new job, a scheduled job or a job that failed and will be retried.
+**Important**: Pruning is only applied to jobs that are completed or discarded
+(has reached the maximum number of retries or has been manually killed). It'll
+never delete a new job, a scheduled job or a job that failed and will be
+retried.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ Advanced features and advantages over other RDBMS based tools:
   `discarded`.
 - **Triggered execution** — Database triggers ensure that jobs are dispatched as
   soon as they are inserted into the database.
+- **Unique Jobs** — Duplicate work can be avoided through unique job controls.
+  Uniqueness can be enforced at the argument, queue and worker level for any
+  period of time.
 - **Scheduled Jobs** — Jobs can be scheduled at any time in the future, down to
   the second.
 - **Job Safety** — When a process crashes or the BEAM is terminated executing
@@ -146,16 +149,16 @@ mix ecto.migrate
 Next see [Usage](#Usage) for how to integrate Oban into your application and
 start defining jobs!
 
+[ecto]: https://hex.pm/packages/ecto
+[jason]: https://hex.pm/packages/jason
+[postgrex]: https://hex.pm/packages/postgrex
+
 #### Note About Releases
 
 If you are using releases you may see Postgrex errors logged during your initial
 deploy (or any deploy requiring an Oban migration). The errors are only
 temporary. After the migration has completed each queue will start producing
 jobs normally.
-
-[ecto]: https://hex.pm/packages/ecto
-[jason]: https://hex.pm/packages/jason
-[postgrex]: https://hex.pm/packages/postgrex
 
 ## Usage
 
@@ -191,14 +194,12 @@ defmodule MyApp.Application do
 end
 ```
 
-If you are running tests (which you should be) you'll need to disable pruning
+If you are running tests (which you should be) you'll want to disable pruning
 and job dispatching altogether when testing:
 
 ```elixir
 # config/test.exs
-config :my_app, Oban,
-  queues: false,
-  prune: :disabled
+config :my_app, Oban, queues: false, prune: :disabled
 ```
 
 Without dispatch and pruning disabled Ecto will raise constant ownership errors
@@ -226,7 +227,7 @@ concurrently. Here are a few caveats and guidelines:
   ImageMagick). The BEAM ensures that the system stays responsive under load,
   but those guarantees don't apply when using ports or shelling out commands.
 
-#### Creating Workers
+#### Defining Workers
 
 Worker modules do the work of processing a job. At a minimum they must define a
 `perform/1` function, which is called with an `args` map.
@@ -234,7 +235,7 @@ Worker modules do the work of processing a job. At a minimum they must define a
 Define a worker to process jobs in the `events` queue:
 
 ```elixir
-defmodule MyApp.Workers.Business do
+defmodule MyApp.Business do
   use Oban.Worker, queue: "events", max_attempts: 10
 
   @impl Oban.Worker
@@ -259,32 +260,49 @@ function that converts an args map into a job changeset suitable for insertion:
 
 ```elixir
 %{in_the: "business", of_doing: "business"}
-|> MyApp.Workers.Business.new()
-|> MyApp.Repo.insert()
+|> MyApp.Business.new()
+|> Oban.insert()
 ```
 
 The worker's defaults may be overridden by passing options:
 
 ```elixir
 %{vote_for: "none of the above"}
-|> MyApp.Workers.Business.new(queue: "special", max_attempts: 5)
-|> MyApp.Repo.insert()
+|> MyApp.Business.new(queue: "special", max_attempts: 5)
+|> Oban.insert()
 ```
 
 Jobs may be scheduled at a specific datetime in the future:
 
 ```elixir
 %{id: 1}
-|> MyApp.Workers.Business.new(scheduled_at: ~U[2020-12-25 19:00:56.0Z])
-|> MyApp.Repo.insert()
+|> MyApp.Business.new(scheduled_at: ~U[2020-12-25 19:00:56.0Z])
+|> Oban.insert()
 ```
 
 Jobs may also be scheduled down to the second any time in the future:
 
 ```elixir
 %{id: 1}
-|> MyApp.Workers.Business.new(schedule_in: 5)
-|> MyApp.Repo.insert()
+|> MyApp.Business.new(schedule_in: 5)
+|> Oban.insert()
+```
+
+Unique jobs can be configured in the worker, or when the job is built:
+
+```elixir
+%{email: "brewster@example.com"}
+|> MyApp.Mailer.new(unique: [period: 300, fields: [:queue, :worker])
+|> Oban.insert()
+```
+
+Multiple jobs can be inserted in a single transaction:
+
+```elixir
+Ecto.Multi.new()
+|> Oban.insert(:b_job, MyApp.Business.new(%{id: 1}))
+|> Oban.insert(:m_job, MyApp.Mailer.new(%{email: "brewser@example.com"}))
+|> Repo.transaction()
 ```
 
 Occasionally you may need to insert a job for a worker that exists in another
@@ -294,8 +312,12 @@ manually:
 ```elixir
 %{id: 1, user_id: 2}
 |> Oban.Job.new(queue: :default, worker: OtherApp.Worker)
-|> MyApp.Repo.insert()
+|> Oban.insert()
 ```
+
+`Oban.insert/2,4` is the preferred way of inserting jobs as it provides some of
+Oban's advanced features (i.e., unique jobs). However, you can use your
+application's `Repo.insert/2` function if necessary.
 
 #### Pruning
 
@@ -385,10 +407,11 @@ See `Oban.drain_queue/1` for additional details.
 
 ### Heroku
 
-If your app crashes on launch, be sure to confirm you are running the correct 
-version of Elixir and Erlang ([view requirements](#Requirements)). If using the 
-*hashnuke/elixir* buildpack, you can update the `elixir_buildpack.config` file 
-in your application's root directory to something like: 
+If your app crashes on launch, be sure to confirm you are running the correct
+version of Elixir and Erlang ([view requirements](#Requirements)). If using the
+*hashnuke/elixir* buildpack, you can update the `elixir_buildpack.config` file
+in your application's root directory to something like:
+
 ```
 # Elixir version
 elixir_version=1.9.0

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -268,7 +268,7 @@ defmodule Oban do
 
   use Supervisor
 
-  alias Oban.{Config, Notifier, Pruner}
+  alias Oban.{Config, Job, Notifier, Pruner, Query}
   alias Oban.Queue.Producer
   alias Oban.Queue.Supervisor, as: QueueSupervisor
 
@@ -367,6 +367,15 @@ defmodule Oban do
     name
     |> child_name("Config")
     |> Config.get()
+  end
+
+  @doc since: "0.7.0"
+  @spec insert(name :: atom(), changeset :: Ecto.Changeset.t()) ::
+          {:ok, Job.t()} | {:error, Ecto.Changeset.t()}
+  def insert(name \\ __MODULE__, changeset) when is_atom(name) do
+    name
+    |> config()
+    |> Query.fetch_or_insert_job(changeset)
   end
 
   @doc """

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -61,7 +61,7 @@ defmodule Oban do
   Define a worker to process jobs in the `events` queue:
 
   ```elixir
-  defmodule MyApp.Workers.Business do
+  defmodule MyApp.Business do
     use Oban.Worker, queue: "events", max_attempts: 10
 
     def perform(%{"id" => id}) do
@@ -87,32 +87,49 @@ defmodule Oban do
 
   ```elixir
   %{in_the: "business", of_doing: "business"}
-  |> MyApp.Workers.Business.new()
-  |> MyApp.Repo.insert()
+  |> MyApp.Business.new()
+  |> Oban.insert()
   ```
 
   The worker's defaults may be overridden by passing options:
 
   ```elixir
   %{vote_for: "none of the above"}
-  |> MyApp.Workers.Business.new(queue: "special", max_attempts: 5)
-  |> MyApp.Repo.insert()
+  |> MyApp.Business.new(queue: "special", max_attempts: 5)
+  |> Oban.insert()
   ```
 
   Jobs may be scheduled at a specific datetime in the future:
 
   ```elixir
   %{id: 1}
-  |> MyApp.Workers.Business.new(scheduled_at: ~U[2020-12-25 19:00:56.0Z])
-  |> MyApp.Repo.insert()
+  |> MyApp.Business.new(scheduled_at: ~U[2020-12-25 19:00:56.0Z])
+  |> Oban.insert()
   ```
 
   Jobs may also be scheduled down to the second any time in the future:
 
   ```elixir
   %{id: 1}
-  |> MyApp.Workers.Business.new(schedule_in: 5)
-  |> MyApp.Repo.insert()
+  |> MyApp.Business.new(schedule_in: 5)
+  |> Oban.insert()
+  ```
+
+  Unique jobs can be configured in the worker, or when the job is built:
+
+  ```elixir
+  %{email: "brewster@example.com"}
+  |> MyApp.Mailer.new(unique: [period: 300, fields: [:queue, :worker])
+  |> Oban.insert()
+  ```
+
+  Multiple jobs can be inserted in a single transaction:
+
+  ```elixir
+  Ecto.Multi.new()
+  |> Oban.insert(:b_job, MyApp.Business.new(%{id: 1}))
+  |> Oban.insert(:m_job, MyApp.Mailer.new(%{email: "brewser@example.com"}))
+  |> Repo.transaction()
   ```
 
   Occasionally you may need to insert a job for a worker that exists in another
@@ -122,10 +139,59 @@ defmodule Oban do
   ```elixir
   %{id: 1, user_id: 2}
   |> Oban.Job.new(queue: :default, worker: OtherApp.Worker)
-  |> MyApp.Repo.insert()
+  |> Oban.insert()
   ```
 
+  `Oban.insert/2,4` is the preferred way of inserting jobs as it provides some of
+  Oban's advanced features (i.e., unique jobs). However, you can use your
+  application's `Repo.insert/2` function if necessary.
+
   See `Oban.Job.new/2` for a full list of job options.
+
+  ## Unique Jobs
+
+  The unique jobs feature lets you specify constraints to prevent enqueuing duplicate jobs.
+  Uniquness is based on a combination of `args`, `queue`, `worker`, `state` and insertion time. It
+  is configured at the worker or job level using the following options:
+
+  * `:period` — The number of seconds until a job is no longer considered duplicate. You should
+    always specify a period.
+  * `:fields` — The fields to compare when evaluating uniqueness. The available fields are
+    `:args`, `:queue` and `:worker`, by default all three are used.
+  * `:states` — The job states that will be checked for duplicates. The available states are
+    `:available`, `:scheduled`, `:executing`, `:retryable` and `:completed`. By default all states
+    are checked, which prevents _any_ duplicates, even if the previous job has been completed.
+
+  For example, configure a worker to be unique across all fields and states for 60 seconds:
+
+  ```elixir
+  use Oban.Worker, unique: [period: 60]
+  ```
+
+  Configure the worker to be unique only by `:worker` and `:queue`:
+
+  ```elixir
+  use Oban.Worker, unique: [fields: [:queue, :worker], period: 60]
+  ```
+
+  Or, configure a worker to be unique until it has executed:
+
+  ```elixir
+  use Oban.Worker, unique: [period: 300, states: [:available, :scheduled, :executing]]
+  ```
+
+  ### Stronger Guarantees
+
+  Oban's unique job support is built on a client side read/write cycle. That makes it subject to
+  duplicate writes if two transactions are started simultaneously. If you _absolutely must_ ensure
+  that a duplicate job isn't inserted then you will have to make use of unique constraints within
+  the database. `Oban.insert/2,4` will handle unique constraints safely through upsert support.
+
+  ### Performance Note
+
+  If your application makes heavy use of unique jobs you may want to add indexes on the `args` and
+  `inserted_at` columns of the `oban_jobs` table. The other columns considered for uniqueness are
+  already covered by indexes.
 
   ## Testing
 
@@ -138,19 +204,18 @@ defmodule Oban do
     created within the sandbox are rolled back at the end of the test. Additionally, the periodic
     pruning queries will raise `DBConnection.OwnershipError` when the application boots.
 
-  * Be sure to use the Ecto Sandbox for testing. Oban makes use of database pubsub
-    events to dispatch jobs, but pubsub events never fire within a transaction.
-    Since sandbox tests run within a transaction no events will fire and jobs
-    won't be dispatched.
+  * Be sure to use the Ecto Sandbox for testing. Oban makes use of database pubsub events to
+  dispatch jobs, but pubsub events never fire within a transaction.  Since sandbox tests run
+  within a transaction no events will fire and jobs won't be dispatched.
 
     ```elixir
     config :my_app, MyApp.Repo, pool: Ecto.Adapters.SQL.Sandbox
     ```
 
-  Oban provides some helpers to facilitate testing. The helpers handle the
-  boilerplate of making assertions on which jobs are enqueued. To use the
-  `assert_enqueued/1` and `refute_enqueued/1` helpers in your tests you must
-  include them in your testing module and specify your app's Ecto repo:
+  Oban provides some helpers to facilitate testing. The helpers handle the boilerplate of making
+  assertions on which jobs are enqueued. To use the `assert_enqueued/1` and `refute_enqueued/1`
+  helpers in your tests you must include them in your testing module and specify your app's Ecto
+  repo:
 
   ```elixir
   use Oban.Testing, repo: MyApp.Repo
@@ -370,6 +435,22 @@ defmodule Oban do
     |> Config.get()
   end
 
+  @doc """
+  Insert a new job into the database for execution.
+
+  This and the other `insert` variants are the recommended way to enqueue jobs because they
+  support features like unique jobs.
+
+  ## Example
+
+  Insert a single job:
+
+      {:ok, job} = Oban.insert(MyApp.Worker.new(%{id: 1}))
+
+  Insert a job while ensuring that it is unique within the past 30 seconds:
+
+      {:ok, job} = Oban.insert(MyApp.Worker.new(%{id: 1}, unique: [period: 30]))
+  """
   @doc since: "0.7.0"
   @spec insert(name :: atom(), changeset :: Changeset.t(Job.t())) ::
           {:ok, Job.t()} | {:error, Changeset.t()}
@@ -379,6 +460,19 @@ defmodule Oban do
     |> Query.fetch_or_insert_job(changeset)
   end
 
+  @doc """
+  Insert a job insert operation into an `Ecto.Multi`.
+
+  Like `insert/2`, this variant is recommended over `Ecto.Multi.insert` beause it supports all of
+  Oban's features, i.e. unique jobs.
+
+  ## Example
+
+      Ecto.Multi.new()
+      |> Oban.insert(:job_1, MyApp.Worker.new(%{id: 1}))
+      |> Oban.insert(:job_2, MyApp.Worker.new(%{id: 2}))
+      |> MyApp.Repo.transaction()
+  """
   @doc since: "0.7.0"
   @spec insert(
           name :: atom(),
@@ -393,6 +487,13 @@ defmodule Oban do
     |> Query.fetch_or_insert_job(multi, multi_name, changeset)
   end
 
+  @doc """
+  Similar to `insert/2`, but raises an `Ecto.InvalidChangesetError` if the job can't be inserted.
+
+  ## Example
+
+      job = Oban.insert!(MyApp.Worker.new(%{id: 1}))
+  """
   @doc since: "0.7.0"
   @spec insert!(name :: atom(), changeset :: Changeset.t(Job.t())) :: Job.t()
   def insert!(name \\ __MODULE__, %Changeset{} = changeset) when is_atom(name) do

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -268,7 +268,7 @@ defmodule Oban do
 
   use Supervisor
 
-  alias Ecto.Changeset
+  alias Ecto.{Changeset, Multi}
   alias Oban.{Config, Job, Notifier, Pruner, Query}
   alias Oban.Queue.Producer
   alias Oban.Queue.Supervisor, as: QueueSupervisor
@@ -379,6 +379,21 @@ defmodule Oban do
     |> Query.fetch_or_insert_job(changeset)
   end
 
+  @doc since: "0.7.0"
+  @spec insert(
+          name :: atom(),
+          multi :: Multi.t(),
+          multi_name :: atom(),
+          changeset :: Changeset.t(Job.t())
+        ) :: Multi.t()
+  def insert(name \\ __MODULE__, %Multi{} = multi, multi_name, %Changeset{} = changeset)
+      when is_atom(name) and is_atom(multi_name) do
+    name
+    |> config()
+    |> Query.fetch_or_insert_job(multi, multi_name, changeset)
+  end
+
+  @doc since: "0.7.0"
   @spec insert!(name :: atom(), changeset :: Changeset.t(Job.t())) :: Job.t()
   def insert!(name \\ __MODULE__, %Changeset{} = changeset) when is_atom(name) do
     case insert(name, changeset) do

--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -101,7 +101,7 @@ defmodule Oban.Job do
 
       %{id: 1, user_id: 2}
       |> Oban.Job.new(queue: :default, worker: MyApp.Worker)
-      |> MyApp.Repo.insert()
+      |> Oban.insert()
 
   Generate a pre-configured job for `MyApp.Worker` and push it:
 

--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -76,7 +76,6 @@ defmodule Oban.Job do
     scheduled_at
     state
     worker
-    unique
   )a
 
   @required ~w(worker args)a
@@ -165,7 +164,7 @@ defmodule Oban.Job do
   defp put_scheduling(changeset, value) do
     case value do
       in_seconds when is_integer(in_seconds) ->
-        scheduled_at = NaiveDateTime.add(NaiveDateTime.utc_now(), in_seconds)
+        scheduled_at = DateTime.add(DateTime.utc_now(), in_seconds)
 
         changeset
         |> put_change(:scheduled_at, scheduled_at)

--- a/lib/oban/query.ex
+++ b/lib/oban/query.ex
@@ -4,6 +4,7 @@ defmodule Oban.Query do
   import Ecto.Query
   import DateTime, only: [utc_now: 0]
 
+  alias Ecto.Changeset
   alias Oban.{Config, Job}
 
   # Taking a shared lock this way will always work, even if a lock has been taken by another
@@ -77,6 +78,14 @@ defmodule Oban.Query do
     ]
 
     repo.update_all(query, updates, log: verbose)
+  end
+
+  @spec fetch_or_insert_job(Config.t(), Changeset.t()) :: {:ok, Job.t()} | {:error, Changeset.t()}
+  def fetch_or_insert_job(%Config{repo: repo}, changeset) do
+    case get_unique_job(repo, changeset) do
+      %Job{} = job -> {:ok, job}
+      nil -> repo.insert(changeset, on_conflict: :nothing)
+    end
   end
 
   @spec stage_scheduled_jobs(Config.t(), binary()) :: {integer(), nil}
@@ -178,11 +187,28 @@ defmodule Oban.Query do
 
   # Helpers
 
-  defp next_attempt_at(backoff), do: NaiveDateTime.add(utc_now(), backoff, :second)
+  defp next_attempt_at(backoff), do: DateTime.add(utc_now(), backoff, :second)
 
   defp select_for_update(id) do
     Job
     |> where(id: ^id)
     |> select(%{lock: drop_lock(^id)})
   end
+
+  defp get_unique_job(repo, %{changes: %{unique: unique} = changes}) when is_map(unique) do
+    %{fields: fields, period: period, states: states} = unique
+
+    since = DateTime.add(utc_now(), period * -1, :second)
+    dynamic = for field <- fields, do: {field, Map.get(changes, field)}
+
+    Job
+    |> where([j], j.state in ^Enum.map(states, &to_string/1))
+    |> where([j], j.inserted_at > ^since)
+    |> where(^dynamic)
+    |> order_by(desc: :id)
+    |> limit(1)
+    |> repo.one()
+  end
+
+  defp get_unique_job(_repo, _changeset), do: nil
 end

--- a/lib/oban/testing.ex
+++ b/lib/oban/testing.ex
@@ -40,7 +40,7 @@ defmodule Oban.Testing do
     def work(args) do
       args
       |> Oban.Job.new(worker: MyApp.Worker, queue: :special)
-      |> MyApp.Repo.insert!()
+      |> Oban.insert!()
     end
   end
   ```

--- a/lib/oban/worker.ex
+++ b/lib/oban/worker.ex
@@ -159,7 +159,7 @@ defmodule Oban.Worker do
             |> Keyword.put(:worker, to_string(__MODULE__))
 
       @impl Worker
-      def new(args, opts \\ []) when is_map(args) do
+      def new(args, opts \\ []) when is_map(args) and is_list(opts) do
         Job.new(args, Keyword.merge(@opts, opts))
       end
 

--- a/test/integration/controlling_test.exs
+++ b/test/integration/controlling_test.exs
@@ -68,9 +68,7 @@ defmodule Oban.Integration.ControllingTest do
 
   defp insert_job!(args) do
     args
-    |> Map.new()
-    |> Map.put(:bin_pid, Worker.pid_to_bin())
-    |> Job.new(worker: Worker, queue: :control)
-    |> Repo.insert!()
+    |> Worker.new(queue: :control)
+    |> Oban.insert!()
   end
 end

--- a/test/integration/draining_test.exs
+++ b/test/integration/draining_test.exs
@@ -23,9 +23,7 @@ defmodule Oban.Integration.DrainingTest do
 
   defp insert_job!(args) do
     args
-    |> Map.new()
-    |> Map.put(:bin_pid, Worker.pid_to_bin())
-    |> Job.new(worker: Worker, queue: :draining)
-    |> Repo.insert!()
+    |> Worker.new(queue: :draining)
+    |> Oban.insert!()
   end
 end

--- a/test/integration/executing_test.exs
+++ b/test/integration/executing_test.exs
@@ -13,7 +13,7 @@ defmodule Oban.Integration.ExecutingTest do
 
   property "jobs in running queues are executed" do
     check all jobs <- list_of(job()), max_runs: 20 do
-      jobs = Enum.map(jobs, &Repo.insert!/1)
+      jobs = Enum.map(jobs, &Oban.insert!/1)
 
       for job <- jobs do
         %{args: %{ref: ref, action: action}, id: id, max_attempts: max} = job
@@ -42,7 +42,7 @@ defmodule Oban.Integration.ExecutingTest do
             action <- member_of(~w(OK FAIL ERROR EXIT)),
             ref <- integer(),
             max_attempts <- integer(1..20) do
-      args = %{ref: ref, bin_pid: Worker.pid_to_bin(), action: action}
+      args = %{ref: ref, action: action}
       opts = [queue: queue, max_attempts: max_attempts]
 
       Worker.new(args, opts)

--- a/test/integration/gossip_test.exs
+++ b/test/integration/gossip_test.exs
@@ -56,9 +56,7 @@ defmodule Oban.Integration.GossipTest do
 
   defp insert_job!(args) do
     args
-    |> Map.new()
-    |> Map.put(:bin_pid, Worker.pid_to_bin())
-    |> Job.new(worker: Worker, queue: args[:queue])
+    |> Worker.new(queue: args[:queue])
     |> Repo.insert!()
   end
 end

--- a/test/integration/isolation_test.exs
+++ b/test/integration/isolation_test.exs
@@ -17,9 +17,7 @@ defmodule Oban.Integration.IsolationTest do
 
   defp insert_job!(args) do
     args
-    |> Map.new()
-    |> Map.put(:bin_pid, Worker.pid_to_bin())
-    |> Job.new(worker: Worker, queue: :alpha)
+    |> Worker.new(queue: :alpha)
     |> Repo.insert!()
   end
 end

--- a/test/integration/pruning_test.exs
+++ b/test/integration/pruning_test.exs
@@ -5,13 +5,17 @@ defmodule Oban.Integration.PruningTest do
 
   @moduletag :integration
 
+  defmodule FakeWorker do
+    use Oban.Worker, queue: :default
+  end
+
   test "historic jobs may be pruned based on a maximum rows count" do
-    %Job{id: id_1} = insert_job(state: "available")
-    %Job{id: _id_} = insert_job(state: "completed")
-    %Job{id: _id_} = insert_job(state: "discarded")
-    %Job{id: id_4} = insert_job(state: "executing")
-    %Job{id: _id_} = insert_job(state: "completed")
-    %Job{id: id_6} = insert_job(state: "completed")
+    %Job{id: id_1} = insert_job!(state: "available")
+    %Job{id: _id_} = insert_job!(state: "completed")
+    %Job{id: _id_} = insert_job!(state: "discarded")
+    %Job{id: id_4} = insert_job!(state: "executing")
+    %Job{id: _id_} = insert_job!(state: "completed")
+    %Job{id: id_6} = insert_job!(state: "completed")
 
     start_supervised!({Oban, repo: Repo, prune: {:maxlen, 1}, prune_interval: 10})
 
@@ -23,10 +27,10 @@ defmodule Oban.Integration.PruningTest do
   end
 
   test "historic jobs may be be pruned based on a maximum age in seconds" do
-    %Job{id: _id_} = insert_job(state: "completed", completed_at: minutes_ago(6))
-    %Job{id: _id_} = insert_job(state: "completed", completed_at: minutes_ago(5))
-    %Job{id: id_1} = insert_job(state: "completed", completed_at: minutes_ago(3))
-    %Job{id: id_2} = insert_job(state: "completed", completed_at: minutes_ago(1))
+    %Job{id: _id_} = insert_job!(state: "completed", completed_at: minutes_ago(6))
+    %Job{id: _id_} = insert_job!(state: "completed", completed_at: minutes_ago(5))
+    %Job{id: id_1} = insert_job!(state: "completed", completed_at: minutes_ago(3))
+    %Job{id: id_2} = insert_job!(state: "completed", completed_at: minutes_ago(1))
 
     start_supervised!({Oban, repo: Repo, prune: {:maxage, 60 * 4}, prune_interval: 10})
 
@@ -37,11 +41,9 @@ defmodule Oban.Integration.PruningTest do
     :ok = stop_supervised(Oban)
   end
 
-  defp insert_job(opts) do
-    opts = Keyword.merge(opts, worker: FakeWorker, queue: "default")
-
+  defp insert_job!(opts) do
     %{}
-    |> Job.new(opts)
+    |> FakeWorker.new(opts)
     |> Repo.insert!()
   end
 

--- a/test/integration/shutdown_test.exs
+++ b/test/integration/shutdown_test.exs
@@ -48,8 +48,6 @@ defmodule Oban.Integration.ShutdownTest do
 
   defp insert_job!(args) do
     args
-    |> Map.new()
-    |> Map.put(:bin_pid, Worker.pid_to_bin())
     |> Worker.new(queue: "alpha")
     |> Repo.insert!()
   end

--- a/test/integration/telemetry_test.exs
+++ b/test/integration/telemetry_test.exs
@@ -68,7 +68,6 @@ defmodule Oban.Integration.TelemetryTest do
 
   defp insert_job!(args) do
     args
-    |> Map.put(:bin_pid, Worker.pid_to_bin())
     |> Worker.new(queue: "zeta")
     |> Repo.insert!()
   end

--- a/test/integration/uniqueness_test.exs
+++ b/test/integration/uniqueness_test.exs
@@ -1,0 +1,83 @@
+defmodule Oban.Integration.UniquenessTest do
+  use Oban.Case
+
+  import Ecto.Query
+
+  @moduletag :integration
+
+  @oban_opts repo: Repo, queues: [alpha: 5]
+
+  defmodule UniqueWorker do
+    use Oban.Worker, queue: :upsilon, unique: [period: 30]
+  end
+
+  setup do
+    start_supervised!({Oban, @oban_opts})
+
+    :ok
+  end
+
+  property "unique: true prevents the same job from being enqueued multiple times" do
+    check all args <- map_of(arg_key(), arg_val()), max_runs: 20 do
+      assert insert_job(args).id == insert_job(args).id
+    end
+  end
+
+  test "uniqueness can be scoped to particular fields" do
+    assert %Job{id: id1} = insert_job(%{id: 1}, queue: "gamma")
+    assert %Job{id: id2} = insert_job(%{id: 2}, queue: "delta")
+    assert %Job{id: ^id2} = insert_job(%{id: 1}, unique: [fields: [:worker]])
+
+    assert %Job{id: ^id1} =
+             insert_job(%{id: 3}, queue: "gamma", unique: [fields: [:queue, :worker]])
+
+    assert %Job{id: ^id2} =
+             insert_job(%{id: 3}, queue: "delta", unique: [fields: [:queue, :worker]])
+
+    assert count_jobs() == 2
+  end
+
+  test "uniqueness can be scoped by state" do
+    assert %Job{id: id1} = insert_job(%{id: 1}, state: "available")
+    assert %Job{id: id2} = insert_job(%{id: 2}, state: "completed")
+    assert %Job{id: id3} = insert_job(%{id: 3}, state: "executing")
+    assert %Job{id: ^id1} = insert_job(%{id: 1}, unique: [states: [:available]])
+    assert %Job{id: ^id2} = insert_job(%{id: 2}, unique: [states: [:available, :completed]])
+    assert %Job{id: ^id3} = insert_job(%{id: 3}, unique: [states: [:completed, :executing]])
+
+    assert count_jobs() == 3
+  end
+
+  test "uniqueness can be scoped by period" do
+    now = DateTime.utc_now()
+    two_minutes_ago = DateTime.add(now, -120, :second)
+    five_minutes_ago = DateTime.add(now, -300, :second)
+
+    assert %Job{id: _id} = insert_job(%{id: 1}, inserted_at: two_minutes_ago)
+    assert %Job{id: _id} = insert_job(%{id: 2}, inserted_at: five_minutes_ago)
+    assert %Job{id: id1} = insert_job(%{id: 1}, unique: [period: 110])
+    assert %Job{id: id2} = insert_job(%{id: 2}, unique: [period: 290])
+    assert %Job{id: ^id1} = insert_job(%{id: 1}, unique: [period: 180])
+    assert %Job{id: ^id2} = insert_job(%{id: 2}, unique: [period: 400])
+
+    assert count_jobs() == 4
+  end
+
+  def arg_key, do: one_of([integer(), string(:ascii)])
+  def arg_val, do: one_of([integer(), string(:ascii), list_of(integer())])
+
+  defp insert_job(args, opts \\ []) do
+    args
+    |> UniqueWorker.new(opts)
+    |> Oban.insert()
+    |> case do
+      {:ok, job} -> job
+    end
+  end
+
+  defp count_jobs do
+    Job
+    |> select([j], count(j.id))
+    |> Repo.one()
+  end
+end

--- a/test/integration/uniqueness_test.exs
+++ b/test/integration/uniqueness_test.exs
@@ -19,31 +19,31 @@ defmodule Oban.Integration.UniquenessTest do
 
   property "unique: true prevents the same job from being enqueued multiple times" do
     check all args <- map_of(arg_key(), arg_val()), max_runs: 20 do
-      assert insert_job(args).id == insert_job(args).id
+      assert insert_job!(args).id == insert_job!(args).id
     end
   end
 
   test "uniqueness can be scoped to particular fields" do
-    assert %Job{id: id1} = insert_job(%{id: 1}, queue: "gamma")
-    assert %Job{id: id2} = insert_job(%{id: 2}, queue: "delta")
-    assert %Job{id: ^id2} = insert_job(%{id: 1}, unique: [fields: [:worker]])
+    assert %Job{id: id1} = insert_job!(%{id: 1}, queue: "gamma")
+    assert %Job{id: id2} = insert_job!(%{id: 2}, queue: "delta")
+    assert %Job{id: ^id2} = insert_job!(%{id: 1}, unique: [fields: [:worker]])
 
     assert %Job{id: ^id1} =
-             insert_job(%{id: 3}, queue: "gamma", unique: [fields: [:queue, :worker]])
+             insert_job!(%{id: 3}, queue: "gamma", unique: [fields: [:queue, :worker]])
 
     assert %Job{id: ^id2} =
-             insert_job(%{id: 3}, queue: "delta", unique: [fields: [:queue, :worker]])
+             insert_job!(%{id: 3}, queue: "delta", unique: [fields: [:queue, :worker]])
 
     assert count_jobs() == 2
   end
 
   test "uniqueness can be scoped by state" do
-    assert %Job{id: id1} = insert_job(%{id: 1}, state: "available")
-    assert %Job{id: id2} = insert_job(%{id: 2}, state: "completed")
-    assert %Job{id: id3} = insert_job(%{id: 3}, state: "executing")
-    assert %Job{id: ^id1} = insert_job(%{id: 1}, unique: [states: [:available]])
-    assert %Job{id: ^id2} = insert_job(%{id: 2}, unique: [states: [:available, :completed]])
-    assert %Job{id: ^id3} = insert_job(%{id: 3}, unique: [states: [:completed, :executing]])
+    assert %Job{id: id1} = insert_job!(%{id: 1}, state: "available")
+    assert %Job{id: id2} = insert_job!(%{id: 2}, state: "completed")
+    assert %Job{id: id3} = insert_job!(%{id: 3}, state: "executing")
+    assert %Job{id: ^id1} = insert_job!(%{id: 1}, unique: [states: [:available]])
+    assert %Job{id: ^id2} = insert_job!(%{id: 2}, unique: [states: [:available, :completed]])
+    assert %Job{id: ^id3} = insert_job!(%{id: 3}, unique: [states: [:completed, :executing]])
 
     assert count_jobs() == 3
   end
@@ -53,12 +53,12 @@ defmodule Oban.Integration.UniquenessTest do
     two_minutes_ago = DateTime.add(now, -120, :second)
     five_minutes_ago = DateTime.add(now, -300, :second)
 
-    assert %Job{id: _id} = insert_job(%{id: 1}, inserted_at: two_minutes_ago)
-    assert %Job{id: _id} = insert_job(%{id: 2}, inserted_at: five_minutes_ago)
-    assert %Job{id: id1} = insert_job(%{id: 1}, unique: [period: 110])
-    assert %Job{id: id2} = insert_job(%{id: 2}, unique: [period: 290])
-    assert %Job{id: ^id1} = insert_job(%{id: 1}, unique: [period: 180])
-    assert %Job{id: ^id2} = insert_job(%{id: 2}, unique: [period: 400])
+    assert %Job{id: _id} = insert_job!(%{id: 1}, inserted_at: two_minutes_ago)
+    assert %Job{id: _id} = insert_job!(%{id: 2}, inserted_at: five_minutes_ago)
+    assert %Job{id: id1} = insert_job!(%{id: 1}, unique: [period: 110])
+    assert %Job{id: id2} = insert_job!(%{id: 2}, unique: [period: 290])
+    assert %Job{id: ^id1} = insert_job!(%{id: 1}, unique: [period: 180])
+    assert %Job{id: ^id2} = insert_job!(%{id: 2}, unique: [period: 400])
 
     assert count_jobs() == 4
   end
@@ -66,13 +66,10 @@ defmodule Oban.Integration.UniquenessTest do
   def arg_key, do: one_of([integer(), string(:ascii)])
   def arg_val, do: one_of([integer(), string(:ascii), list_of(integer())])
 
-  defp insert_job(args, opts \\ []) do
+  defp insert_job!(args, opts \\ []) do
     args
     |> UniqueWorker.new(opts)
-    |> Oban.insert()
-    |> case do
-      {:ok, job} -> job
-    end
+    |> Oban.insert!()
   end
 
   defp count_jobs do

--- a/test/oban/worker_test.exs
+++ b/test/oban/worker_test.exs
@@ -8,7 +8,7 @@ defmodule Oban.WorkerTest do
   end
 
   defmodule CustomWorker do
-    use Worker, queue: "special", max_attempts: 5
+    use Worker, queue: "special", max_attempts: 5, unique: [period: 60]
 
     @impl Worker
     def backoff(attempt), do: attempt * attempt
@@ -29,6 +29,7 @@ defmodule Oban.WorkerTest do
       assert job.queue == "special"
       assert job.max_attempts == 5
       assert job.worker == "Oban.WorkerTest.CustomWorker"
+      assert job.unique.period == 60
     end
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -8,6 +8,16 @@ defmodule Oban.Integration.Worker do
   use Oban.Worker
 
   @impl Worker
+  def new(args, opts) do
+    opts = Keyword.merge(@opts, opts)
+
+    args
+    |> Map.new()
+    |> Map.put(:bin_pid, pid_to_bin())
+    |> Job.new(opts)
+  end
+
+  @impl Worker
   def perform(%{"ref" => ref, "action" => action, "bin_pid" => bin_pid}) do
     pid = bin_to_pid(bin_pid)
 


### PR DESCRIPTION
This set of commits adds support for dynamic unique jobs via a new `Oban.insert/2,4` function. There is still some work to do around top level documentation, describing the unique options and validating unique values.

Opening this up for review and discussion in the meantime.

This is based on the discussion in #27 and the implementation described in the [unique jobs](https://sorentwo.com/2019/07/18/oban-recipes-part-1-unique-jobs.html) blog post.

Note: Combined with isolated supervisors introduced in a17a154, the addition of`Oban.insert`  paves the way for prefix support.