### PR TITLE
Add reboot handling to crontab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- [Oban.Crontab] Add `@reboot` special case to crontab scheduling
+
 ### Fixes
 
 - [Oban.Breaker] Prevent connection bomb when the Notifier experiences repeated

--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ The following Cron extensions are supported:
 * `@weekly` — `0 0 * * 0`
 * `@monthly` — `0 0 1 * *`
 * `@yearly` (as well as `@annually`) — `0 0 1 1 *`
+* `@reboot` — Run once at boot across the entire cluster
 
 Some specific examples that demonstrate the full range of expressions:
 

--- a/test/oban/crontab/crontab_test.exs
+++ b/test/oban/crontab/crontab_test.exs
@@ -88,6 +88,8 @@ defmodule Oban.Crontab.CronTest do
                months: [:*],
                weekdays: [:*]
              } == Cron.parse!("@hourly")
+
+      assert %Cron{reboot: true} == Cron.parse!("@reboot")
     end
   end
 
@@ -117,6 +119,24 @@ defmodule Oban.Crontab.CronTest do
 
         assert Cron.now?(crontab, datetime)
       end
+    end
+
+    test "reboot never matches" do
+      crontab = %Cron{reboot: true}
+
+      refute Cron.now?(crontab)
+    end
+  end
+
+  describe "reboot?/1" do
+    test "only reboot matches" do
+      crontab = %Cron{reboot: true}
+
+      assert Cron.reboot?(crontab)
+
+      crontab = %Cron{reboot: false}
+
+      refute Cron.reboot?(crontab)
     end
   end
 


### PR DESCRIPTION
Addresses #212 

I wasn't sure if the locking from `lock_and_enqueue` was required or not, and I added a test specifically around running once a node and it seems to be passing.

The reboot option still follows the one minute unique clause.

If either of these are undesirable, or if I should add locking under the same or a slightly different key, let me know.