### PR TITLE
Create a better error message for assert_enqueued

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Better error message for `Oban.Testing.assert_enqueued/2`
+- [Oban.Testing] Better error message for `Oban.Testing.assert_enqueued/2`
 
 ## [0.12.0] – 2019-11-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Better error message for `Oban.Testing.assert_enqueued/2`
+
 ## [0.12.0] – 2019-11-26
 
 **Migration Optional (V7)**

--- a/lib/oban/testing.ex
+++ b/lib/oban/testing.ex
@@ -158,10 +158,19 @@ defmodule Oban.Testing do
   @doc since: "0.3.0"
   @spec assert_enqueued(repo :: module(), opts :: Keyword.t()) :: true
   def assert_enqueued(repo, [_ | _] = opts) do
-    assert get_job(repo, opts),
-           "Expected a job matching #{inspect(opts)} to be enqueued. Found: #{
-             inspect(available_jobs(repo, opts))
-           }"
+    job = Enum.into(opts, %{})
+
+    error_message = """
+    Expected a job matching:
+
+    #{inspect(job, pretty: true)}
+
+    to be enqueued. Instead found:
+
+    #{inspect(available_jobs(repo, opts), pretty: true)}
+    """
+
+    assert get_job(repo, opts), error_message
   end
 
   @doc """

--- a/lib/oban/testing.ex
+++ b/lib/oban/testing.ex
@@ -158,12 +158,10 @@ defmodule Oban.Testing do
   @doc since: "0.3.0"
   @spec assert_enqueued(repo :: module(), opts :: Keyword.t()) :: true
   def assert_enqueued(repo, [_ | _] = opts) do
-    job = Enum.into(opts, %{})
-
     error_message = """
     Expected a job matching:
 
-    #{inspect(job, pretty: true)}
+    #{inspect(Map.new(opts), pretty: true)}
 
     to be enqueued. Instead found:
 

--- a/test/oban/testing_test.exs
+++ b/test/oban/testing_test.exs
@@ -43,6 +43,27 @@ defmodule Oban.TestingTest do
 
       assert_enqueued worker: Ping, scheduled_at: {seconds_from_now(69), delta: 10}
     end
+
+    test "prints a helpful error message" do
+      insert_job!(%{dest: "some_node"}, worker: Ping)
+
+      try do
+        assert_enqueued worker: Ping, args: %{dest: "other_node"}
+      rescue
+        error in [ExUnit.AssertionError] ->
+          expected = """
+          Expected a job matching:
+
+          %{args: %{dest: "other_node"}, worker: Ping}
+
+          to be enqueued. Instead found:
+
+          [%{args: %{"dest" => "some_node"}, worker: "Ping"}]
+          """
+
+          assert error.message == expected
+      end
+    end
   end
 
   describe "refute_enqueued/1" do

--- a/test/oban/testing_test.exs
+++ b/test/oban/testing_test.exs
@@ -44,7 +44,7 @@ defmodule Oban.TestingTest do
       assert_enqueued worker: Ping, scheduled_at: {seconds_from_now(69), delta: 10}
     end
 
-    test "prints a helpful error message" do
+    test "printing a helpful error message" do
       insert_job!(%{dest: "some_node"}, worker: Ping)
 
       try do


### PR DESCRIPTION
Now the error message will look like (and it includes pretty printing):
```
Expected a job matching:

%{args: %{dest: "other_node"}, worker: Ping}

to be enqueued. Instead found:

[%{args: %{"dest" => "some_node"}, worker: "Ping"}]
```

This should make it more easy to compare changes. Additionally the options are rendered as a map instead of keyword list to better match what the jobs look like.

Fixes #115 