### PR TITLE
Update examples to give correct type for backoff/1

### DIFF
--- a/lib/oban/worker.ex
+++ b/lib/oban/worker.ex
@@ -111,7 +111,7 @@ defmodule Oban.Worker do
 
         @impl Worker
         def backoff(%Job{attempt: attempt}) do
-          :math.pow(attempt, 4) + 15 + :rand.uniform(30) * attempt
+          trunc(:math.pow(attempt, 4) + 15 + :rand.uniform(30) * attempt)
         end
 
         @impl Worker
@@ -150,7 +150,7 @@ defmodule Oban.Worker do
 
           case reason do
             %MyApp.ApiError{status: 429} -> @five_minutes
-            _ -> :math.pow(attempt, 4)
+            _ -> trunc(:math.pow(attempt, 4))
           end
         end
       end


### PR DESCRIPTION
`DateTime.add/4` only accepts `integer()`, and the contract for `backoff/1` requires it to return `pos_integer()`. 

Adds `trunc` (as used in `default_backoff`) to the examples to match this requirement.

Original discussion here: https://elixirforum.com/t/datetime-issue-with-elixir-oban/32015