### PR TITLE
feat: Include queuing time in job telemetry

### DIFF
--- a/lib/oban/queue/executor.ex
+++ b/lib/oban/queue/executor.ex
@@ -201,7 +201,12 @@ defmodule Oban.Queue.Executor do
   defp backoff(worker, job), do: worker.backoff(job)
 
   defp execute_stop(exec) do
-    :telemetry.execute([:oban, :job, :stop], %{duration: exec.duration}, exec.meta)
+    event_measurements = %{
+      duration: exec.duration,
+      enqueue_time: DateTime.diff(exec.job.attempted_at, exec.job.scheduled_at, :microsecond)
+    }
+
+    :telemetry.execute([:oban, :job, :stop], event_measurements, exec.meta)
   end
 
   defp execute_exception(exec) do


### PR DESCRIPTION
This PR adds `enqueue_time` as part of the event measurements for the telemetry event: `[:oban, :job, :stop]`

Fixes: #233