### PR TITLE
Add job priority to control the order of execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 **Migration Required (V8)**
 
 This is the first required migration since 0.8.0, released in 09/2019. It brings
-with it a new column, `discarded_at` and a streamlined notifications trigger.
+with it a new column, `discarded_at`, a streamlined notifications trigger, and
+job prioritiy.
 
 ### Added
 
@@ -26,6 +27,10 @@ with it a new column, `discarded_at` and a streamlined notifications trigger.
   is also included in the original `create table` from V1 as a minor space
   saving optimization (packing datetime columns together because they use a
   predictable 4bytes of space).
+
+- [Oban.Job] Add numerical `priority` value to control the order of execution
+  for jobs within a queue. The `priority` can be set between 0 and 3, with 0
+  being the default and the highest priority.
 
 ### Changed
 

--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -27,6 +27,7 @@ defmodule Oban.Job do
   @type option ::
           {:args, args()}
           | {:max_attempts, pos_integer()}
+          | {:priority, pos_integer()}
           | {:queue, atom() | binary()}
           | {:schedule_in, pos_integer()}
           | {:scheduled_at, DateTime.t()}
@@ -43,6 +44,7 @@ defmodule Oban.Job do
           attempt: non_neg_integer(),
           attempted_by: [binary()],
           max_attempts: pos_integer(),
+          priority: pos_integer(),
           inserted_at: DateTime.t(),
           scheduled_at: DateTime.t(),
           attempted_at: DateTime.t(),
@@ -60,6 +62,7 @@ defmodule Oban.Job do
     field :attempt, :integer, default: 0
     field :attempted_by, {:array, :string}
     field :max_attempts, :integer, default: 20
+    field :priority, :integer, default: 0
     field :attempted_at, :utc_datetime_usec
     field :completed_at, :utc_datetime_usec
     field :discarded_at, :utc_datetime_usec
@@ -78,6 +81,7 @@ defmodule Oban.Job do
     errors
     inserted_at
     max_attempts
+    priority
     queue
     scheduled_at
     state
@@ -92,6 +96,8 @@ defmodule Oban.Job do
   ## Options
 
     * `:max_attempts` — the maximum number of times a job can be retried if there are errors during execution
+    * `:priority` — a numerical indicator from 0 to 3 of how important this job is relative to
+      other jobs in the same queue. The lower the number, the higher priority the job.
     * `:queue` — a named queue to push the job into. Jobs may be pushed into any queue, regardless
       of whether jobs are currently being processed for the queue.
     * `:schedule_in` - the number of seconds until the job should be executed
@@ -149,6 +155,7 @@ defmodule Oban.Job do
     |> validate_length(:queue, min: 1, max: 128)
     |> validate_length(:worker, min: 1, max: 128)
     |> validate_number(:max_attempts, greater_than: 0, less_than: 50)
+    |> validate_number(:priority, greater_than: -1, less_than: 4)
   end
 
   @doc """

--- a/lib/oban/query.ex
+++ b/lib/oban/query.ex
@@ -14,12 +14,12 @@ defmodule Oban.Query do
 
     subquery =
       Job
+      |> select([:id])
       |> where([j], j.state == "available")
       |> where([j], j.queue == ^queue)
-      |> lock("FOR UPDATE SKIP LOCKED")
+      |> order_by([j], asc: j.priority, asc: j.scheduled_at, asc: j.id)
       |> limit(^demand)
-      |> order_by([j], asc: j.scheduled_at, asc: j.id)
-      |> select([:id])
+      |> lock("FOR UPDATE SKIP LOCKED")
 
     updates = [
       set: [state: "executing", attempted_at: utc_now(), attempted_by: [node, queue, nonce]],

--- a/lib/oban/worker.ex
+++ b/lib/oban/worker.ex
@@ -3,15 +3,24 @@ defmodule Oban.Worker do
   Defines a behavior and macro to guide the creation of worker modules.
 
   Worker modules do the work of processing a job. At a minimum they must define a `perform/2`
-  function, which will be called with an `args` map and the job struct.
+  function, which is called with an `args` map and the full `Oban.Job` struct.
 
   ## Defining Workers
 
-  Define a worker to process jobs in the `events` queue, retrying at most 10 times if a job fails,
-  and ensuring that duplicate jobs aren't enqueued within a 30 second period:
+  Worker modules are defined by using `Oban.Worker`. A bare `use Oban.Worker` invocation sets a
+  worker with these defaults:
+
+  * `:max_attempts` — 20
+  * `:priority` — 0
+  * `:queue` — `:default`
+  * `:unique` — no uniquness set
+
+  The following example demonstrates defining a worker module to process jobs in the `events`
+  queue. It also dials down the priority from 0 to 1, limits retrying on failure to 10, and
+  ensures that duplicate jobs aren't enqueued within a 30 second period:
 
       defmodule MyApp.Workers.Business do
-        use Oban.Worker, queue: "events", max_attempts: 10, unique: [period: 30]
+        use Oban.Worker, queue: :events, max_attempts: 10, priority: 1, unique: [period: 30]
 
         @impl Oban.Worker
         def perform(_args, %Oban.Job{attempt: attempt}) when attempt > 3 do
@@ -77,51 +86,6 @@ defmodule Oban.Worker do
   Note that `unique` options aren't merged, they are overridden entirely.
 
   See `Oban.Job` for all available options.
-
-  ## Unique Jobs
-
-  The unique jobs feature lets you specify constraints to prevent enqueuing duplicate jobs.
-  Uniquness is based on a combination of `args`, `queue`, `worker`, `state` and insertion time. It
-  is configured at the worker or job level using the following options:
-
-  * `:period` — The number of seconds until a job is no longer considered duplicate. You should
-    always specify a period.
-  * `:fields` — The fields to compare when evaluating uniqueness. The available fields are
-    `:args`, `:queue` and `:worker`, by default all three are used.
-  * `:states` — The job states that will be checked for duplicates. The available states are
-    `:available`, `:scheduled`, `:executing`, `:retryable` and `:completed`. By default all states
-    are checked, which prevents _any_ duplicates, even if the previous job has been completed.
-
-  For example, configure a worker to be unique across all fields and states for 60 seconds:
-
-  ```elixir
-  use Oban.Worker, unique: [period: 60]
-  ```
-
-  Configure the worker to be unique only by `:worker` and `:queue`:
-
-  ```elixir
-  use Oban.Worker, unique: [fields: [:queue, :worker], period: 60]
-  ```
-
-  Or, configure a worker to be unique until it has executed:
-
-  ```elixir
-  use Oban.Worker, unique: [period: 300, states: [:available, :scheduled, :executing]]
-  ```
-
-  ### Stronger Guarantees
-
-  Oban's unique job support is built on a client side read/write cycle. That makes it subject to
-  duplicate writes if two transactions are started simultaneously. If you _absolutely must_ ensure
-  that a duplicate job isn't inserted then you will have to make use of unique constraints within
-  the database. `Oban.insert/2,4` will handle unique constraints safely through upsert support.
-
-  ### Performance Note
-
-  If your application makes heavy use of unique jobs you may want to add indexes on the `args` and
-  `inserted_at` columns of the `oban_jobs` table. The other columns considered for uniqueness are
-  already covered by indexes.
 
   ## Customizing Backoff
 
@@ -230,7 +194,15 @@ defmodule Oban.Worker do
 
   defp validate_opt!({:max_attempts, max_attempts}) do
     unless is_integer(max_attempts) and max_attempts > 0 do
-      raise ArgumentError, "expected :max_attempts to be a positive integer"
+      raise ArgumentError,
+            "expected :max_attempts to be a positive integer, got: #{inspect(max_attempts)}"
+    end
+  end
+
+  defp validate_opt!({:priority, priority}) do
+    unless is_integer(priority) and priority > -1 and priority < 4 do
+      raise ArgumentError,
+            "expected :priority to be an integer from 0 to 3, got: #{inspect(priority)}"
     end
   end
 

--- a/test/integration/executing_test.exs
+++ b/test/integration/executing_test.exs
@@ -41,16 +41,15 @@ defmodule Oban.Integration.ExecutingTest do
     gen all queue <- member_of(~w(alpha beta gamma delta)),
             action <- member_of(~w(OK FAIL ERROR EXIT)),
             ref <- integer(),
-            max_attempts <- integer(1..20) do
+            max_attempts <- integer(1..20),
+            priority <- integer(0..3) do
       args = %{ref: ref, action: action}
-      opts = [queue: queue, max_attempts: max_attempts]
+      opts = [queue: queue, max_attempts: max_attempts, priority: priority]
 
       Worker.new(args, opts)
     end
   end
 
-  # The `maximum_attempts` option is set to 1 to prevent retries. This ensures that the state for
-  # failed jobs will be `discarded`.
   defp action_to_state("OK", _max), do: "completed"
   defp action_to_state(_state, 1), do: "discarded"
   defp action_to_state(_state, max) when max > 1, do: "retryable"

--- a/test/oban/job_test.exs
+++ b/test/oban/job_test.exs
@@ -48,7 +48,8 @@ defmodule Oban.JobTest do
   end
 
   describe "to_map/1" do
-    @keys_with_defaults ~w(args attempt errors max_attempts queue state)a
+    @keys_with_defaults ~w(args attempt errors max_attempts priority queue state)a
+
     defp to_keys(opts) do
       %{}
       |> Job.new(opts)

--- a/test/oban/worker_test.exs
+++ b/test/oban/worker_test.exs
@@ -18,6 +18,7 @@ defmodule Oban.WorkerTest do
     use Worker,
       queue: "special",
       max_attempts: @max_attempts,
+      priority: 1,
       unique: [fields: [:queue, :worker], period: 60, states: [:scheduled]]
 
     @impl Worker
@@ -105,7 +106,7 @@ defmodule Oban.WorkerTest do
 
     assert_raise ArgumentError, fn ->
       defmodule BrokenModuleD do
-        use Oban.Worker, unique: 0
+        use Oban.Worker, priority: 11
 
         def perform(_, _), do: :ok
       end
@@ -113,7 +114,7 @@ defmodule Oban.WorkerTest do
 
     assert_raise ArgumentError, fn ->
       defmodule BrokenModuleE do
-        use Oban.Worker, unique: [unknown: []]
+        use Oban.Worker, unique: 0
 
         def perform(_, _), do: :ok
       end
@@ -121,7 +122,7 @@ defmodule Oban.WorkerTest do
 
     assert_raise ArgumentError, fn ->
       defmodule BrokenModuleF do
-        use Oban.Worker, unique: [fields: [:unknown]]
+        use Oban.Worker, unique: [unknown: []]
 
         def perform(_, _), do: :ok
       end
@@ -129,7 +130,7 @@ defmodule Oban.WorkerTest do
 
     assert_raise ArgumentError, fn ->
       defmodule BrokenModuleG do
-        use Oban.Worker, unique: [period: 0]
+        use Oban.Worker, unique: [fields: [:unknown]]
 
         def perform(_, _), do: :ok
       end
@@ -137,6 +138,14 @@ defmodule Oban.WorkerTest do
 
     assert_raise ArgumentError, fn ->
       defmodule BrokenModuleH do
+        use Oban.Worker, unique: [period: 0]
+
+        def perform(_, _), do: :ok
+      end
+    end
+
+    assert_raise ArgumentError, fn ->
+      defmodule BrokenModuleI do
         use Oban.Worker, unique: [states: [:unknown]]
 
         def perform(_, _), do: :ok


### PR DESCRIPTION
This adds an integer based `priority` column to jobs. Values between 0 and 3 are allowed, with 0 being the highest priority. The priority change requires rebuilding the primary compound index, but the resulting queries are just as fast as the previous version.

---

Note: This is bundled in with the v1.0.0 milestone because it requires a migration and I'm attempting to bundle them all together rather than stringing them out between versions.