### PR TITLE
Add mix test.setup alias to make it easier to get started with Oban development

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,11 +464,7 @@ database named `oban_test`. Follow these steps to create the database, create
 the database and run all migrations:
 
 ```bash
-# Create the database
-MIX_ENV=test mix ecto.create -r Oban.Test.Repo
-
-# Run the base migration
-MIX_ENV=test mix ecto.migrate -r Oban.Test.Repo
+mix test.setup
 ```
 
 To ensure a commit passes CI you should run `mix ci` locally, which executes the

--- a/config/config.exs
+++ b/config/config.exs
@@ -3,3 +3,6 @@ use Mix.Config
 config :oban, Oban.Test.Repo,
   priv: "test/support/",
   url: System.get_env("DATABASE_URL") || "postgres://localhost:5432/oban_test"
+
+config :oban,
+  ecto_repos: [Oban.Test.Repo]

--- a/mix.exs
+++ b/mix.exs
@@ -12,6 +12,9 @@ defmodule Oban.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       aliases: aliases(),
+      preferred_cli_env: [
+        "test.setup": :test
+      ],
 
       # Hex
       package: package(),
@@ -69,6 +72,7 @@ defmodule Oban.MixProject do
 
   defp aliases do
     [
+      "test.setup": ["ecto.create", "ecto.migrate"],
       ci: [
         "format --check-formatted",
         "credo --strict",


### PR DESCRIPTION
This PR makes it easier for a developer to get started with oban development since there is less that needs to be typed in to create the test database. Alternatively we could make it even easier by creating the alias as `test` instead of `test.setup` (for my own applications I prefer to have them separate so that the migrations aren't checked every time tests are run).

Adding `config :oban, ecto_repos: [Oban.Test.Repo]` should be fine since any application depending on oban doesn't pull in its configuration.