### PR TITLE
Remove perform/1 callback in favor of perform/2

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ concurrently. Here are a few caveats and guidelines:
 #### Defining Workers
 
 Worker modules do the work of processing a job. At a minimum they must define a
-`perform/1` function, which is called with an `args` map.
+`perform/2` function, which is called with an `args` map and the job struct.
 
 Define a worker to process jobs in the `events` queue:
 
@@ -239,7 +239,7 @@ defmodule MyApp.Business do
   use Oban.Worker, queue: "events", max_attempts: 10
 
   @impl Oban.Worker
-  def perform(%{"id" => id}) do
+  def perform(%{"id" => id}, _job) do
     model = MyApp.Repo.get(MyApp.Business.Man, id)
 
     IO.inspect(model)
@@ -247,7 +247,7 @@ defmodule MyApp.Business do
 end
 ```
 
-The value returned from `perform/1` is ignored, unless it returns an `{:error,
+The value returned from `perform/2` is ignored, unless it returns an `{:error,
 reason}` tuple. With an error return or when perform has an uncaught exception
 or throw then the error will be reported and the job will be retried (provided
 there are attempts remaining).

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -54,7 +54,7 @@ defmodule Oban do
 
   ### Defining Workers
 
-  Worker modules do the work of processing a job. At a minimum they must define a `perform/1`
+  Worker modules do the work of processing a job. At a minimum they must define a `perform/2`
   function, which is called first with the full `Oban.Job` struct, and subsequently with the
   `args` map if no clause matches.
 
@@ -64,7 +64,8 @@ defmodule Oban do
   defmodule MyApp.Business do
     use Oban.Worker, queue: "events", max_attempts: 10
 
-    def perform(%{"id" => id}) do
+    @impl Worker
+    def perform(%{"id" => id}, _job) do
       model = MyApp.Repo.get(MyApp.Business.Man, id)
 
       IO.inspect(model)
@@ -72,7 +73,7 @@ defmodule Oban do
   end
   ```
 
-  The value returned from `perform/1` is ignored, unless it an `{:error, reason}` tuple. With an
+  The value returned from `perform/2` is ignored, unless it an `{:error, reason}` tuple. With an
   error return or when perform has an uncaught exception or throw then the error will be reported
   and the job will be retried (provided there are attempts remaining).
 

--- a/lib/oban/queue/executor.ex
+++ b/lib/oban/queue/executor.ex
@@ -36,10 +36,10 @@ defmodule Oban.Queue.Executor do
   end
 
   @doc false
-  def safe_call(%Job{worker: worker} = job) do
+  def safe_call(%Job{args: args, worker: worker} = job) do
     worker
     |> to_module()
-    |> apply(:perform, [job])
+    |> apply(:perform, [args, job])
     |> case do
       {:error, error} ->
         {:current_stacktrace, stacktrace} = Process.info(self(), :current_stacktrace)

--- a/test/integration/pruning_test.exs
+++ b/test/integration/pruning_test.exs
@@ -7,6 +7,9 @@ defmodule Oban.Integration.PruningTest do
 
   defmodule FakeWorker do
     use Oban.Worker, queue: :default
+
+    @impl Worker
+    def perform(_args, _job), do: :ok
   end
 
   test "historic jobs may be pruned based on a maximum rows count" do

--- a/test/integration/scheduling_test.exs
+++ b/test/integration/scheduling_test.exs
@@ -9,6 +9,9 @@ defmodule Oban.Integration.SchedulingTest do
 
   defmodule FakeWorker do
     use Oban.Worker, queue: :scheduled
+
+    @impl Worker
+    def perform(_args, _job), do: :ok
   end
 
   test "jobs scheduled in the future are unavailable for execution" do

--- a/test/integration/uniqueness_test.exs
+++ b/test/integration/uniqueness_test.exs
@@ -11,6 +11,9 @@ defmodule Oban.Integration.UniquenessTest do
 
   defmodule UniqueWorker do
     use Oban.Worker, queue: :upsilon, unique: [period: 30]
+
+    @impl Worker
+    def perform(_args, _job), do: :ok
   end
 
   setup do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -18,7 +18,7 @@ defmodule Oban.Integration.Worker do
   end
 
   @impl Worker
-  def perform(%{"ref" => ref, "action" => action, "bin_pid" => bin_pid}) do
+  def perform(%{"ref" => ref, "action" => action, "bin_pid" => bin_pid}, _job) do
     pid = bin_to_pid(bin_pid)
 
     case action do
@@ -42,7 +42,7 @@ defmodule Oban.Integration.Worker do
     end
   end
 
-  def perform(%{"ref" => ref, "sleep" => sleep, "bin_pid" => bin_pid}) do
+  def perform(%{"ref" => ref, "sleep" => sleep, "bin_pid" => bin_pid}, _job) do
     pid = bin_to_pid(bin_pid)
 
     send(pid, {:started, ref})


### PR DESCRIPTION
The new `perform/2` function receives the job's args, followed by the complete job struct. This new function signature makes it clear that the args are always available, and the job struct is also there when it is needed.

This is a breaking change that will require all worker modules to be updated.

Closes #45

/cc @chrismccord