### PR TITLE
chore: remove dialyzer CLI warning while running `mix ci`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1010,4 +1010,4 @@ following commands:
 * Check formatting (`mix format --check-formatted`)
 * Lint with Credo (`mix credo --strict`)
 * Run all tests (`mix test --raise`)
-* Run Dialyzer (`mix dialyzer --halt-exit-status`)
+* Run Dialyzer (`mix dialyzer`)

--- a/mix.exs
+++ b/mix.exs
@@ -83,7 +83,7 @@ defmodule Oban.MixProject do
         "format --check-formatted",
         "credo --strict",
         "test --raise",
-        "dialyzer --halt-exit-status"
+        "dialyzer"
       ]
     ]
   end


### PR DESCRIPTION
The option `--halt-exit-status` is no longer valid for the dialyzer CLI, that's the default behavior since `1.0.0-rc.7`.

<img width="1145" alt="Screen Shot 2020-05-25 at 6 33 25 AM" src="https://user-images.githubusercontent.com/34700/82811212-d586a000-9e55-11ea-9619-10b6965b035c.png">
