### PR TITLE
put/get config via persistent term

### DIFF
--- a/bench/benchmarks/config_bench.exs
+++ b/bench/benchmarks/config_bench.exs
@@ -1,0 +1,29 @@
+defmodule ConfigViaAgent do
+  use Agent
+
+  def start_link(opts) when is_list(opts) do
+    {conf, opts} = Keyword.pop(opts, :conf)
+    Agent.start_link(fn -> conf end, opts)
+  end
+
+  def get(name), do: Agent.get(name, & &1)
+end
+
+defmodule ConfigViaPersistentTerm do
+  def put(name, conf), do: :persistent_term.put(name, conf)
+  def get(name), do: :persistent_term.get(name)
+end
+
+defmodule Repo do
+  def __adapter__, do: :ok
+end
+
+name = Bench
+conf = Oban.Config.new(repo: Repo)
+ConfigViaAgent.start_link(conf: conf, name: name)
+ConfigViaPersistentTerm.put(name, conf)
+
+Benchee.run(%{
+  "via_agent" => fn -> ConfigViaAgent.get(name) end,
+  "via_persistent_term" => fn -> ConfigViaPersistentTerm.get(name) end
+})

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -134,8 +134,9 @@ defmodule Oban do
 
   @impl Supervisor
   def init(%Config{name: name, plugins: plugins, queues: queues} = conf) do
+    store_config(name, conf)
+
     children = [
-      {Config, conf: conf, name: child_name(name, "Config")},
       {Notifier, conf: conf, name: child_name(name, "Notifier")},
       {Midwife, conf: conf, name: child_name(name, "Midwife")},
       {Scheduler, conf: conf, name: child_name(name, "Scheduler")}
@@ -545,4 +546,10 @@ defmodule Oban do
   end
 
   defp child_name(name, child), do: Module.concat(name, child)
+
+  defp store_config(name, conf) do
+    name
+    |> child_name("Config")
+    |> Config.put(conf)
+  end
 end

--- a/lib/oban/config.ex
+++ b/lib/oban/config.ex
@@ -3,8 +3,6 @@ defmodule Oban.Config do
 
   alias Oban.Crontab.Cron
 
-  use Agent
-
   @type cronjob :: {Cron.t(), module(), Keyword.t()}
 
   @type t :: %__MODULE__{
@@ -40,13 +38,6 @@ defmodule Oban.Config do
             timezone: "Etc/UTC",
             log: false
 
-  @spec start_link([option()]) :: GenServer.on_start()
-  def start_link(opts) when is_list(opts) do
-    {conf, opts} = Keyword.pop(opts, :conf)
-
-    Agent.start_link(fn -> conf end, opts)
-  end
-
   @spec new(Keyword.t()) :: t()
   def new(opts) when is_list(opts) do
     opts =
@@ -63,8 +54,11 @@ defmodule Oban.Config do
     struct!(__MODULE__, opts)
   end
 
+  @spec put(atom(), t()) :: :ok
+  def put(name, conf), do: :persistent_term.put(name, conf)
+
   @spec get(atom()) :: t()
-  def get(name), do: Agent.get(name, & &1)
+  def get(name), do: :persistent_term.get(name)
 
   @spec node_name(%{optional(binary()) => binary()}) :: binary()
   def node_name(env \\ System.get_env()) do

--- a/test/oban/config_test.exs
+++ b/test/oban/config_test.exs
@@ -4,13 +4,14 @@ defmodule Oban.ConfigTest do
   alias Oban.Config
   alias Oban.Plugins.FixedPruner
 
-  describe "start_link/1" do
+  describe "put/2" do
     test "a config struct is stored for retreival" do
-      conf = Config.new(repo: Repo)
+      key = __MODULE__
+      conf = Config.new(repo: Repo, name: key)
 
-      {:ok, pid} = Config.start_link(conf: conf)
+      :ok = Config.put(key, conf)
 
-      assert %Config{} = Config.get(pid)
+      assert conf == Config.get(key)
     end
   end
 


### PR DESCRIPTION
It seems that `Oban.Config` is a good candidate for `persistent_term`, given that is only established at the beginning while setting up the supervision tree, and then is read it all over the place.

One benefit of this change is the performance improvement for reading operations. I made a quick benchmark using `Benchee` and here are the results:

```console
$ mix run bench/benchmarks/config_bench.exs
Operating System: macOS
CPU Information: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
Number of Available Cores: 12
Available memory: 16 GB
Elixir 1.10.2
Erlang 22.3.4

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 10 s
memory time: 2 s
parallel: 1
inputs: none specified
Estimated total run time: 28 s

Benchmarking via_agent...
Benchmarking via_persistent_term...

Name                          ips        average  deviation         median         99th %
via_persistent_term        7.64 M       0.131 μs   ±294.53%           0 μs           1 μs
via_agent                  0.49 M        2.05 μs  ±1307.05%           2 μs           4 μs

Comparison:
via_persistent_term        7.64 M
via_agent                  0.49 M - 15.69x slower +1.92 μs

Memory usage statistics:

Name                        average  deviation         median         99th %
via_persistent_term             0 B     ±0.00%            0 B            0 B
via_agent                  336.00 B     ±0.16%          336 B          336 B

Comparison:
via_persistent_term             0 B
via_agent                  336.00 B - ∞ x memory usage +336.00 B
```

One caveat of this change is that `persistent_term` is available since Erlang/OTP 21.2. But, from the CI configuration, I can infer that the minimum Erlang/OTP version supported is 22.2. So, based on that, we should be good.