### PR TITLE
Don't require migration modules be preloaded

### DIFF
--- a/lib/oban/migrations.ex
+++ b/lib/oban/migrations.ex
@@ -46,7 +46,7 @@ defmodule Oban.Migrations do
   defp change(prefix, range, direction) do
     for index <- range do
       [__MODULE__, "V#{index}"]
-      |> Module.safe_concat()
+      |> Module.concat()
       |> apply(direction, [prefix])
     end
   end


### PR DESCRIPTION
When called from Ecto.Migrator.run you can (apparently) encounter times when the app is running but the migration code isn't loaded, raising an ArgumentError in `safe_concat`.

 In the event of erroneous data there the code would bomb on the next call anyway so hopefully you don't feel like it's too risky.