### PR TITLE
Debounce producer dispatch for throughput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   than "Etc/UTC". Using a custom timezone requires a timezone database such as
   tzdata.
 
+- [Oban] Add `dispatch_cooldown` option to configure the minimum time between
+  a producer fetching more jobs to execute.
+
+### Changed
+
+- [Oban.Queue.Producer] Introduce "dispatch cooldown" as a way to debounce
+  repeatedly fetching new jobs. Repeated fetching floods the producer's message
+  queue and forces the producer to repeatedly fetch one job at a time, which is
+  not especially efficient. Debounced fetching is much more efficient for the
+  producer and the database, increasing maximum jobs/sec throughput so that it
+  scales linearly with a queue's concurrency settings (up to what the database
+  can handle).
+
 ## [0.12.1] — 2019-12-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ and job dispatching altogether when testing:
 
 ```elixir
 # config/test.exs
-config :my_app, Oban, queues: false, prune: :disabled
+config :my_app, Oban, crontab: false, queues: false, prune: :disabled
 ```
 
 Without dispatch and pruning disabled Ecto will raise constant ownership errors

--- a/lib/oban/config.ex
+++ b/lib/oban/config.ex
@@ -12,6 +12,7 @@ defmodule Oban.Config do
   @type t :: %__MODULE__{
           circuit_backoff: timeout(),
           crontab: [cronjob()],
+          dispatch_cooldown: pos_integer(),
           name: atom(),
           node: binary(),
           poll_interval: pos_integer(),
@@ -33,6 +34,7 @@ defmodule Oban.Config do
   @enforce_keys [:node, :repo]
   defstruct circuit_backoff: :timer.seconds(30),
             crontab: [],
+            dispatch_cooldown: 5,
             name: Oban,
             node: nil,
             poll_interval: :timer.seconds(1),
@@ -100,6 +102,12 @@ defmodule Oban.Config do
       raise ArgumentError,
             "expected :crontab to be a list of {expression, worker} or " <>
               "{expression, worker, options} tuples"
+    end
+  end
+
+  defp validate_opt!({:dispatch_cooldown, period}) do
+    unless is_integer(period) and period > 0 do
+      raise ArgumentError, "expected :dispatch_cooldown to be a positive integer"
     end
   end
 

--- a/lib/oban/worker.ex
+++ b/lib/oban/worker.ex
@@ -13,7 +13,7 @@ defmodule Oban.Worker do
       defmodule MyApp.Workers.Business do
         use Oban.Worker, queue: "events", max_attempts: 10, unique: [period: 30]
 
-        @impl Worker
+        @impl Oban.Worker
         def perform(_args, %Oban.Job{attempt: attempt}) when attempt > 3 do
           IO.inspect(attempt)
         end

--- a/test/oban/config_test.exs
+++ b/test/oban/config_test.exs
@@ -23,6 +23,15 @@ defmodule Oban.ConfigTest do
       assert_valid(circuit_backoff: 10)
     end
 
+    test ":dispatch_cooldown is validated as a positive integer" do
+      assert_invalid(dispatch_cooldown: -1)
+      assert_invalid(dispatch_cooldown: 0)
+      assert_invalid(dispatch_cooldown: "5")
+      assert_invalid(dispatch_cooldown: 1.0)
+
+      assert_valid(dispatch_cooldown: 500)
+    end
+
     test ":crontab is validated as a list of cron job expressions" do
       assert_invalid(crontab: ["* * * * *"])
       assert_invalid(crontab: [["* * * * *", Fake]])


### PR DESCRIPTION
Producers may become overloaded under high insert/execute load when processes complete quickly. This is due to a flood of `DOWN` messages from completed jobs, which triggers an immediate dispatch. Under high load the "demand" (concurrency limit - running jobs) hovers around 1, so every dispatch only retrieves one job. This is wasteful, unnecessarily hard on the database, and floods the producer's message queue.

This introduces dispatch debouncing for each producer. Rather than fetching jobs every time dispatch is called it waits a small period of time (5ms by default) to allow demand to accumulate. According to benchmarks this has a huge impact on overall throughput: without debouncing a producer maxes out around ~1000 jobs/sec, with a 5ms debounce producers can handle ~5000 jobs/sec and have an empty message queue.

---

Still in progress:

- [x] Document processing throughput and hard limits
- [x] Document configuration
- [x] Eliminate flakiness from test runs (leading edge debounce issues)

---

Here are some numbers/charts from continuous insertion benchmarks. The benchmark inserts 20 jobs every 10ms for 10s and checks the number of available vs completed jobs in the database afterwards. The `x` value is the queue limit. Without debouncing there isn't a predictable increase in throughput as the queue size increases:

<img width="621" alt="Screen Shot 2019-12-20 at 4 40 22 PM" src="https://user-images.githubusercontent.com/270831/71297055-7d4bef00-2347-11ea-9037-9e24e8ce8d96.png">

With debouncing the overall throughput increases along with the queue size:

<img width="619" alt="Screen Shot 2019-12-20 at 4 40 32 PM" src="https://user-images.githubusercontent.com/270831/71297164-fcd9be00-2347-11ea-9d69-3b486d83b056.png">

/cc @christianjgreen @TheFirstAvenger