### PR TITLE
[#101] Allow to run scheduled jobs with drain_queue/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ create index(
   Circuit breaker activity is logged by the default telemetry logger (both
   `:trip_circuit` and `:open_circuit` events).
 
+- [Oban] Expose `circuit_backoff` as a "twiddly" option that controls how long
+  tripped circuit breakers wait until re-opening.
+
+- [Oban] Add `drain_queue/3` to accept drain options. `with_scheduled: true`
+  allows draining scheduled jobs.
+
 ### Fixed
 
 - [Oban.Query] Avoid using prepared statements for all unique queries. This

--- a/test/integration/draining_test.exs
+++ b/test/integration/draining_test.exs
@@ -21,9 +21,49 @@ defmodule Oban.Integration.DrainingTest do
     stop_supervised(Oban)
   end
 
+  test "scheduled jobs are not executed by default" do
+    start_supervised!({Oban, @oban_opts})
+
+    insert_scheduled_job!()
+
+    assert %{success: 0, failure: 0} = Oban.drain_queue(:draining)
+
+    stop_supervised(Oban)
+  end
+
+  test "scheduled jobs are executed when given the :with_scheduled flag" do
+    start_supervised!({Oban, @oban_opts})
+
+    insert_scheduled_job!()
+
+    assert %{success: 1, failure: 0} = Oban.drain_queue(:draining, with_scheduled: true)
+
+    stop_supervised(Oban)
+  end
+
+  test "drain_queue/2 allows to pass in the config name as first argument" do
+    start_supervised!({Oban, @oban_opts})
+
+    insert_job!()
+
+    assert %{success: 1, failure: 0} = Oban.drain_queue(Oban, :draining)
+
+    stop_supervised(Oban)
+  end
+
+  defp insert_job! do
+    insert_job!(ref: 1, action: "OK")
+  end
+
   defp insert_job!(args) do
     args
     |> Worker.new(queue: :draining)
+    |> Oban.insert!()
+  end
+
+  defp insert_scheduled_job! do
+    %{ref: 1, action: "OK"}
+    |> Worker.new(queue: :draining, scheduled_at: seconds_from_now(3600))
     |> Oban.insert!()
   end
 end

--- a/test/integration/rescuing_test.exs
+++ b/test/integration/rescuing_test.exs
@@ -87,8 +87,4 @@ defmodule Oban.Integration.RescuingTest do
     |> Worker.new(opts)
     |> Repo.insert!()
   end
-
-  defp seconds_ago(seconds) do
-    DateTime.add(DateTime.utc_now(), -seconds)
-  end
 end

--- a/test/oban/testing_test.exs
+++ b/test/oban/testing_test.exs
@@ -5,10 +5,6 @@ defmodule Oban.TestingTest do
 
   @moduletag :integration
 
-  defp seconds_from_now(seconds) do
-    DateTime.add(DateTime.utc_now(), seconds, :second)
-  end
-
   describe "all_enqueued/1" do
     test "retrieving a filtered list of enqueued jobs" do
       insert_job!(%{id: 1, ref: "a"}, worker: Ping, queue: :alpha)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -77,6 +77,8 @@ defmodule Oban.Case do
     quote do
       use ExUnitProperties
 
+      import Oban.Case
+
       alias Oban.Integration.Worker
       alias Oban.{Beat, Job}
       alias Repo
@@ -117,5 +119,13 @@ defmodule Oban.Case do
     end
 
     {:ok, %{}}
+  end
+
+  def seconds_from_now(seconds) do
+    DateTime.add(DateTime.utc_now(), seconds, :second)
+  end
+
+  def seconds_ago(seconds) do
+    DateTime.add(DateTime.utc_now(), -seconds)
   end
 end


### PR DESCRIPTION
This PR will add a way to use `Oban.drain_queue` to execute scheduled jobs.

Fixes #101

## TODO

- [x] Solve interface issue
- [x] Add more documentation, enrich commit msg
- [x] Add changelog entry

## Interface Issue [Resolved]

@sorentwo Pushed this in a WIP state for now to ask you for advice. I wanted to give `drain_queue/2` a `with_scheduled` option, but realized that it won't work with the current way of how the `Oban` module is handed as the first (default) argument. 

```elixir
def drain_queue(name \\ __MODULE__, queue, opts \\ [])
end

# This will put :default into name and the keyword list into queue.
drain_queue(:default, with_scheduled: true)
```

Also see the failing test case.

I currently see a few ways to go about this:

1) Mission abort. Don't add a flag to `drain_queue/2`, but instead add a `drain_queue_with_scheduled/2`. Or possible just let the user use `Query.stage_all_scheduled_jobs/2` (exposed through `Oban`).
2) Solve this with heavy guarding of the function, i.e. basically "shift" the arguments when the second one is a list. Least amount of work, but IMO pretty ugly and fragile.
3) I'm assuming the idea behind this whole `name` argument and defaulting to `Oban` is to have multiple different configurations per app? In this case one could also go through with it fully and move functionality from `Oban` to something like `Oban.API` which `Oban` uses. `Oban.API` defines simple redirect functions like 

```
defmacro __using__(_opts) do
  quote do
    def drain_queue(name, opts) do
      Oban.API.drain_queue(__MODULE__, name, opts)
    end
  end
end
```

This is basically the `Ecto.Repo` approach. One would still have the "default" `Oban` module, but the user could also define their own API modules, e.g. `MyApp.Oban`.

Not sure if this is exactly what you were heading for ^^, but it's currently the most appealing solution to me :). Option 1 would also be fine, I guess.

[UPDATE] Resolved with `Oban.drain/2`.

---

cheers,
malte