### PR TITLE
Allow passing a timeout for testing assertions

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -7,7 +7,17 @@
   ],
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
   export: [
-    locals_without_parens: [assert_enqueued: 1, refute_enqueued: 1]
+    locals_without_parens: [
+      assert_enqueued: 1,
+      assert_enqueued: 2,
+      refute_enqueued: 1,
+      refute_enqueued: 2
+    ]
   ],
-  locals_without_parens: [assert_enqueued: 1, refute_enqueued: 1]
+  locals_without_parens: [
+    assert_enqueued: 1,
+    assert_enqueued: 2,
+    refute_enqueued: 1,
+    refute_enqueued: 2
+  ]
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- [Oban.Testing] Add `assert_enqueued/2` and `refute_enqueued/2` to allow
+  asserting with a timeout, like `assert_received`.
+
 ## [1.1.0] — 2020-02-17
 
 ### Fixed


### PR DESCRIPTION
Add `assert_enqueued/2` and `refute_enqueued/2` to allow asserting with a timeout, like `assert_received`. This uses a quick 10ms poll to make the assertion. Polling is a little brute force, but it is 100% accurate compared to pubsub or instrumentation.

Closes #179

/cc @anthonator 