### PR TITLE
Add top level start_queue/3 and stop_queue/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ create index(
 
 ### Added
 
+- [Oban] Add `start_queue/3` and `stop_queue/2` for dynamically starting an
+  stopping supervised queues across nodes.
+
+- [Oban] Expose `circuit_backoff` as a "twiddly" option that controls how long
+  tripped circuit breakers wait until re-opening.
+
 - [Oban.Testing] Accept a value/delta tuple for testing timestamp fields. This
   allows more robust testing of timestamps such as `scheduled_at`.
 
@@ -38,9 +44,6 @@ create index(
 
   Circuit breaker activity is logged by the default telemetry logger (both
   `:trip_circuit` and `:open_circuit` events).
-
-- [Oban] Expose `circuit_backoff` as a "twiddly" option that controls how long
-  tripped circuit breakers wait until re-opening.
 
 ### Fixed
 

--- a/lib/oban/config.ex
+++ b/lib/oban/config.ex
@@ -198,7 +198,7 @@ defmodule Oban.Config do
 
   defp valid_crontab?(_crontab), do: false
 
-  defp valid_queue?({_name, size}), do: is_integer(size) and size > 0
+  defp valid_queue?({_name, limit}), do: is_integer(limit) and limit > 0
 
   defp parse_crontab(crontab) do
     for tuple <- crontab do

--- a/lib/oban/midwife.ex
+++ b/lib/oban/midwife.ex
@@ -1,0 +1,66 @@
+defmodule Oban.Midwife do
+  @moduledoc false
+
+  use GenServer
+
+  import Oban.Notifier, only: [signal: 0]
+
+  alias Oban.{Config, Notifier}
+  alias Oban.Queue.Supervisor, as: QueueSupervisor
+
+  @type option :: {:name, module()} | {:conf, Config.t()}
+
+  defmodule State do
+    @moduledoc false
+
+    defstruct [:conf]
+  end
+
+  @spec start_link([option]) :: GenServer.on_start()
+  def start_link(opts) do
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @impl GenServer
+  def init(opts) do
+    {:ok, struct!(State, opts), {:continue, :start}}
+  end
+
+  @impl GenServer
+  def handle_continue(:start, %State{conf: conf} = state) do
+    conf.name
+    |> Module.concat("Notifier")
+    |> Notifier.listen()
+
+    {:noreply, state}
+  end
+
+  @impl GenServer
+  def handle_info({:notification, signal(), payload}, %State{conf: conf} = state) do
+    case payload do
+      %{"action" => "start", "queue" => queue, "limit" => limit} ->
+        Supervisor.start_child(conf.name, queue_spec(queue, limit, conf))
+
+      %{"action" => "stop", "queue" => queue} ->
+        %{id: child_id} = queue_spec(queue, 0, conf)
+
+        Supervisor.terminate_child(conf.name, child_id)
+        Supervisor.delete_child(conf.name, child_id)
+
+      _ ->
+        :ok
+    end
+
+    {:noreply, state}
+  end
+
+  def handle_info(_message, state) do
+    {:noreply, state}
+  end
+
+  defp queue_spec(queue, limit, conf) do
+    QueueSupervisor.child_spec({queue, limit}, conf)
+  end
+end

--- a/lib/oban/queue/supervisor.ex
+++ b/lib/oban/queue/supervisor.ex
@@ -19,6 +19,15 @@ defmodule Oban.Queue.Supervisor do
     Supervisor.start_link(__MODULE__, Map.new(opts), name: name)
   end
 
+  @spec child_spec({atom(), integer()}, Config.t()) :: Supervisor.child_spec()
+  def child_spec({queue, limit}, conf) do
+    queue = to_string(queue)
+    name = Module.concat([conf.name, "Queue", Macro.camelize(queue)])
+    opts = [conf: conf, queue: queue, limit: limit, name: name]
+
+    Supervisor.child_spec({__MODULE__, opts}, id: name)
+  end
+
   @impl Supervisor
   def init(%{conf: conf, limit: limit, name: name, queue: queue}) do
     fore_name = Module.concat([name, "Foreman"])


### PR DESCRIPTION
The new start_queue/3 function dynamically starts a queue across all running nodes. Similarly, stop_queue/2 will stop queues across all running nodes in a graceful way.

Closes #91