### PR TITLE
Fixed connection bomb from issue #90

### DIFF
--- a/lib/oban/breaker.ex
+++ b/lib/oban/breaker.ex
@@ -20,7 +20,11 @@ defmodule Oban.Breaker do
   defmacro trip_errors, do: [DBConnection.ConnectionError, Postgrex.Error]
 
   @spec trip_circuit(Exception.t(), list(), state_struct()) :: state_struct()
-  def trip_circuit(exception, stack, %{circuit: _, conf: conf, name: name, reset_timer: reset_timer} = state) do
+  def trip_circuit(
+        exception,
+        stack,
+        %{circuit: _, conf: conf, name: name, reset_timer: reset_timer} = state
+      ) do
     :telemetry.execute(
       [:oban, :circuit, :trip],
       %{},

--- a/lib/oban/crontab/scheduler.ex
+++ b/lib/oban/crontab/scheduler.ex
@@ -26,6 +26,7 @@ defmodule Oban.Crontab.Scheduler do
       :name,
       :poll_ref,
       circuit: :enabled,
+      reset_timer: nil,
       poll_interval: :timer.seconds(60)
     ]
   end

--- a/lib/oban/notifier.ex
+++ b/lib/oban/notifier.ex
@@ -93,6 +93,7 @@ defmodule Oban.Notifier do
       :conn,
       :name,
       circuit: :enabled,
+      reset_timer: nil,
       listeners: %{}
     ]
   end
@@ -242,8 +243,8 @@ defmodule Oban.Notifier do
 
         %{state | conn: conn}
 
-      {:error, _error} ->
-        %{state | circuit: :disabled}
+      {:error, error} ->
+        trip_circuit(error, [], state)
     end
   end
 

--- a/lib/oban/notifier.ex
+++ b/lib/oban/notifier.ex
@@ -242,8 +242,8 @@ defmodule Oban.Notifier do
 
         %{state | conn: conn}
 
-      {:error, error} ->
-        trip_circuit(error, [], state)
+      {:error, _error} ->
+        %{state | circuit: :disabled}
     end
   end
 

--- a/lib/oban/queue/producer.ex
+++ b/lib/oban/queue/producer.ex
@@ -31,6 +31,7 @@ defmodule Oban.Queue.Producer do
       :started_at,
       :timer,
       circuit: :enabled,
+      reset_timer: nil,
       paused: false,
       running: %{}
     ]


### PR DESCRIPTION
Hey there,

Today I faced the same issue from https://github.com/sorentwo/oban/issues/90.

The notifier has a Breaker circuit which will restart the postgres connection on an interval if it crashes for any reason. However, it's triggering the trip_circuit schedule twice. It calls it once because of the error result from Notifications.start_link and once because of the exit trap at the start of the GenServer. This exit is called, not so obviously, because the Notifications.start_link is starting a linked Connection process which emits the signal when the connection fails. The erlang documentation points this out: _"Terminating processes emit exit signals to all linked processes"_


![image](https://user-images.githubusercontent.com/3946451/84464045-d1c28e00-ac49-11ea-8425-23a749190e6e.png)


![image](https://user-images.githubusercontent.com/3946451/84463967-9f189580-ac49-11ea-9ed2-9d58ef7cf1cf.png)

It's quite simple to see it happening. I added some logs to Notifiers functions and it's quite clear. Here, the same notifier PID is already receiving two resets from the breaker, followed by two exits.
![image](https://user-images.githubusercontent.com/3946451/84464292-82c92880-ac4a-11ea-9423-a7c56f123b5a.png)

The reset routine is doubled each time, similar to a fork bomb. If this happens for a while (db maintenance, for instance), my terminal turns to flood, with high cpu usage and, once the db server is up, thousands of connections wear the postgres out.

![image](https://user-images.githubusercontent.com/3946451/84464425-d6d40d00-ac4a-11ea-9f20-da6b4f5cbe55.png)
