### PR TITLE
Only create schema if prefix not "public"

### DIFF
--- a/lib/oban/migrations.ex
+++ b/lib/oban/migrations.ex
@@ -138,7 +138,8 @@ defmodule Oban.Migrations do
     import Oban.Migrations.Helper
 
     def up(prefix) do
-      execute "CREATE SCHEMA IF NOT EXISTS #{prefix}"
+      if prefix != "public", do:
+        execute "CREATE SCHEMA IF NOT EXISTS #{prefix}"
 
       execute """
       DO $$

--- a/lib/oban/migrations.ex
+++ b/lib/oban/migrations.ex
@@ -138,8 +138,7 @@ defmodule Oban.Migrations do
     import Oban.Migrations.Helper
 
     def up(prefix) do
-      if prefix != "public", do:
-        execute "CREATE SCHEMA IF NOT EXISTS #{prefix}"
+      if prefix != "public", do: execute("CREATE SCHEMA IF NOT EXISTS #{prefix}")
 
       execute """
       DO $$


### PR DESCRIPTION
- Patrick Thompson: Don't unnecessarily try to create a new schema if prefix is "public", as public is the default schema and doing so may cause an issue on databases that do not allow new schemas to be created.