### PR TITLE
Introduce tags as way to organize jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ job prioritiy.
   for jobs within a queue. The `priority` can be set between 0 and 3, with 0
   being the default and the highest priority.
 
+- [Oban.Job] Add `tags` field for arbitrarily organizing associated tags. Tags
+  are a list of strings stored as an `array` in the database, making them easy
+  to search and filter by.
+
 ### Changed
 
 - [Oban] Change the default `prune` value from `:disabled` to `{:maxlen,

--- a/README.md
+++ b/README.md
@@ -303,12 +303,17 @@ defmodule MyApp.Business do
 end
 ```
 
-The `use` macro also accepts options to customize max attempts, priority, and
-uniqueness:
+The `use` macro also accepts options to customize max attempts, priority, tags,
+and uniqueness:
 
 ```elixir
 defmodule MyApp.LazyBusiness do
-  use Oban.Worker, queue: :events, priority: 3, max_attempts: 3, unique: [period: 30]
+  use Oban.Worker,
+    queue: :events,
+    priority: 3,
+    max_attempts: 3,
+    tags: ["business"],
+    unique: [period: 30]
 
   @impl Oban.Worker
   def perform(_args, _job) do
@@ -375,6 +380,17 @@ default and highest priority:
 ```elixir
 %{id: 1}
 |> MyApp.Backfiller.new(priority: 2)
+|> Oban.insert()
+```
+
+Any number of tags can be added to a job dynamically, at the time it is
+inserted:
+
+```elixir
+id = 1
+
+%{id: id}
+|> MyApp.OnboardMailer.new(tags: ["mailer", "record-#{id}"])
 |> Oban.insert()
 ```
 
@@ -504,7 +520,7 @@ config :my_app, Oban, repo: MyApp.Repo, crontab: [
   {"* * * * *", MyApp.MinuteWorker},
   {"0 * * * *", MyApp.HourlyWorker, args: %{custom: "arg"}},
   {"0 0 * * *", MyApp.DailyWorker, max_attempts: 1},
-  {"0 12 * * MON", MyApp.MondayWorker, queue: :scheduled}
+  {"0 12 * * MON", MyApp.MondayWorker, queue: :scheduled, tags: ["mondays"]}
 ]
 ```
 

--- a/lib/oban/migrations.ex
+++ b/lib/oban/migrations.ex
@@ -164,6 +164,7 @@ defmodule Oban.Migrations do
         add :queue, :text, null: false, default: "default"
         add :worker, :text, null: false
         add :args, :map, null: false
+        add :tags, {:array, :string}, null: false, default: []
         add :errors, {:array, :map}, null: false, default: []
         add :attempt, :integer, null: false, default: 0
         add :max_attempts, :integer, null: false, default: 20
@@ -406,7 +407,9 @@ defmodule Oban.Migrations do
       alter table(:oban_jobs, prefix: prefix) do
         add_if_not_exists(:discarded_at, :utc_datetime_usec)
         add_if_not_exists(:priority, :integer)
+        add_if_not_exists(:tags, {:array, :string})
         modify :priority, :integer, default: 0
+        modify :tags, {:array, :string}, default: []
       end
 
       drop_if_exists index(:oban_jobs, [:queue, :state, :scheduled_at, :id], prefix: prefix)

--- a/lib/oban/worker.ex
+++ b/lib/oban/worker.ex
@@ -16,11 +16,16 @@ defmodule Oban.Worker do
   * `:unique` — no uniquness set
 
   The following example demonstrates defining a worker module to process jobs in the `events`
-  queue. It also dials down the priority from 0 to 1, limits retrying on failure to 10, and
-  ensures that duplicate jobs aren't enqueued within a 30 second period:
+  queue. It also dials down the priority from 0 to 1, limits retrying on failures to 10, adds a
+  "business" tag, and ensures that duplicate jobs aren't enqueued within a 30 second period:
 
       defmodule MyApp.Workers.Business do
-        use Oban.Worker, queue: :events, max_attempts: 10, priority: 1, unique: [period: 30]
+        use Oban.Worker,
+          queue: :events,
+          max_attempts: 10,
+          priority: 1,
+          tags: ["business"],
+          unique: [period: 30]
 
         @impl Oban.Worker
         def perform(_args, %Oban.Job{attempt: attempt}) when attempt > 3 do
@@ -209,6 +214,12 @@ defmodule Oban.Worker do
   defp validate_opt!({:queue, queue}) do
     unless is_atom(queue) or is_binary(queue) do
       raise ArgumentError, "expected :queue to be an atom or a binary, got: #{inspect(queue)}"
+    end
+  end
+
+  defp validate_opt!({:tags, tags}) do
+    unless is_list(tags) and Enum.all?(tags, &is_binary/1) do
+      raise ArgumentError, "expected :tags to be a list of strings, got: #{inspect(tags)}"
     end
   end
 

--- a/test/integration/executing_test.exs
+++ b/test/integration/executing_test.exs
@@ -42,9 +42,10 @@ defmodule Oban.Integration.ExecutingTest do
             action <- member_of(~w(OK FAIL ERROR EXIT)),
             ref <- integer(),
             max_attempts <- integer(1..20),
-            priority <- integer(0..3) do
+            priority <- integer(0..3),
+            tags <- list_of(string(:ascii)) do
       args = %{ref: ref, action: action}
-      opts = [queue: queue, max_attempts: max_attempts, priority: priority]
+      opts = [queue: queue, max_attempts: max_attempts, priority: priority, tags: tags]
 
       Worker.new(args, opts)
     end

--- a/test/oban/job_test.exs
+++ b/test/oban/job_test.exs
@@ -16,6 +16,19 @@ defmodule Oban.JobTest do
     end
   end
 
+  describe "tags with new/2" do
+    test "normalizing and deduping tags" do
+      tag_changes = fn tags ->
+        Job.new(%{}, worker: Fake, tags: tags).changes[:tags]
+      end
+
+      refute tag_changes.(["", " ", "\n"])
+      assert ["alpha"] = tag_changes.([" ", "\nalpha\n"])
+      assert ["alpha"] = tag_changes.(["ALPHA", " alpha "])
+      assert ["1", "2"] = tag_changes.([nil, 1, 2])
+    end
+  end
+
   describe "unique constraints with new/2" do
     test "marking a job as unique by setting the period provides defaults" do
       changeset = Job.new(%{}, worker: Fake, unique: [period: 60])
@@ -48,7 +61,7 @@ defmodule Oban.JobTest do
   end
 
   describe "to_map/1" do
-    @keys_with_defaults ~w(args attempt errors max_attempts priority queue state)a
+    @keys_with_defaults ~w(args attempt errors max_attempts priority queue state tags)a
 
     defp to_keys(opts) do
       %{}

--- a/test/oban/worker_test.exs
+++ b/test/oban/worker_test.exs
@@ -19,6 +19,7 @@ defmodule Oban.WorkerTest do
       queue: "special",
       max_attempts: @max_attempts,
       priority: 1,
+      tags: ["scheduled", "special"],
       unique: [fields: [:queue, :worker], period: 60, states: [:scheduled]]
 
     @impl Worker
@@ -80,72 +81,98 @@ defmodule Oban.WorkerTest do
   end
 
   test "validating __using__ macro options" do
-    assert_raise ArgumentError, fn ->
-      defmodule BrokenModuleA do
+    assert_raise ArgumentError, ~r/unknown option/, fn ->
+      defmodule UnknownOption do
         use Oban.Worker, state: "youcantsetthis"
 
         def perform(_, _), do: :ok
       end
     end
+  end
 
-    assert_raise ArgumentError, fn ->
-      defmodule BrokenModuleB do
+  test "validating the queue provided to __using__" do
+    assert_raise ArgumentError, ~r/expected :queue to be/, fn ->
+      defmodule InvalidQueue do
         use Oban.Worker, queue: 1234
 
         def perform(_, _), do: :ok
       end
     end
+  end
 
-    assert_raise ArgumentError, fn ->
-      defmodule BrokenModuleC do
+  test "validating the max attempts provided to __using__" do
+    assert_raise ArgumentError, ~r/expected :max_attempts to be/, fn ->
+      defmodule InvalidMaxAttempts do
         use Oban.Worker, max_attempts: 0
 
         def perform(_, _), do: :ok
       end
     end
+  end
 
-    assert_raise ArgumentError, fn ->
-      defmodule BrokenModuleD do
+  test "validating the priority provided to __using__" do
+    assert_raise ArgumentError, ~r/expected :priority to be/, fn ->
+      defmodule InvalidPriority do
         use Oban.Worker, priority: 11
 
         def perform(_, _), do: :ok
       end
     end
+  end
 
-    assert_raise ArgumentError, fn ->
-      defmodule BrokenModuleE do
+  test "validating the tags provided to __using__" do
+    assert_raise ArgumentError, ~r/expected :tags to be a list/, fn ->
+      defmodule InvalidTagsType do
+        use Oban.Worker, tags: nil
+
+        def perform(_, _), do: :ok
+      end
+    end
+
+    assert_raise ArgumentError, ~r/expected :tags to be a list/, fn ->
+      defmodule InvalidTagsValue do
+        use Oban.Worker, tags: ["alpha", :beta]
+
+        def perform(_, _), do: :ok
+      end
+    end
+  end
+
+  test "validating the unique options provided to __using__" do
+    assert_raise ArgumentError, ~r/unexpected unique options/, fn ->
+      defmodule InvalidUniqueType do
         use Oban.Worker, unique: 0
 
         def perform(_, _), do: :ok
       end
     end
 
-    assert_raise ArgumentError, fn ->
-      defmodule BrokenModuleF do
+    assert_raise ArgumentError, ~r/unexpected unique options/, fn ->
+      defmodule InvalidUniqueOption do
         use Oban.Worker, unique: [unknown: []]
 
         def perform(_, _), do: :ok
       end
     end
 
-    assert_raise ArgumentError, fn ->
-      defmodule BrokenModuleG do
+    assert_raise ArgumentError, ~r/unexpected unique options/, fn ->
+      defmodule InvalidUniqueField do
         use Oban.Worker, unique: [fields: [:unknown]]
 
         def perform(_, _), do: :ok
       end
     end
 
-    assert_raise ArgumentError, fn ->
-      defmodule BrokenModuleH do
+    assert_raise ArgumentError, ~r/unexpected unique options/, fn ->
+      defmodule InvalidUniquePeriod do
         use Oban.Worker, unique: [period: 0]
 
         def perform(_, _), do: :ok
       end
     end
 
-    assert_raise ArgumentError, fn ->
-      defmodule BrokenModuleI do
+    assert_raise ArgumentError, ~r/unexpected unique options/, fn ->
+      defmodule InvalidUniqueStates do
         use Oban.Worker, unique: [states: [:unknown]]
 
         def perform(_, _), do: :ok


### PR DESCRIPTION
Jobs now have a tags field (array in PG) that can be defined at the worker or job level. Tags are arbitrary strings that can be used to group and organize related jobs.