### PR TITLE
Don't eat ArgumentError from worker backoff function

### DIFF
--- a/lib/oban/queue/executor.ex
+++ b/lib/oban/queue/executor.ex
@@ -71,7 +71,12 @@ defmodule Oban.Queue.Executor do
   # `safe_call/1`. There is a possibility that the worker module can't be found at all and we
   # need to fall back to a default implementation.
   defp worker_backoff(%Job{attempt: attempt, worker: worker}) do
-    module = to_module(worker)
+    module =
+      try do
+        to_module(worker)
+      rescue
+        ArgumentError -> nil
+      end
 
     if function_exported?(module, :backoff, 1) do
       module.backoff(attempt)

--- a/lib/oban/queue/executor.ex
+++ b/lib/oban/queue/executor.ex
@@ -71,11 +71,13 @@ defmodule Oban.Queue.Executor do
   # `safe_call/1`. There is a possibility that the worker module can't be found at all and we
   # need to fall back to a default implementation.
   defp worker_backoff(%Job{attempt: attempt, worker: worker}) do
-    worker
-    |> to_module()
-    |> apply(:backoff, [attempt])
-  rescue
-    ArgumentError -> Worker.default_backoff(attempt)
+    module = to_module(worker)
+
+    if function_exported?(module, :backoff, 1) do
+      module.backoff(attempt)
+    else
+      Worker.default_backoff(attempt)
+    end
   end
 
   defp format_blamed(:exception, error, stack), do: format_blamed(:error, error, stack)


### PR DESCRIPTION
If an `ArgumentError` is raised in the `backoff` function of a worker then it is silently eaten. This can hide bugs and make debugging confusing. This is particularly problematic since `ArgumentError` is very common exception.

A safer alternative is to check if the `backoff` function is defined before calling it. Then there is no need to catch exceptions.

Thanks ❤️ 