### PR TITLE
Improve prune query with dedicated index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+**Migration Optional (V7)**
+
+The queries used to prune by limit and age are written to utilize a single
+partial index for a huge performance boost on large tables. The new V7 migration
+will create the index for you—but that may not be ideal for tables with millions
+of completed or discarded jobs because it can't be done concurrently.
+
+If you have an extremely large jobs table you can add the index concurrently in
+a dedicated migration:
+
+```elixir
+create index(
+         :oban_jobs,
+         ["attempted_at desc", :id],
+         where: "state in ('completed', 'discarded')",
+         name: :oban_jobs_attempted_at_id_index,
+         concurrently: true
+       )
+```
+
 ### Added
 
 - [Oban.Testing] Accept a value/delta tuple for testing timestamp fields. This
@@ -32,6 +52,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - [Oban] Allow the multi `name` provided to `Oban.insert/3,4` to be any term,
   not just an atom.
+
+- [Oban.Query] Use a consistent and more performant set of queries for pruning.
+  Both pruning methods are optimized to utilize a single partial index.
 
 ## [0.11.1] — 2019-11-13
 

--- a/lib/oban/migrations.ex
+++ b/lib/oban/migrations.ex
@@ -4,7 +4,7 @@ defmodule Oban.Migrations do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 6
+  @current_version 7
   @default_prefix "public"
 
   def up(opts \\ []) when is_list(opts) do
@@ -331,6 +331,32 @@ defmodule Oban.Migrations do
       execute "ALTER TABLE #{prefix}.oban_beats ALTER COLUMN running TYPE integer[]"
 
       record_version(prefix, 5)
+    end
+  end
+
+  defmodule V7 do
+    @moduledoc false
+
+    use Ecto.Migration
+
+    import Oban.Migrations.Helper
+
+    def up(prefix) do
+      create_if_not_exists index(
+                             :oban_jobs,
+                             ["attempted_at desc", :id],
+                             where: "state in ('completed', 'discarded')",
+                             prefix: prefix,
+                             name: :oban_jobs_attempted_at_id_index
+                           )
+
+      record_version(prefix, 7)
+    end
+
+    def down(prefix) do
+      drop_if_exists index(:oban_jobs, [:attempted_at, :id], prefix: prefix)
+
+      record_version(prefix, 6)
     end
   end
 end

--- a/test/integration/pruning_test.exs
+++ b/test/integration/pruning_test.exs
@@ -13,12 +13,12 @@ defmodule Oban.Integration.PruningTest do
   end
 
   test "historic jobs may be pruned based on a maximum rows count" do
-    %Job{id: id_1} = insert_job!(state: "available")
-    %Job{id: _id_} = insert_job!(state: "completed")
-    %Job{id: _id_} = insert_job!(state: "discarded")
-    %Job{id: id_4} = insert_job!(state: "executing")
-    %Job{id: _id_} = insert_job!(state: "completed")
-    %Job{id: id_6} = insert_job!(state: "completed")
+    %Job{id: id_1} = insert_job!(state: "available", attempted_at: minutes_ago(1))
+    %Job{id: _id_} = insert_job!(state: "completed", attempted_at: minutes_ago(1))
+    %Job{id: _id_} = insert_job!(state: "discarded", attempted_at: minutes_ago(1))
+    %Job{id: id_4} = insert_job!(state: "executing", attempted_at: minutes_ago(1))
+    %Job{id: _id_} = insert_job!(state: "completed", attempted_at: minutes_ago(1))
+    %Job{id: id_6} = insert_job!(state: "completed", attempted_at: minutes_ago(1))
 
     start_supervised!({Oban, repo: Repo, prune: {:maxlen, 1}, prune_interval: 10})
 
@@ -30,10 +30,10 @@ defmodule Oban.Integration.PruningTest do
   end
 
   test "historic jobs may be be pruned based on a maximum age in seconds" do
-    %Job{id: _id_} = insert_job!(state: "completed", completed_at: minutes_ago(6))
-    %Job{id: _id_} = insert_job!(state: "completed", completed_at: minutes_ago(5))
-    %Job{id: id_1} = insert_job!(state: "completed", completed_at: minutes_ago(3))
-    %Job{id: id_2} = insert_job!(state: "completed", completed_at: minutes_ago(1))
+    %Job{id: _id_} = insert_job!(state: "completed", attempted_at: minutes_ago(6))
+    %Job{id: _id_} = insert_job!(state: "completed", attempted_at: minutes_ago(5))
+    %Job{id: id_1} = insert_job!(state: "completed", attempted_at: minutes_ago(3))
+    %Job{id: id_2} = insert_job!(state: "completed", attempted_at: minutes_ago(1))
 
     start_supervised!({Oban, repo: Repo, prune: {:maxage, 60 * 4}, prune_interval: 10})
 


### PR DESCRIPTION
The prune queries were unable to utilize any of the existing indexes and could be tremendously slow for large tables. This rewrites the queries to depend on the same columns and adds a dedicated partial index purely for pruning.

Addresses #92

/cc @ethangunderson