### PR TITLE
Updated readme for realse 2.0.0-rc.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:oban, "~> 1.2"}
+    {:oban, "~> 2.0.0-rc.0"}
   ]
 end
 ```


### PR DESCRIPTION
Updated readme version from  `{:oban, "~> 1.2"}` to `{:oban, "~> 2.0.0-rc.0"}`.

As we have replaced the pruner with a plugin system the following plugin option in test config throws an error. 

```elixir
# config/test.exs
config :my_app, Oban, crontab: false, queues: false, plugins: false
```

So I changed the current version in the readme to keep the consistency. I hope that is worth it. 
