### PR TITLE
Fix worker docs

### DIFF
--- a/lib/oban/worker.ex
+++ b/lib/oban/worker.ex
@@ -42,7 +42,6 @@ defmodule Oban.Worker do
   Any of these return values or error events will fail the job:
 
   * return `{:error, error}`
-  * return `:error`
   * an unhandled exception
   * an unhandled exit or throw
 


### PR DESCRIPTION
According to [the code](https://github.com/sorentwo/oban/blob/afa30971b8e58c44fd19ab1acf0fc0e3cb983a5a/lib/oban/queue/executor.ex#L39-L58) and [this readme section](https://github.com/sorentwo/oban/blob/afa30971b8e58c44fd19ab1acf0fc0e3cb983a5a/README.md#Defining-Workers), only `{:error, reason}` is considered as an error, while `:error` is considered as success.

Related, I think it would be a bit nicer if `perform` contract was tighter, requiring the client to explicitly indicate success by returning `:ok`. So basically something like:

```elixir
@callback perform(args :: Job.args(), job :: Job.t()) :: :ok | {:error, reason :: term}
```

What do you think?