### PR TITLE
chore: make assert_valid_worker private

### DIFF
--- a/lib/oban/testing.ex
+++ b/lib/oban/testing.ex
@@ -324,7 +324,7 @@ defmodule Oban.Testing do
 
   # Perform Helpers
 
-  def assert_valid_worker(worker) do
+  defp assert_valid_worker(worker) do
     assert Code.ensure_loaded?(worker) and implements_worker?(worker), """
      Expected worker to be a module that implements the Oban.Worker behaviour, got:
 


### PR DESCRIPTION
The function `Oban.Testing.assert_valid_worker/1` seems like a helper for the
newly added `perform_job/3` and I think it should be private.