### PR TITLE
keep permitted fields in Job.to_map / insert_all

### DIFF
--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -165,7 +165,7 @@ defmodule Oban.Job do
     changeset
     |> apply_changes()
     |> Map.from_struct()
-    |> Map.take([:args, :queue, :state, :worker, :scheduled_at])
+    |> Map.take(@permitted)
     |> Enum.reject(fn {_, val} -> is_nil(val) end)
     |> Map.new()
   end


### PR DESCRIPTION
`Oban.insert_all` uses `Job.to_map/1` before actually inserting `Job` records into the database. Prior to this commit, that function was only returning a limited set of fields from the `Job` struct, meaning certain fields like `max_attempts` were lost (#103).

To fix this, we include all permitted fields when converting a `Job` to a map, preserving any optional values that were either specified by the user or came via Worker defaults.

Fixes #103.