### PR TITLE
Remove query for `scheduled_at` now or in the future from `fetch_available_jobs/3`

### DIFF
--- a/lib/oban/query.ex
+++ b/lib/oban/query.ex
@@ -48,7 +48,6 @@ defmodule Oban.Query do
       Job
       |> where([j], j.state == "available")
       |> where([j], j.queue == ^queue)
-      |> where([j], j.scheduled_at <= ^utc_now())
       |> lock("FOR UPDATE SKIP LOCKED")
       |> limit(^demand)
       |> order_by([j], asc: j.scheduled_at, asc: j.id)


### PR DESCRIPTION
Not sure how long the Slack logs will be around so I took a screenshot: https://c.seanwash.com/1565977760.png

I'm running my Elixir app/tests on my laptop and my database is running inside of Docker. Somehow the current time between the two differ, causing jobs to not run in tests when using `drain_queue/1`.