### PR TITLE
Transition worker callback from perform/2 to perform/1

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ defmodule MyApp.Business do
   use Oban.Worker, queue: :events
 
   @impl Oban.Worker
-  def perform(%{"id" => id} = args, _job) do
+  def perform(%_{args: %{"id" => id}}) do
     model = MyApp.Repo.get(MyApp.Business.Man, id)
 
     case args do
@@ -350,7 +350,7 @@ defmodule MyApp.LazyBusiness do
     unique: [period: 30]
 
   @impl Oban.Worker
-  def perform(_args, _job) do
+  def perform(_job) do
     # do business slowly
 
     :ok
@@ -359,7 +359,7 @@ end
 ```
 
 Successful jobs should return `:ok` or an `{:ok, value}` tuple. The value
-returned from `perform/2` is used to control whether the job is treated as a
+returned from `perform/1` is used to control whether the job is treated as a
 success, a failure, discarded completely or deferred until later.
 
 See the `Oban.Worker` docs for more details on failure conditions and

--- a/bench/benchmarks/throughput_bench.exs
+++ b/bench/benchmarks/throughput_bench.exs
@@ -4,7 +4,7 @@ defmodule BenchWorker do
   use Oban.Worker
 
   @impl Oban.Worker
-  def perform(%{"max" => max, "bin_pid" => bin_pid, "bin_cnt" => bin_cnt}, _job) do
+  def perform(%{args: %{"max" => max, "bin_pid" => bin_pid, "bin_cnt" => bin_cnt}}) do
     pid = BenchHelper.base64_to_term(bin_pid)
     ctn = BenchHelper.base64_to_term(bin_cnt)
 

--- a/lib/oban/config.ex
+++ b/lib/oban/config.ex
@@ -173,7 +173,7 @@ defmodule Oban.Config do
   defp valid_crontab?({expression, worker, opts}) do
     is_binary(expression) and
       Code.ensure_loaded?(worker) and
-      function_exported?(worker, :perform, 2) and
+      function_exported?(worker, :perform, 1) and
       Keyword.keyword?(opts)
   end
 

--- a/lib/oban/notifier.ex
+++ b/lib/oban/notifier.ex
@@ -39,8 +39,8 @@ defmodule Oban.Notifier do
         use Oban.Worker
 
         @impl Oban.Worker
-        def perform(args, job) do
-          :ok = MyApp.do_work(args)
+        def perform(job) do
+          :ok = MyApp.do_work(job.args)
 
           Oban.Notifier.notify(Oban.config(), :gossip, %{complete: job.id})
 

--- a/lib/oban/queue/executor.ex
+++ b/lib/oban/queue/executor.ex
@@ -153,7 +153,7 @@ defmodule Oban.Queue.Executor do
   end
 
   defp perform_inline(%{worker: worker, job: job} = exec) do
-    case worker.perform(job.args, job) do
+    case worker.perform(job) do
       :ok ->
         %{exec | state: :success}
 

--- a/lib/oban/worker.ex
+++ b/lib/oban/worker.ex
@@ -28,12 +28,12 @@ defmodule Oban.Worker do
           unique: [period: 30]
 
         @impl Oban.Worker
-        def perform(_args, %Oban.Job{attempt: attempt}) when attempt > 3 do
+        def perform(%{attempt: attempt}) when attempt > 3 do
           IO.inspect(attempt)
         end
 
-        def perform(args, _job) do
-          IO.inspect(args)
+        def perform(job) do
+          IO.inspect(job.args)
         end
       end
 
@@ -60,7 +60,7 @@ defmodule Oban.Worker do
         use Oban.Worker
 
         @impl Worker
-        def perform(%{"value" => value}, _job) do
+        def perform(%{args: %{"value" => value}}) do
           if value > 1 do
             :ok
           else
@@ -113,7 +113,7 @@ defmodule Oban.Worker do
         end
 
         @impl Worker
-        def perform(_args, _job) do
+        def perform(_job) do
           :do_business
         end
       end
@@ -138,7 +138,7 @@ defmodule Oban.Worker do
         @five_minutes 5 * 60
 
         @impl Worker
-        def perform(args, _job) do
+        def perform(%{args: args}) do
           MyApp.make_external_api_call(args)
         end
 
@@ -164,7 +164,7 @@ defmodule Oban.Worker do
         use Oban.Worker
 
         @impl Oban.Worker
-        def perform(_args, _job) do
+        def perform(_job) do
           something_that_may_take_a_long_time()
 
           :ok
@@ -214,17 +214,17 @@ defmodule Oban.Worker do
   @callback timeout(job :: Job.t()) :: :infinity | pos_integer()
 
   @doc """
-  The `perform/2` function is called to execute a job.
+  The `perform/1` function is called to execute a job.
 
-  Each `perform/2` function should return `:ok` or a success tuple. When the return is an error
+  Each `perform/1` function should return `:ok` or a success tuple. When the return is an error
   tuple, an uncaught exception or a throw then the error is recorded and the job may be retried
   if there are any attempts remaining.
 
-  Note that the `args` map passed to `perform/2` will _always_ have string keys, regardless of the
-  key type when the job was enqueued. The `args` are stored as `jsonb` in PostgreSQL and the
+  Note that the `args` map provided to `perform/1` will _always_ have string keys, regardless of
+  the key type when the job was enqueued. The `args` are stored as `jsonb` in PostgreSQL and the
   serialization process automatically stringifies all keys.
   """
-  @callback perform(args :: Job.args(), job :: Job.t()) ::
+  @callback perform(job :: Job.t()) ::
               :ok
               | :discard
               | {:ok, ignored :: term()}

--- a/test/integration/pruning_test.exs
+++ b/test/integration/pruning_test.exs
@@ -9,7 +9,7 @@ defmodule Oban.Integration.PruningTest do
     use Oban.Worker, queue: :default
 
     @impl Worker
-    def perform(_args, _job), do: :ok
+    def perform(_job), do: :ok
   end
 
   test "historic jobs are pruned when they are older than 60 seconds" do

--- a/test/integration/scheduling_test.exs
+++ b/test/integration/scheduling_test.exs
@@ -11,7 +11,7 @@ defmodule Oban.Integration.SchedulingTest do
     use Oban.Worker, queue: :scheduled
 
     @impl Worker
-    def perform(_args, _job), do: :ok
+    def perform(_job), do: :ok
   end
 
   test "jobs scheduled in the future are unavailable for execution" do

--- a/test/integration/uniqueness_test.exs
+++ b/test/integration/uniqueness_test.exs
@@ -13,7 +13,7 @@ defmodule Oban.Integration.UniquenessTest do
     use Oban.Worker, queue: :upsilon, unique: [period: 30]
 
     @impl Worker
-    def perform(_args, _job), do: :ok
+    def perform(_job), do: :ok
   end
 
   setup do

--- a/test/oban/queue/executor_test.exs
+++ b/test/oban/queue/executor_test.exs
@@ -9,11 +9,11 @@ defmodule Oban.Queue.ExecutorTest do
     use Oban.Worker
 
     @impl Worker
-    def perform(%{"mode" => "ok"}, _job), do: :ok
-    def perform(%{"mode" => "warn"}, _job), do: {:bad, :this_will_warn}
-    def perform(%{"mode" => "raise"}, _job), do: raise(ArgumentError)
-    def perform(%{"mode" => "catch"}, _job), do: throw(:no_reason)
-    def perform(%{"mode" => "error"}, _job), do: {:error, "no reason"}
+    def perform(%{args: %{"mode" => "ok"}}), do: :ok
+    def perform(%{args: %{"mode" => "warn"}}), do: {:bad, :this_will_warn}
+    def perform(%{args: %{"mode" => "raise"}}), do: raise(ArgumentError)
+    def perform(%{args: %{"mode" => "catch"}}), do: throw(:no_reason)
+    def perform(%{args: %{"mode" => "error"}}), do: {:error, "no reason"}
   end
 
   describe "perform/1" do

--- a/test/oban/worker_test.exs
+++ b/test/oban/worker_test.exs
@@ -7,7 +7,7 @@ defmodule Oban.WorkerTest do
     use Worker
 
     @impl Worker
-    def perform(_args, _job), do: :ok
+    def perform(_job), do: :ok
   end
 
   defmodule CustomWorker do
@@ -26,8 +26,8 @@ defmodule Oban.WorkerTest do
     def backoff(%{attempt: attempt}), do: attempt * attempt
 
     @impl Worker
-    def perform(_args, %{attempt: attempt}) when attempt > 1, do: attempt
-    def perform(%{"a" => a, "b" => b}, _job), do: a + b
+    def perform(%{attempt: attempt}) when attempt > 1, do: attempt
+    def perform(%{args: %{"a" => a, "b" => b}}), do: a + b
 
     @impl Worker
     def timeout(%{args: %{"timeout" => timeout}}), do: timeout
@@ -89,8 +89,8 @@ defmodule Oban.WorkerTest do
     test "arguments from the complete job struct are extracted" do
       args = %{"a" => 2, "b" => 3}
 
-      assert 5 == CustomWorker.perform(args, %Job{args: args})
-      assert 4 == CustomWorker.perform(args, %Job{attempt: 4, args: args})
+      assert 5 == CustomWorker.perform(%Job{args: args})
+      assert 4 == CustomWorker.perform(%Job{attempt: 4, args: args})
     end
   end
 
@@ -99,7 +99,7 @@ defmodule Oban.WorkerTest do
       defmodule UnknownOption do
         use Oban.Worker, state: "youcantsetthis"
 
-        def perform(_, _), do: :ok
+        def perform(_), do: :ok
       end
     end
   end
@@ -109,7 +109,7 @@ defmodule Oban.WorkerTest do
       defmodule InvalidQueue do
         use Oban.Worker, queue: 1234
 
-        def perform(_, _), do: :ok
+        def perform(_), do: :ok
       end
     end
   end
@@ -119,7 +119,7 @@ defmodule Oban.WorkerTest do
       defmodule InvalidMaxAttempts do
         use Oban.Worker, max_attempts: 0
 
-        def perform(_, _), do: :ok
+        def perform(_), do: :ok
       end
     end
   end
@@ -129,7 +129,7 @@ defmodule Oban.WorkerTest do
       defmodule InvalidPriority do
         use Oban.Worker, priority: 11
 
-        def perform(_, _), do: :ok
+        def perform(_), do: :ok
       end
     end
   end
@@ -139,7 +139,7 @@ defmodule Oban.WorkerTest do
       defmodule InvalidTagsType do
         use Oban.Worker, tags: nil
 
-        def perform(_, _), do: :ok
+        def perform(_), do: :ok
       end
     end
 
@@ -147,7 +147,7 @@ defmodule Oban.WorkerTest do
       defmodule InvalidTagsValue do
         use Oban.Worker, tags: ["alpha", :beta]
 
-        def perform(_, _), do: :ok
+        def perform(_), do: :ok
       end
     end
   end
@@ -157,7 +157,7 @@ defmodule Oban.WorkerTest do
       defmodule InvalidUniqueType do
         use Oban.Worker, unique: 0
 
-        def perform(_, _), do: :ok
+        def perform(_), do: :ok
       end
     end
 
@@ -165,7 +165,7 @@ defmodule Oban.WorkerTest do
       defmodule InvalidUniqueOption do
         use Oban.Worker, unique: [unknown: []]
 
-        def perform(_, _), do: :ok
+        def perform(_), do: :ok
       end
     end
 
@@ -173,7 +173,7 @@ defmodule Oban.WorkerTest do
       defmodule InvalidUniqueField do
         use Oban.Worker, unique: [fields: [:unknown]]
 
-        def perform(_, _), do: :ok
+        def perform(_), do: :ok
       end
     end
 
@@ -181,7 +181,7 @@ defmodule Oban.WorkerTest do
       defmodule InvalidUniquePeriod do
         use Oban.Worker, unique: [period: 0]
 
-        def perform(_, _), do: :ok
+        def perform(_), do: :ok
       end
     end
 
@@ -189,7 +189,7 @@ defmodule Oban.WorkerTest do
       defmodule InvalidUniqueStates do
         use Oban.Worker, unique: [states: [:unknown]]
 
-        def perform(_, _), do: :ok
+        def perform(_), do: :ok
       end
     end
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -18,7 +18,7 @@ defmodule Oban.Integration.Worker do
   end
 
   @impl Worker
-  def perform(%{"ref" => ref, "action" => action, "bin_pid" => bin_pid}, _job) do
+  def perform(%_{args: %{"ref" => ref, "action" => action, "bin_pid" => bin_pid}}) do
     pid = bin_to_pid(bin_pid)
 
     case action do
@@ -65,7 +65,7 @@ defmodule Oban.Integration.Worker do
     end
   end
 
-  def perform(%{"ref" => ref, "sleep" => sleep, "bin_pid" => bin_pid}, _job) do
+  def perform(%_{args: %{"ref" => ref, "sleep" => sleep, "bin_pid" => bin_pid}}) do
     pid = bin_to_pid(bin_pid)
 
     send(pid, {:started, ref})


### PR DESCRIPTION
As the project approaches a major version bump it is time to get in a few breaking changes. The goal of this PR is to unify the worker callbacks so that they all accept a job struct and to make testing cleaner.

### Rationale

Having spent a _lot_ more time writing and testing workers I kept running into the same situation. Most workers never use the `job` argument and I (or my team) would work around it to try and make the test clearer. We would repeatedly do one of the following:

* Give `job` a default of `nil`, e.g. `perform(args, job \\ nil)`
* Call `perform/2` with `nil` or an empty map explicitly

After doing that in dozens of places it seems wrong!

### Solution

Go *back* to a `perform/1` callback, but expect a job struct rather than an args map. That means a worker that looks like this:

```elixir
def perform(%{"id" => id}, _job)
```

Will now look like this:

```elixir
def perform(%{args: %{"id" => id}})
```

It is slightly noisier, but much clearer when invoked manually in tests. Compare this:

```elixir
perform(%{"id" => 1}, nil)
perform(%{"id" => 1}, %{})
perform(%{"id" => 1}, %Job{})
```

with this:

```elixir
perform(%{args: %{"id" => 1}})
```

This also enables a fix for a related issue, which is attempting to match on atom keys when they'll always be strings. A helper function like `Oban.Job.new/1,2` can ensure all keys are strings and be used to craft a real-world payload when testing. With `new/1,2` test calls could look like this:

```elixir
perform(Job.new(id: 1))
perform(Job.new(%{id: 1}, attempt: 42))
```

---

This flips the decision made in https://github.com/sorentwo/oban/pull/46