### PR TITLE
fix: handle cases where the given cron step is one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- [Oban.Crontab.Cron] Do not raise an `ArgumentError` exception when the
+  crontab configuration includes a step of 1, which is a valid step value.
+
 ## [2.0.0-rc.2] — 2020-06-23
 
 ### Breaking Changes

--- a/lib/oban/crontab/cron.ex
+++ b/lib/oban/crontab/cron.ex
@@ -121,7 +121,9 @@ defmodule Oban.Crontab.Cron do
 
   defp expand({:literal, value}, min, max) when value in min..max, do: [value]
 
-  defp expand({:step, [{:wild, _}, value]}, min, max) when value in (min + 1)..max do
+  defp expand({:step, value}, 0, max), do: expand({:step, value}, 1, max)
+
+  defp expand({:step, [{:wild, _}, value]}, min, max) when value in min..max do
     for step <- min..max, rem(step, value) == 0, do: step
   end
 


### PR DESCRIPTION
The cron configuration presented on the `#oban` slack channel was the following:

```elixir
{"0 0 */1 * *", Worker.MarkerScheduler}
```

That configuration produced an `ArgumentError` exception while Oban tried to expand the parsed result by `nimble_parsec` saying that we got an `Unexpected value 1 outside of range 1..31`.

In this case, given that the step is 1, one quick workaround is replacing the original configuration with:

```elixir
{"0 0 * * *", Worker.MarkerScheduler}
```

And it will produce the same result, which is to run the specified job at 00:00 on every day-of-month.

But, given that the original configuration is valid, we need to support that as well. So, here is my attempt to fix that issue.