### PR TITLE
Add installation guide to Hexdocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,9 @@ enqueuing scheduled jobs and job dispatching altogether when testing:
 config :my_app, Oban, crontab: false, queues: false, plugins: false
 ```
 
+See the installation instructions in the README or on the Hexdocs guide for details
+on how to migrate your database.
+
 ### Configuring Queues
 
 Queues are specified as a keyword list where the key is the name of the queue

--- a/guides/installation.md
+++ b/guides/installation.md
@@ -1,0 +1,58 @@
+# Installation
+
+Oban is published on [Hex](https://hex.pm/packages/oban). Add it to your list of
+dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:oban, "~> 2.0.0-rc.3"}
+  ]
+end
+```
+
+Then run `mix deps.get` to install Oban and its dependencies, including
+[Ecto][ecto], [Jason][jason] and [Postgrex][postgrex].
+
+After the packages are installed you must create a database migration to
+add the `oban_jobs` table to your database:
+
+```bash
+mix ecto.gen.migration add_oban_jobs_table
+```
+
+Open the generated migration in your editor and call the `up` and `down`
+functions on `Oban.Migrations`:
+
+```elixir
+defmodule MyApp.Repo.Migrations.AddObanJobsTable do
+  use Ecto.Migration
+
+  def up do
+    Oban.Migrations.up()
+  end
+
+  # We specify `version: 1` in `down`, ensuring that we'll roll all the way back down if
+  # necessary, regardless of which version we've migrated `up` to.
+  def down do
+    Oban.Migrations.down(version: 1)
+  end
+end
+```
+
+This will run all of Oban's versioned migrations for your database. Migrations
+between versions are idempotent and will _never_ change after a release. As new
+versions are released you may need to run additional migrations.
+
+Now, run the migration to create the table:
+
+```bash
+mix ecto.migrate
+```
+
+Next see [Usage](Oban.html) for how to integrate Oban into your application and
+start defining jobs!
+
+[ecto]: https://hex.pm/packages/ecto
+[jason]: https://hex.pm/packages/jason
+[postgrex]: https://hex.pm/packages/postgrex

--- a/mix.exs
+++ b/mix.exs
@@ -57,6 +57,7 @@ defmodule Oban.MixProject do
   defp extras do
     [
       "CHANGELOG.md",
+      "guides/installation.md",
       "guides/troubleshooting.md",
       "guides/release_configuration.md",
       "guides/recipes/recursive-jobs.md",


### PR DESCRIPTION
Currently, there are no installation instructions on Hexdocs for Oban and the only reference at all to the migrations is in the isolating docs, and theres nothing to say "hey go read the readme" (which as obvious as it might seem, was not obvious to me that there would be a detailed unpublished readme!).

This is not an ideal solution I'll admit, as its not automated from the readme like the main Oban module docs. I could prepare an alternative (if you prefer) that documents the migration module via pull that section from the read me, and link to it from the main module docs?