### PR TITLE
chore: Oban.Worker docs review

### DIFF
--- a/lib/oban/worker.ex
+++ b/lib/oban/worker.ex
@@ -2,23 +2,22 @@ defmodule Oban.Worker do
   @moduledoc """
   Defines a behavior and macro to guide the creation of worker modules.
 
-  Worker modules do the work of processing a job. At a minimum they must define
-  a `c:perform/1` function, which is called with the full `Oban.Job` struct.
+  Worker modules do the work of processing a job. At a minimum they must define a `c:perform/1`
+  function, which is called with the full `Oban.Job` struct.
 
   ## Defining Workers
 
-  Worker modules are defined by using `Oban.Worker`. A bare `use Oban.Worker`
-  invocation sets a worker with these defaults:
+  Worker modules are defined by using `Oban.Worker`. A bare `use Oban.Worker` invocation sets a
+  worker with these defaults:
 
   * `:max_attempts` — 20
   * `:priority` — 0
   * `:queue` — `:default`
   * `:unique` — no uniqueness set
 
-  The following example defines a worker module to process jobs in the `events`
-  queue. It then dials down the priority from 0 to 1, limits retrying on
-  failures to 10, adds a "business" tag, and ensures that duplicate jobs aren't
-  enqueued within a 30 second period:
+  The following example defines a worker module to process jobs in the `events` queue. It then
+  dials down the priority from 0 to 1, limits retrying on failures to 10, adds a "business" tag,
+  and ensures that duplicate jobs aren't enqueued within a 30 second period:
 
       defmodule MyApp.Workers.Business do
         use Oban.Worker,
@@ -38,27 +37,24 @@ defmodule Oban.Worker do
         end
       end
 
-  The `c:perform/1` function receives an `Oban.Job` struct as argument. This
-  allows workers to change the behavior of `c:perform/1` based on attributes of
-  the job, e.g. the number of execution attempts or when it was inserted.
+  The `c:perform/1` function receives an `Oban.Job` struct as argument. This allows workers to
+  change the behavior of `c:perform/1` based on attributes of the job, e.g. the number of
+  execution attempts or when it was inserted.
 
-  The value returned from `c:perform/1` can control whether the job is a success
-  or a failure:
+  The value returned from `c:perform/1` can control whether the job is a success or a failure:
 
-  * `:ok` or `{:ok, value}` — the job is successful; for success tuples the
-    `value` is ignored
+  * `:ok` or `{:ok, value}` — the job is successful; for success tuples the `value` is ignored
   * `:discard` — discard the job and prevent it from being retried again
-  * `{:error, error}` — the job failed, record the error and schedule a retry if
-    possible
-  * `{:snooze, seconds}` — consider the job a success and schedule it to run
-    `seconds` in the future. Snoozing will also increase the `max_attempts` by
-    one to ensure that the job isn't accidentally discarded before it can run.
+  * `{:error, error}` — the job failed, record the error and schedule a retry if possible
+  * `{:snooze, seconds}` — consider the job a success and schedule it to run `seconds` in the
+    future. Snoozing will also increase the `max_attempts` by one to ensure that the job isn't
+    accidentally discarded before it can run.
 
-  In addition to explicit return values, any _unhandled exception_, _exit_ or
-  _throw_ will fail the job and schedule a retry if possible.
+  In addition to explicit return values, any _unhandled exception_, _exit_ or _throw_ will fail
+  the job and schedule a retry if possible.
 
-  As an example of error tuple handling, this worker will return an error tuple
-  when the `value` is less than one:
+  As an example of error tuple handling, this worker will return an error tuple when the `value`
+  is less than one:
 
       defmodule MyApp.Workers.ErrorExample do
         use Oban.Worker
@@ -75,8 +71,8 @@ defmodule Oban.Worker do
 
   ## Enqueuing Jobs
 
-  All workers implement a `c:new/2` function that converts an args map into a
-  job changeset suitable for inserting into the database for later execution:
+  All workers implement a `c:new/2` function that converts an args map into a job changeset
+  suitable for inserting into the database for later execution:
 
       %{in_the: "business", of_doing: "business"}
       |> MyApp.Workers.Business.new()
@@ -100,17 +96,15 @@ defmodule Oban.Worker do
 
   ## Customizing Backoff
 
-  When jobs fail they may be retried again in the future using a backoff
-  algorithm. By default the backoff is exponential with a fixed padding of 15
-  seconds. The default backoff is clamped to a maximum of 24 days, the
-  equivalent of the 20th attempt.
+  When jobs fail they may be retried again in the future using a backoff algorithm. By default the
+  backoff is exponential with a fixed padding of 15 seconds. The default backoff is clamped to a
+  maximum of 24 days, the equivalent of the 20th attempt.
 
-  If the default strategy is too aggressive or otherwise unsuited to your app's
-  workload you can define a custom backoff function using the `c:backoff/1`
-  callback.
+  If the default strategy is too aggressive or otherwise unsuited to your app's workload you can
+  define a custom backoff function using the `c:backoff/1` callback.
 
-  The following worker defines a `c:backoff/1` function that delays retries using
-  a variant of the historic Resque/Sidekiq algorithm:
+  The following worker defines a `c:backoff/1` function that delays retries using a variant of the
+  historic Resque/Sidekiq algorithm:
 
       defmodule MyApp.SidekiqBackoffWorker do
         use Oban.Worker
@@ -129,19 +123,16 @@ defmodule Oban.Worker do
   Here are some alternative backoff strategies to consider:
 
   * **constant** — delay by a fixed number of seconds, e.g. 1→15, 2→15, 3→15
-  * **linear** — delay for the same number of seconds as the current attempt,
-    e.g. 1→1, 2→2, 3→3
+  * **linear** — delay for the same number of seconds as the current attempt, e.g. 1→1, 2→2, 3→3
   * **squared** — delay by attempt number squared, e.g. 1→1, 2→4, 3→9
-  * **sidekiq** — delay by a base amount plus some jitter, e.g. 1→32, 2→61,
-    3→135
+  * **sidekiq** — delay by a base amount plus some jitter, e.g. 1→32, 2→61, 3→135
 
   ### Contextual Backoff
 
-  Any error, catch or throw is temporarily recorded in the job's `unsaved_error`
-  map. The unsaved error map can be used by `c:backoff/1` to calculate a custom
-  backoff based on the exact error that failed the job. In this example the
-  `c:backoff/1` callback checks to see if the error was due to rate limiting and
-  adjusts the backoff accordingly:
+  Any error, catch or throw is temporarily recorded in the job's `unsaved_error` map. The unsaved
+  error map can be used by `c:backoff/1` to calculate a custom backoff based on the exact error
+  that failed the job. In this example the `c:backoff/1` callback checks to see if the error was
+  due to rate limiting and adjusts the backoff accordingly:
 
       defmodule MyApp.ApiWorker do
         use Oban.Worker
@@ -166,9 +157,8 @@ defmodule Oban.Worker do
 
   ## Limiting Execution Time
 
-  By default, individual jobs may execute indefinitely. If this is undesirable
-  you may define a timeout in milliseconds with the `c:timeout/1` callback on
-  your worker module.
+  By default, individual jobs may execute indefinitely. If this is undesirable you may define a
+  timeout in milliseconds with the `c:timeout/1` callback on your worker module.
 
   For example, to limit a worker's execution time to 30 seconds:
 
@@ -186,8 +176,8 @@ defmodule Oban.Worker do
         def timeout(_job), do: :timer.seconds(30)
       end
 
-  The `c:timeout/1` function accepts an `Oban.Job` struct, so you can customize
-  the timeout using any job attributes.
+  The `c:timeout/1` function accepts an `Oban.Job` struct, so you can customize the timeout using
+  any job attributes.
 
   Define the `timeout` value through job args:
 
@@ -219,8 +209,7 @@ defmodule Oban.Worker do
   @doc """
   Calculate the execution backoff.
 
-  In this context backoff specifies the number of seconds to wait before
-  retrying a failed job.
+  In this context backoff specifies the number of seconds to wait before retrying a failed job.
 
   Defaults to an exponential algorithm with a minimum delay of 15 seconds.
   """
@@ -238,14 +227,13 @@ defmodule Oban.Worker do
   @doc """
   The `c:perform/1` function is called to execute a job.
 
-  Each `c:perform/1` function should return `:ok` or a success tuple. When the
-  return is an error tuple, an uncaught exception or a throw then the error is
-  recorded and the job may be retried if there are any attempts remaining.
+  Each `c:perform/1` function should return `:ok` or a success tuple. When the return is an error
+  tuple, an uncaught exception or a throw then the error is recorded and the job may be retried if
+  there are any attempts remaining.
 
-  Note that the `args` map provided to `perform/1` will _always_ have string
-  keys, regardless of the key type when the job was enqueued. The `args` are
-  stored as `jsonb` in PostgreSQL and the serialization process automatically
-  stringifies all keys.
+  Note that the `args` map provided to `perform/1` will _always_ have string keys, regardless of
+  the key type when the job was enqueued. The `args` are stored as `jsonb` in PostgreSQL and the
+  serialization process automatically stringifies all keys.
   """
   @callback perform(job :: Job.t()) :: result()
 


### PR DESCRIPTION
This PR includes a few changes on the `Oban.Worker` documentation:

* `@moduledoc` should not mention `perform/2`, it was recently removed
* Wraps the documentation to 80 columns
* Add proper references to callbacks: `perform/1`, `new/2`, `backoff/1`,
  and `timeout/1` (the current ones are not working in the produced docs by ExDoc)
  * Keep the first paragraph of some function docs concise and simple