### PR TITLE
Initial structure for guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,7 @@ wildcards, step values or ranges:
 * `0` — Literal, matches only itself (only 0)
 * `*/15` — Step, matches any value that is a multiple (0, 15, 30, 45)
 * `0-5` — Range, matches any value within the range (0, 1, 2, 3, 4, 5)
+* `0-23/2` - Step values can be used in conjunction with ranges (0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22)
 
 Each part may have multiple rules, where rules are separated by a comma. The
 allowed values for each field are as follows:
@@ -933,49 +934,6 @@ def start(_type, _args) do
   Supervisor.start_link(children, strategy: :one_for_one, name: MyApp.Supervisor)
 end
 ```
-
-## Troubleshooting
-
-### Querying the Jobs Table
-
-`Oban.Job` defines an Ecto schema and the jobs table can therefore be queried as usual, e.g.:
-
-```
-MyApp.Repo.all(
-  from j in Oban.Job,
-    where: j.worker == "MyApp.Business",
-    where: j.state == "discarded"
-)
-```
-
-### Heroku
-
-#### Elixir and Erlang versions
-
-If your app crashes on launch, be sure to confirm you are running the correct
-version of Elixir and Erlang ([view requirements](#Requirements)). If using the
-*hashnuke/elixir* buildpack, you can update the `elixir_buildpack.config` file
-in your application's root directory to something like:
-
-```
-# Elixir version
-elixir_version=1.9.0
-
-# Erlang version
-erlang_version=22.0.3
-```
-
-Available Erlang versions are available [here](https://github.com/HashNuke/heroku-buildpack-elixir-otp-builds/blob/master/otp-versions).
-
-#### Database connections
-
-Make sure that you have enough available database connections when running on
-Heroku. Oban uses a database connection in order to listen for pubsub
-notifications. This is in addition to your Ecto Repo `pool_size` setting.
-
-Heroku's [Hobby tier Postgres plans](https://devcenter.heroku.com/articles/heroku-postgres-plans#hobby-tier)
-have a maximum of 20 connections, so if you're using one of those plan
-accordingly.
 
 <!-- MDOC -->
 

--- a/guides/troubleshooting.md
+++ b/guides/troubleshooting.md
@@ -1,0 +1,42 @@
+# Troubleshooting
+
+## Querying the Jobs Table
+
+`Oban.Job` defines an Ecto schema and the jobs table can therefore be queried as usual, e.g.:
+
+```
+MyApp.Repo.all(
+  from j in Oban.Job,
+    where: j.worker == "MyApp.Business",
+    where: j.state == "discarded"
+)
+```
+
+## Heroku
+
+## Elixir and Erlang versions
+
+If your app crashes on launch, be sure to confirm you are running the correct
+version of Elixir and Erlang ([view requirements](#Requirements)). If using the
+*hashnuke/elixir* buildpack, you can update the `elixir_buildpack.config` file
+in your application's root directory to something like:
+
+```
+# Elixir version
+elixir_version=1.9.0
+
+# Erlang version
+erlang_version=22.0.3
+```
+
+Available Erlang versions are available [here](https://github.com/HashNuke/heroku-buildpack-elixir-otp-builds/blob/master/otp-versions).
+
+## Database connections
+
+Make sure that you have enough available database connections when running on
+Heroku. Oban uses a database connection in order to listen for pubsub
+notifications. This is in addition to your Ecto Repo `pool_size` setting.
+
+Heroku's [Hobby tier Postgres plans](https://devcenter.heroku.com/articles/heroku-postgres-plans#hobby-tier)
+have a maximum of 20 connections, so if you're using one of those plan
+accordingly.

--- a/guides/troubleshooting.md
+++ b/guides/troubleshooting.md
@@ -14,7 +14,7 @@ MyApp.Repo.all(
 
 ## Heroku
 
-## Elixir and Erlang versions
+### Elixir and Erlang versions
 
 If your app crashes on launch, be sure to confirm you are running the correct
 version of Elixir and Erlang ([view requirements](#Requirements)). If using the
@@ -31,7 +31,7 @@ erlang_version=22.0.3
 
 Available Erlang versions are available [here](https://github.com/HashNuke/heroku-buildpack-elixir-otp-builds/blob/master/otp-versions).
 
-## Database connections
+### Database connections
 
 Make sure that you have enough available database connections when running on
 Heroku. Oban uses a database connection in order to listen for pubsub

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,9 @@ defmodule Oban.MixProject do
         main: "Oban",
         source_ref: "v#{@version}",
         source_url: "https://github.com/sorentwo/oban",
-        extras: ["README.md", "CHANGELOG.md": [filename: "CHANGELOG.md", title: "CHANGELOG"]]
+        extra_section: "GUIDES",
+        extras: extras(),
+        groups_for_extras: groups_for_extras()
       ]
     ]
   end
@@ -85,6 +87,21 @@ defmodule Oban.MixProject do
         "test --raise",
         "dialyzer --halt-exit-status"
       ]
+    ]
+  end
+
+  defp extras do
+    [
+      "README.md",
+      "guides/troubleshooting.md",
+      "CHANGELOG.md": [filename: "CHANGELOG.md", title: "CHANGELOG"]
+    ]
+  end
+
+  defp groups_for_extras do
+    [
+      Guides: ~r{guides/[^\/]+\.md},
+      Extras: ~r{(README|CHANGELOG).md}
     ]
   end
 end


### PR DESCRIPTION
Given that the current `Oban` module takes its `@moduledoc` from the `README`, I think that the "Troubleshooting" section does not belong there. So, that's why I took that out from the `README` and started a "Guides" section, which I think is more appropriate in this case, and it could provide the space for more guides, recipes, or How-tos in the future.

Part of the sidebar main page:

<img width="300" alt="Screen Shot 2020-05-24 at 2 28 48 PM" src="https://user-images.githubusercontent.com/34700/82763180-649aa600-9dcb-11ea-8b2d-5212ad98b21f.png">

Sidebar from Troubleshooting guide:

<img width="753" alt="Screen Shot 2020-05-24 at 2 36 11 PM" src="https://user-images.githubusercontent.com/34700/82763255-f0accd80-9dcb-11ea-8ec6-91cb2c52c14f.png">

Please let me know what do you think.