### PR TITLE
Add compile time verification of string key maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ job prioritiy.
   for jobs within a queue. The `priority` can be set between 0 and 3, with 0
   being the default and the highest priority.
 
+- [Oban.Worker] Verify at compile time that the first argument to `perform/2` is
+  unbound, an empty map, or a map with string keys. This aims to prevent matches
+  that can never succeed, for example when using atoms as keys.
+
+  Note that only the initial `args` value is checked. Any matches inside the
+  body of `perform/2` are ignored.
+
 ### Changed
 
 - [Oban.Queue.Producer] Introduce "dispatch cooldown" as a way to debounce

--- a/test/oban/worker_test.exs
+++ b/test/oban/worker_test.exs
@@ -77,6 +77,41 @@ defmodule Oban.WorkerTest do
       assert 5 == CustomWorker.perform(args, %Job{args: args})
       assert 4 == CustomWorker.perform(args, %Job{attempt: 4, args: args})
     end
+
+    test "validating that the first argument is a map with string keys" do
+      assert_raise ArgumentError, fn ->
+        defmodule AtomKeys do
+          use Oban.Worker
+
+          def perform(%{a: 1}, _), do: :ok
+        end
+      end
+
+      assert_raise ArgumentError, fn ->
+        defmodule MixedKeys do
+          use Oban.Worker
+
+          def perform(%{"a" => 1}, _), do: :ok
+          def perform(%{b: 2}, _), do: :ok
+        end
+      end
+
+      assert_raise ArgumentError, fn ->
+        defmodule WrongType do
+          use Oban.Worker
+
+          def perform([a: 1, b: 2], _), do: :ok
+        end
+      end
+
+      assert_raise ArgumentError, fn ->
+        defmodule NestedMaps do
+          use Oban.Worker
+
+          def perform(%{"a" => %{b: 2}}, _), do: :ok
+        end
+      end
+    end
   end
 
   test "validating __using__ macro options" do


### PR DESCRIPTION
This adds a compile time hook to `Oban.Worker` to enforce string based keys when pattern matching args in `perform/2` function heads.