### PR TITLE
Protect against opening multiple connections in the Notifier

### DIFF
--- a/lib/oban/notifier.ex
+++ b/lib/oban/notifier.ex
@@ -187,10 +187,16 @@ defmodule Oban.Notifier do
     {:noreply, state}
   end
 
-  def handle_info({:EXIT, _pid, error}, %State{} = state) do
+  def handle_info({:EXIT, pid, error}, %State{conn: conn} = state) when pid == conn do
     state = trip_circuit(error, [], state)
 
     {:noreply, %{state | conn: nil}}
+  end
+
+  def handle_info({:EXIT, _pid, error}, %State{} = state) do
+    state = trip_circuit(error, [], state)
+
+    {:noreply, state}
   end
 
   def handle_info(:reset_circuit, %State{circuit: :disabled} = state) do


### PR DESCRIPTION
**Existing Behavior**
In practice we have seen the `EXIT` signals bomb the `Notifier` when postgres becomes unavailable. When postgres becomes available again, these `EXIT` signals will set the Notifier conn state to `nil`, while the `reset_circuit` message creates connections and sets the conn state to the connection pid. 

Depending on the duration of the postgres outage, there could be thousands of `EXIT` and `reset_circuit` messages in flight. Each time these messages are processed sequentially, it opens a new connection to the database, despite the current connection still being alive. This could result in unbounded growth of database connections (until postgres connection limits are reached). 

**Changes**
The changes in this PR will only sets the state connection to `nil` if the `EXIT` message received is from the same process as the current conn state pid. This enforces that the existing connection must have exited, before a new connection can be opened.