### PR TITLE
Fix anchor link on Readme's ToC

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 - [Installation](#Installation)
 - [Usage](#Usage)
   - [Configuring Queues](#Configuring-Queues)
-  - [Creating Workers](#Creating-Workers)
+  - [Defining Workers](#Defining-Workers)
   - [Enqueuing Jobs](#Enqueueing-Jobs)
   - [Pruning](#Pruning)
 - [Testing](#Testing)


### PR DESCRIPTION
Fixes a broken anchor link in the ToC of the Readme file