### PR TITLE
fix readme, :stack -> :stacktrace change in 2.0.0-rc.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -869,13 +869,13 @@ defmodule ErrorReporter do
       |> Map.take([:id, :args, :queue, :worker])
       |> Map.merge(measure)
 
-    Honeybadger.notify(meta.error, context, meta.stack)
+    Honeybadger.notify(meta.error, context, meta.stacktrace)
   end
 
   def handle_event([:oban, :circuit, :trip], _measure, meta, _) do
     context = Map.take(meta, [:name])
 
-    Honeybadger.notify(meta.error, context, meta.stack)
+    Honeybadger.notify(meta.error, context, meta.stacktrace)
   end
 end
 


### PR DESCRIPTION
Sorry, should have caught this with the last PR! The error reporting example needs the new `:stacktrace` key in `meta`.