### PR TITLE
Add prefix support for isolated execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   powerful way to insert jobs. Features such as unique jobs and the upcoming
   prefix support only work with `insert`.
 
+- [Oban] Add `prefix` support. This allows entirely isolated job queues within
+  the same database.
+
 - [Oban.Worker] Compile time validation of all passed options. Catch typos and
   other invalid options when a worker is compiled rather than when a job is
   inserted for the first time.
@@ -55,6 +58,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [Oban.Producer] Use `send_after/3` instead of `:timer.send_interval/2` to
   maintain scheduled dispatch. This mechanism is more accurate under system
   load and it prevents `:poll` messages from backing up for each producer.
+
+- [Oban.Migration] Accept a keyword list with `:prefix` and `:version` as
+  options rather than a single version string. When a prefix is supplied the
+  migration will create all tables, indexes, functions and triggers within that
+  namespace. For example, to create the jobs table within a "private" prefix:
+
+  `Oban.Migrate.up(prefix: "private")`
 
 [i45]: https://github.com/sorentwo/oban/issues/45
 

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ assert [%{args: %{"id" => 1}}] = all_enqueued worker: MyWorker
 
 See the `Oban.Testing` module for more details.
 
-## Integration Testing
+### Integration Testing
 
 During integration testing it may be necessary to run jobs because they do work
 essential for the test to complete, i.e. sending an email, processing media,

--- a/lib/oban/config.ex
+++ b/lib/oban/config.ex
@@ -9,6 +9,7 @@ defmodule Oban.Config do
           name: atom(),
           node: binary(),
           poll_interval: pos_integer(),
+          prefix: binary(),
           prune: prune(),
           prune_interval: pos_integer(),
           prune_limit: pos_integer(),
@@ -24,6 +25,7 @@ defmodule Oban.Config do
   defstruct name: Oban,
             node: nil,
             poll_interval: :timer.seconds(1),
+            prefix: "public",
             prune: :disabled,
             prune_interval: :timer.minutes(1),
             prune_limit: 5_000,
@@ -82,6 +84,12 @@ defmodule Oban.Config do
   defp validate_opt!({:poll_interval, interval}) do
     unless is_integer(interval) and interval > 0 do
       raise ArgumentError, "expected :poll_interval to be a positive integer"
+    end
+  end
+
+  defp validate_opt!({:prefix, prefix}) do
+    unless is_binary(prefix) and Regex.match?(~r/^[a-z0-9_]+$/i, prefix) do
+      raise ArgumentError, "expected :prefix to be a binary with alphanumeric characters"
     end
   end
 

--- a/lib/oban/migrations.ex
+++ b/lib/oban/migrations.ex
@@ -6,34 +6,47 @@ defmodule Oban.Migrations do
   @initial_version 1
   @current_version 2
 
-  def up(version \\ @current_version) do
-    change(get_current()..version, :up)
+  @default_opts %{prefix: "public", version: @current_version}
+
+  def up(opts \\ []) when is_list(opts) do
+    opts
+    |> merge_defaults()
+    |> change(:up)
   end
 
-  def down(version \\ @current_version) do
-    change(get_current()..version, :down)
+  def down(opts \\ []) when is_list(opts) do
+    opts
+    |> merge_defaults()
+    |> change(:down)
   end
 
-  defp change(range, direction) do
-    for index <- range do
-      [__MODULE__, "V#{index}"]
-      |> Module.safe_concat()
-      |> apply(direction, [])
-    end
+  defp merge_defaults(opts) do
+    opts = Map.merge(@default_opts, Map.new(opts))
+
+    Map.put(opts, :range, get_current(opts.prefix)..opts.version)
   end
 
-  defp get_current do
+  defp get_current(prefix) do
     result =
       repo().query("""
       SELECT description
       FROM pg_class
       LEFT JOIN pg_description ON pg_description.objoid = pg_class.oid
-      WHERE relname = 'oban_jobs'
+      LEFT JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
+      WHERE pg_class.relname = 'oban_jobs' AND pg_namespace.nspname = '#{prefix}'
       """)
 
     case result do
       {:ok, %{rows: [[version]]}} when is_binary(version) -> String.to_integer(version)
       _ -> @initial_version
+    end
+  end
+
+  defp change(%{prefix: prefix, range: range}, direction) do
+    for index <- range do
+      [__MODULE__, "V#{index}"]
+      |> Module.safe_concat()
+      |> apply(direction, [prefix])
     end
   end
 
@@ -48,12 +61,16 @@ defmodule Oban.Migrations do
       end
     end
 
-    def up do
+    def up(prefix) do
+      execute "CREATE SCHEMA IF NOT EXISTS #{prefix}"
+
       execute """
       DO $$
       BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'oban_job_state') THEN
-          CREATE TYPE oban_job_state AS ENUM (
+      IF NOT EXISTS (SELECT 1 FROM pg_type
+                     WHERE typname = 'oban_job_state'
+                       AND typnamespace = '#{prefix}'::regnamespace::oid) THEN
+          CREATE TYPE #{prefix}.oban_job_state AS ENUM (
             'available',
             'scheduled',
             'executing',
@@ -65,9 +82,9 @@ defmodule Oban.Migrations do
       END$$;
       """
 
-      create_if_not_exists table(:oban_jobs, primary_key: false) do
+      create_if_not_exists table(:oban_jobs, primary_key: false, prefix: prefix) do
         add :id, :bigserial, primary_key: true
-        add :state, :oban_job_state, null: false, default: "available"
+        add :state, :"#{prefix}.oban_job_state", null: false, default: "available"
         add :queue, :text, null: false, default: "default"
         add :worker, :text, null: false
         add :args, :map, null: false
@@ -81,18 +98,18 @@ defmodule Oban.Migrations do
         add :completed_at, :utc_datetime_usec
       end
 
-      create_if_not_exists index(:oban_jobs, [:queue])
-      create_if_not_exists index(:oban_jobs, [:state])
-      create_if_not_exists index(:oban_jobs, [:scheduled_at])
+      create_if_not_exists index(:oban_jobs, [:queue], prefix: prefix)
+      create_if_not_exists index(:oban_jobs, [:state], prefix: prefix)
+      create_if_not_exists index(:oban_jobs, [:scheduled_at], prefix: prefix)
 
       execute """
-      CREATE OR REPLACE FUNCTION oban_jobs_notify() RETURNS trigger AS $$
+      CREATE OR REPLACE FUNCTION #{prefix}.oban_jobs_notify() RETURNS trigger AS $$
       DECLARE
         channel text;
         notice json;
       BEGIN
         IF (TG_OP = 'INSERT') THEN
-          channel = 'oban_insert';
+          channel = '#{prefix}.oban_insert';
           notice = json_build_object('queue', NEW.queue, 'state', NEW.state);
 
           -- No point triggering for a job that isn't scheduled to run now
@@ -100,7 +117,7 @@ defmodule Oban.Migrations do
             RETURN null;
           END IF;
         ELSE
-          channel = 'oban_update';
+          channel = '#{prefix}.oban_update';
           notice = json_build_object('queue', NEW.queue, 'new_state', NEW.state, 'old_state', OLD.state);
         END IF;
 
@@ -111,24 +128,24 @@ defmodule Oban.Migrations do
       $$ LANGUAGE plpgsql;
       """
 
-      execute "DROP TRIGGER IF EXISTS oban_notify ON oban_jobs"
+      execute "DROP TRIGGER IF EXISTS oban_notify ON #{prefix}.oban_jobs"
 
       execute """
       CREATE TRIGGER oban_notify
-      AFTER INSERT OR UPDATE ON oban_jobs
-      FOR EACH ROW EXECUTE PROCEDURE oban_jobs_notify();
+      AFTER INSERT OR UPDATE OF state ON #{prefix}.oban_jobs
+      FOR EACH ROW EXECUTE PROCEDURE #{prefix}.oban_jobs_notify();
       """
 
-      execute "COMMENT ON TABLE oban_jobs IS '1'"
+      execute "COMMENT ON TABLE #{prefix}.oban_jobs IS '1'"
     end
 
-    def down do
-      execute "DROP TRIGGER oban_notify ON oban_jobs"
-      execute "DROP FUNCTION oban_jobs_notify()"
+    def down(prefix) do
+      execute "DROP TRIGGER IF EXISTS #{prefix}.oban_notify ON oban_jobs"
+      execute "DROP FUNCTION #{prefix}.oban_jobs_notify()"
 
-      drop_if_exists table("oban_jobs")
+      drop_if_exists table("#{prefix}.oban_jobs")
 
-      execute "DROP TYPE IF EXISTS oban_job_state"
+      execute "DROP TYPE IF EXISTS #{prefix}.oban_job_state"
     end
   end
 
@@ -137,43 +154,48 @@ defmodule Oban.Migrations do
 
     use Ecto.Migration
 
-    def up do
+    def up(prefix) do
       # We only need the scheduled_at index for scheduled and available jobs
-      drop_if_exists index(:oban_jobs, [:scheduled_at])
+      drop_if_exists index(:oban_jobs, [:scheduled_at], prefix: prefix)
+
+      state = "#{prefix}.oban_job_state"
 
       create index(:oban_jobs, [:scheduled_at],
-               where: "state in ('available'::oban_job_state, 'scheduled'::oban_job_state)"
+               where: "state in ('available'::#{state}, 'scheduled'::#{state})",
+               prefix: prefix
              )
 
       create constraint(:oban_jobs, :worker_length,
-               check: "char_length(worker) > 0 AND char_length(worker) < 128"
+               check: "char_length(worker) > 0 AND char_length(worker) < 128",
+               prefix: prefix
              )
 
       create constraint(:oban_jobs, :queue_length,
-               check: "char_length(queue) > 0 AND char_length(queue) < 128"
+               check: "char_length(queue) > 0 AND char_length(queue) < 128",
+               prefix: prefix
              )
 
       execute """
-      CREATE OR REPLACE FUNCTION oban_wrap_id(value bigint) RETURNS int AS $$
+      CREATE OR REPLACE FUNCTION #{prefix}.oban_wrap_id(value bigint) RETURNS int AS $$
       BEGIN
         RETURN (CASE WHEN value > 2147483647 THEN mod(value, 2147483647) ELSE value END)::int;
       END;
       $$ LANGUAGE plpgsql IMMUTABLE;
       """
 
-      execute "COMMENT ON TABLE oban_jobs IS '2'"
+      execute "COMMENT ON TABLE #{prefix}.oban_jobs IS '2'"
     end
 
-    def down do
-      drop_if_exists constraint(:oban_jobs, :queue_length)
-      drop_if_exists constraint(:oban_jobs, :worker_length)
+    def down(prefix) do
+      drop_if_exists constraint(:oban_jobs, :queue_length, prefix: prefix)
+      drop_if_exists constraint(:oban_jobs, :worker_length, prefix: prefix)
 
-      drop_if_exists index(:oban_jobs, [:scheduled_at])
-      create index(:oban_jobs, [:scheduled_at])
+      drop_if_exists index(:oban_jobs, [:scheduled_at], prefix: prefix)
+      create index(:oban_jobs, [:scheduled_at], prefix: prefix)
 
-      execute("DROP FUNCTION oban_wrap_id(value bigint)")
+      execute("DROP FUNCTION #{prefix}.oban_wrap_id(value bigint)")
 
-      execute "COMMENT ON TABLE oban_jobs IS '1'"
+      execute "COMMENT ON TABLE #{prefix}.oban_jobs IS '1'"
     end
   end
 end

--- a/test/integration/gossip_test.exs
+++ b/test/integration/gossip_test.exs
@@ -15,7 +15,7 @@ defmodule Oban.Integration.GossipTest do
 
     start_supervised!({Oban, @oban_opts})
 
-    :ok = Notifier.listen(Oban.Notifier, :gossip)
+    :ok = Notifier.listen(Oban.Notifier, "public", :gossip)
 
     assert_gossip(%{
       "count" => 2,
@@ -28,7 +28,7 @@ defmodule Oban.Integration.GossipTest do
     stop_supervised(Oban)
   end
 
-  test "broadcasts are not logged when :verbose mode is disabled" do
+  test "broadcasts are silenced when :verbose mode is disabled" do
     insert_job!(ref: 1, sleep: 500, queue: "alpha")
 
     Logger.configure(level: :debug)
@@ -37,7 +37,7 @@ defmodule Oban.Integration.GossipTest do
       capture_log(fn ->
         start_supervised!({Oban, @oban_opts})
 
-        :ok = Notifier.listen(Oban.Notifier, :gossip)
+        :ok = Notifier.listen(Oban.Notifier, "public", :gossip)
 
         stop_supervised(Oban)
       end)
@@ -49,7 +49,7 @@ defmodule Oban.Integration.GossipTest do
   end
 
   defp assert_gossip(message) do
-    assert_receive {:notification, _, _, "oban_gossip", payload}
+    assert_receive {:notification, _, _, "public.oban_gossip", payload}
     assert {:ok, decoded} = Jason.decode(payload)
     assert message == decoded
   end

--- a/test/integration/isolation_test.exs
+++ b/test/integration/isolation_test.exs
@@ -7,7 +7,7 @@ defmodule Oban.Integration.IsolationTest do
     start_supervised!({Oban, name: ObanA, repo: Repo, queues: [alpha: 1]}, id: ObanA)
     start_supervised!({Oban, name: ObanB, repo: Repo, queues: [gamma: 1]}, id: ObanB)
 
-    insert_job!(ref: 1, action: "OK")
+    insert_job!(ObanA, ref: 1, action: "OK")
 
     assert_receive {:ok, 1}
 
@@ -15,9 +15,21 @@ defmodule Oban.Integration.IsolationTest do
     stop_supervised(ObanB)
   end
 
-  defp insert_job!(args) do
-    args
-    |> Worker.new(queue: :alpha)
-    |> Repo.insert!()
+  test "inserting and executing jobs with a custom prefix" do
+    start_supervised!({Oban, prefix: "private", repo: Repo, queues: [alpha: 5]})
+
+    job = insert_job!(ref: 1, action: "OK")
+
+    assert Ecto.get_meta(job, :prefix) == "private"
+
+    assert_receive {:ok, 1}
+
+    :ok = stop_supervised(Oban)
+  end
+
+  defp insert_job!(oban \\ Oban, args) do
+    job = Worker.new(args, queue: :alpha)
+
+    Oban.insert!(oban, job)
   end
 end

--- a/test/oban/config_test.exs
+++ b/test/oban/config_test.exs
@@ -39,6 +39,14 @@ defmodule Oban.ConfigTest do
       assert %Config{} = Config.new(repo: Repo, poll_interval: 10)
     end
 
+    test ":prefix is validated as a binary" do
+      assert_raise ArgumentError, fn -> Config.new(repo: Repo, prefix: :private) end
+      assert_raise ArgumentError, fn -> Config.new(repo: Repo, prefix: " private schema ") end
+      assert_raise ArgumentError, fn -> Config.new(repo: Repo, prefix: "") end
+
+      assert %Config{} = Config.new(repo: Repo, prefix: "private")
+    end
+
     test ":prune is validated as disabled or a max* option" do
       assert_raise ArgumentError, fn -> Config.new(repo: Repo, prune: :unknown) end
       assert_raise ArgumentError, fn -> Config.new(repo: Repo, prune: 5) end

--- a/test/support/migrations/20190808125457_add_prefixed_oban_jobs_table.exs
+++ b/test/support/migrations/20190808125457_add_prefixed_oban_jobs_table.exs
@@ -1,0 +1,11 @@
+defmodule Oban.Test.Repo.Migrations.AddPrefixedObanJobsTable do
+  use Ecto.Migration
+
+  def up do
+    Oban.Migrations.up(prefix: "private")
+  end
+
+  def down do
+    Oban.Migrations.down(prefix: "private")
+  end
+end


### PR DESCRIPTION
This adds support for migrating, notifying and executing jobs within a specific schema (aka Prefix).

Closes #12

/cc @anthonator