### PR TITLE
Fix prefix usage in V1 migration `down/1` statements

### DIFF
--- a/lib/oban/migrations.ex
+++ b/lib/oban/migrations.ex
@@ -140,10 +140,10 @@ defmodule Oban.Migrations do
     end
 
     def down(prefix) do
-      execute "DROP TRIGGER IF EXISTS #{prefix}.oban_notify ON oban_jobs"
+      execute "DROP TRIGGER IF EXISTS oban_notify ON #{prefix}.oban_jobs"
       execute "DROP FUNCTION #{prefix}.oban_jobs_notify()"
 
-      drop_if_exists table("#{prefix}.oban_jobs")
+      drop_if_exists table(:oban_jobs, prefix: prefix)
 
       execute "DROP TYPE IF EXISTS #{prefix}.oban_job_state"
     end

--- a/test/support/migrations/20190210214150_add_oban_jobs_table.exs
+++ b/test/support/migrations/20190210214150_add_oban_jobs_table.exs
@@ -2,5 +2,8 @@ defmodule Oban.Test.Repo.Migrations.AddObanJobsTable do
   use Ecto.Migration
 
   defdelegate up, to: Oban.Migrations
-  defdelegate down, to: Oban.Migrations
+
+  def down do
+    Oban.Migrations.down(version: 1)
+  end
 end

--- a/test/support/migrations/20190808125457_add_prefixed_oban_jobs_table.exs
+++ b/test/support/migrations/20190808125457_add_prefixed_oban_jobs_table.exs
@@ -6,6 +6,6 @@ defmodule Oban.Test.Repo.Migrations.AddPrefixedObanJobsTable do
   end
 
   def down do
-    Oban.Migrations.down(prefix: "private")
+    Oban.Migrations.down(prefix: "private", version: 1)
   end
 end


### PR DESCRIPTION
I ran into an issue when trying to ensure migrations could be rolled back cleanly.

One question I had was about the test migrations. By default a call to `Oban.Migrations.down/1` only rolls back a single version, so the test migrations never call V1 during a rollback. I added the `version: 1` option to both migrations explicitly in their `down/1` calls, but please let me know if this is not an acceptable solution.

Thank you for this library, it's great! 👍 