### PR TITLE
Allow :infinity as a unique period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [Oban.Telemetry] Add `span/3` for reporting normalized `:start`, `:stop` and
   `:exception` events with timing information.
 
+- [Oban.Query] Add `:infinity` option for unique period.
+
 ### Changed
 
 - [Oban.Notifier] Make the module public and clean up the primary function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [Oban.Telemetry] Add `span/3` for reporting normalized `:start`, `:stop` and
   `:exception` events with timing information.
 
-- [Oban.Query] Add `:infinity` option for unique period.
+- [Oban.Worker] Add `:infinity` option for unique period.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -483,7 +483,8 @@ duplicate jobs.  Uniquness is based on a combination of `args`, `queue`,
 level using the following options:
 
 * `:period` — The number of seconds until a job is no longer considered
-  duplicate. You should always specify a period.
+  duplicate. You should always specify a period. `:infinity` can be used to
+  indicate the job be considered a duplicate as long as jobs are retained.
 
 * `:fields` — The fields to compare when evaluating uniqueness. The available
   fields are `:args`, `:queue` and `:worker`, by default all three are used.

--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -18,11 +18,13 @@ defmodule Oban.Job do
 
   @type unique_field :: [:args | :queue | :worker]
 
+  @type unique_period :: pos_integer() | :infinity
+
   @type unique_state :: [:available | :scheduled | :executing | :retryable | :completed]
 
   @type unique_option ::
           {:fields, [unique_field()]}
-          | {:period, pos_integer()}
+          | {:period, unique_period()}
           | {:states, [unique_state()]}
 
   @type option ::
@@ -53,7 +55,7 @@ defmodule Oban.Job do
           attempted_at: DateTime.t(),
           completed_at: DateTime.t(),
           discarded_at: DateTime.t(),
-          unique: %{fields: [unique_field()], period: pos_integer(), states: [unique_state()]},
+          unique: %{fields: [unique_field()], period: unique_period(), states: [unique_state()]},
           unsaved_error: %{kind: atom(), reason: term(), stacktrace: Exception.stacktrace()}
         }
 
@@ -211,6 +213,7 @@ defmodule Oban.Job do
   @doc false
   @spec valid_unique_opt?({:fields | :period | :states, [atom()] | integer()}) :: boolean()
   def valid_unique_opt?({:fields, [_ | _] = fields}), do: fields -- @unique_fields == []
+  def valid_unique_opt?({:period, :infinity}), do: true
   def valid_unique_opt?({:period, period}), do: is_integer(period) and period > 0
   def valid_unique_opt?({:states, [_ | _] = states}), do: states -- @unique_states == []
   def valid_unique_opt?(_option), do: false

--- a/test/integration/uniqueness_test.exs
+++ b/test/integration/uniqueness_test.exs
@@ -67,15 +67,20 @@ defmodule Oban.Integration.UniquenessTest do
     now = DateTime.utc_now()
     two_minutes_ago = DateTime.add(now, -120, :second)
     five_minutes_ago = DateTime.add(now, -300, :second)
+    one_thousand_years_ago = Map.put(now, :year, now.year - 1000)
+    one_hundred_years_in_seconds = 100 * 365 * 24 * 60 * 60
 
     assert %Job{id: _id} = insert_job!(%{id: 1}, inserted_at: two_minutes_ago)
     assert %Job{id: _id} = insert_job!(%{id: 2}, inserted_at: five_minutes_ago)
+    assert %Job{id: _id} = insert_job!(%{id: 3}, inserted_at: one_thousand_years_ago)
     assert %Job{id: id_1} = insert_job!(%{id: 1}, unique: [period: 110])
     assert %Job{id: id_2} = insert_job!(%{id: 2}, unique: [period: 290])
+    assert %Job{id: id_3} = insert_job!(%{id: 3}, unique: [period: one_hundred_years_in_seconds])
     assert %Job{id: ^id_1} = insert_job!(%{id: 1}, unique: [period: 180])
     assert %Job{id: ^id_2} = insert_job!(%{id: 2}, unique: [period: 400])
+    assert %Job{id: ^id_3} = insert_job!(%{id: 3}, unique: [period: :infinity])
 
-    assert count_jobs() == 4
+    assert count_jobs() == 6
   end
 
   test "inserting unique jobs within a multi transaction" do

--- a/test/oban/job_test.exs
+++ b/test/oban/job_test.exs
@@ -55,7 +55,7 @@ defmodule Oban.JobTest do
       assert Job.new(%{}, worker: Fake, unique: []).errors[:unique]
       assert Job.new(%{}, worker: Fake, unique: [special: :value]).errors[:unique]
       assert Job.new(%{}, worker: Fake, unique: [fields: [:bogus]]).errors[:unique]
-      assert Job.new(%{}, worker: Fake, unique: [period: :infinity]).errors[:unique]
+      assert Job.new(%{}, worker: Fake, unique: [period: :bogus]).errors[:unique]
       assert Job.new(%{}, worker: Fake, unique: [states: [:random]]).errors[:unique]
     end
   end


### PR DESCRIPTION
Resolves #210 

This isn't the exact proposed solution, if you want me to change it to translate the `:infinity` option to a large period I can change that. Instead I just alter the query to not limit to any date range if `:infinity` was passed.