### PR TITLE
Introduce Worker.to_string/1

### DIFF
--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -161,8 +161,8 @@ defmodule Oban.Job do
       opts
       |> Keyword.put(:args, args)
       |> Map.new()
-      |> coerce_field(:queue)
-      |> coerce_field(:worker)
+      |> coerce_field(:queue, &to_clean_string/1)
+      |> coerce_field(:worker, &Oban.Worker.to_string/1)
       |> normalize_tags()
 
     %__MODULE__{}
@@ -215,13 +215,13 @@ defmodule Oban.Job do
     |> Map.new()
   end
 
-  defp coerce_field(params, field) do
+  defp coerce_field(params, field, fun) do
     case Map.get(params, field) do
       value when is_atom(value) and not is_nil(value) ->
-        update_in(params, [field], &to_clean_string/1)
+        update_in(params, [field], fun)
 
       value when is_binary(value) ->
-        update_in(params, [field], &to_clean_string/1)
+        update_in(params, [field], fun)
 
       _ ->
         params
@@ -314,8 +314,9 @@ defmodule Oban.Job do
   end
 
   defp to_clean_string(value) do
-    value
-    |> to_string()
-    |> String.trim_leading("Elixir.")
+    case to_string(value) do
+      "Elixir." <> val -> val
+      val -> val
+    end
   end
 end

--- a/lib/oban/worker.ex
+++ b/lib/oban/worker.ex
@@ -188,6 +188,8 @@ defmodule Oban.Worker do
   """
   @moduledoc since: "0.1.0"
 
+  import Kernel, except: [to_string: 1]
+
   alias Oban.Job
 
   @type t :: module()
@@ -249,7 +251,7 @@ defmodule Oban.Worker do
 
       @doc false
       def __opts__ do
-        Keyword.put(unquote(opts), :worker, to_string(__MODULE__))
+        Keyword.put(unquote(opts), :worker, Kernel.to_string(__MODULE__))
       end
 
       @impl Worker
@@ -336,4 +338,32 @@ defmodule Oban.Worker do
   defp validate_opt!(option) do
     raise ArgumentError, "unknown option provided #{inspect(option)}"
   end
+
+  @doc """
+  Return a string representation of a worker module.
+
+  This is particularly useful for normalizing
+  worker names when building custom Ecto queries.
+
+  ## Examples
+
+      iex> Oban.Worker.to_string(MyApp.SomeWorker)
+      "MyApp.SomeWorker"
+
+      iex> Oban.Worker.to_string(Elixir.MyApp.SomeWorker)
+      "MyApp.SomeWorker"
+
+      iex> Oban.Worker.to_string("Elixir.MyApp.SomeWorker")
+      "MyApp.SomeWorker"
+  """
+  @spec to_string(module() | String.t()) :: String.t()
+  def to_string(worker) when is_atom(worker) and not is_nil(worker) do
+    worker
+    |> Kernel.to_string()
+    |> to_string()
+  end
+
+  def to_string("Elixir." <> val), do: val
+
+  def to_string(worker) when is_binary(worker), do: worker
 end

--- a/lib/oban/worker.ex
+++ b/lib/oban/worker.ex
@@ -342,8 +342,7 @@ defmodule Oban.Worker do
   @doc """
   Return a string representation of a worker module.
 
-  This is particularly useful for normalizing
-  worker names when building custom Ecto queries.
+  This is particularly useful for normalizing worker names when building custom Ecto queries.
 
   ## Examples
 

--- a/test/oban/worker_test.exs
+++ b/test/oban/worker_test.exs
@@ -1,6 +1,8 @@
 defmodule Oban.WorkerTest do
   use ExUnit.Case, async: true
 
+  doctest Oban.Worker
+
   use ExUnitProperties
 
   alias Oban.{Job, Worker}


### PR DESCRIPTION
### Goal

See #281

### Changes

- Introduce `Oban.Worker.to_string/1` with docs and tests
- Replace `String/trim_leading` with binary pattern match

