### PR TITLE
chore: minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,11 +729,11 @@ backoff strategies.
 ### Error Details
 
 Execution errors are stored as a formatted exception along with metadata about
-when the failure ocurred and which attempt caused it. Each error is stored with
+when the failure occurred and which attempt caused it. Each error is stored with
 the following keys:
 
 * `at` The utc timestamp when the error occurred at
-* `attempt` The attempt number when the error ocurred
+* `attempt` The attempt number when the error occurred
 * `error` A formatted error message and stacktrace
 
 See the [Instrumentation](#Instrumentation-and-Logging) docs for an example of

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -64,7 +64,7 @@ defmodule Oban do
     documentation for more details.
   * `:queues` — a keyword list where the keys are queue names and the values are the concurrency
     setting. For example, setting queues to `[default: 10, exports: 5]` would start the queues
-    `default` and `exports` with a combined concurrency level of 20. The concurrency setting
+    `default` and `exports` with a combined concurrency level of 15. The concurrency setting
     specifies how many jobs _each queue_ will run concurrently.
 
     For testing purposes `:queues` may be set to `false` or `nil`, which effectively disables all
@@ -471,22 +471,9 @@ defmodule Oban do
     |> Notifier.notify(:signal, %{action: :stop, queue: queue})
   end
 
-  @doc """
-  Kill an actively executing job and mark it as `discarded`, ensuring that it won't be retried.
-
-  If the job happens to fail before it can be killed the state is set to `discarded`. However,
-  if it manages to complete successfully then the state will still be `completed`.
-
-  ## Example
-
-  Kill a long running job with an id of `1`:
-
-      Oban.kill_job(1)
-      :ok
-  """
-  @doc since: "0.2.0"
-  @doc deprecated: "Use Oban.cancel_job/1 instead"
-  @spec kill_job(name :: atom(), job_id :: pos_integer()) :: :ok
+  @doc false
+  @deprecated "Use Oban.cancel_job/1 instead"
+  @spec kill_job(name :: module(), job_id :: pos_integer()) :: :ok
   def kill_job(name \\ __MODULE__, job_id) when is_integer(job_id) do
     name
     |> config()

--- a/lib/oban/crontab/scheduler.ex
+++ b/lib/oban/crontab/scheduler.ex
@@ -55,7 +55,7 @@ defmodule Oban.Crontab.Scheduler do
 
   @impl GenServer
   def terminate(_reason, %State{poll_ref: poll_ref}) do
-    if not is_nil(poll_ref), do: Process.cancel_timer(poll_ref)
+    if is_reference(poll_ref), do: Process.cancel_timer(poll_ref)
 
     :ok
   end

--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -192,8 +192,7 @@ defmodule Oban.Job do
     |> Map.new()
   end
 
-  @doc false
-  def coerce_field(params, field) do
+  defp coerce_field(params, field) do
     case Map.get(params, field) do
       value when is_atom(value) and not is_nil(value) ->
         update_in(params, [field], &to_clean_string/1)

--- a/test/integration/controlling_test.exs
+++ b/test/integration/controlling_test.exs
@@ -83,7 +83,7 @@ defmodule Oban.Integration.ControllingTest do
 
     assert_receive {:started, 1}
 
-    Oban.kill_job(job.id)
+    Oban.cancel_job(job.id)
 
     refute_receive {:ok, 1}, 200
 


### PR DESCRIPTION
This PR introduces some minor changes:

* fix two typos in the README file
* use `is_reference/1` before `Process.cancel_timer/1`
* make `Oban.Job.coerce_field/1` private, it's only used internally
* fix combined concurrency level value in `Oban` docs
* introduce a hard-deprecation for `Oban.kill_job/2`, that way, the compiler will emit a warning during compilation.