### PR TITLE
Clear up worker snooze documentation

### DIFF
--- a/lib/oban/worker.ex
+++ b/lib/oban/worker.ex
@@ -46,9 +46,8 @@ defmodule Oban.Worker do
   * `:ok` or `{:ok, value}` — the job is successful; for success tuples the `value` is ignored
   * `:discard` — discard the job and prevent it from being retried again
   * `{:error, error}` — the job failed, record the error and schedule a retry if possible
-  * `{:snooze, seconds}` — consider the job a success and schedule it to run `seconds` in the
-    future. Snoozing will also increase the `max_attempts` by one to ensure that the job isn't
-    accidentally discarded before it can run.
+  * `{:snooze, seconds}` — mark the job as `snoozed` and schedule it to run again `seconds` in the
+    future. Snoozing a job does not change the number of retries remaining on the job.
 
   In addition to explicit return values, any _unhandled exception_, _exit_ or _throw_ will fail
   the job and schedule a retry if possible.


### PR DESCRIPTION
I was confused by the worker snooze documentation and asked @milmazz for some clarification. I think (?) this summarizes its behavior.

It's unclear to me in what way a job is marked as a "success" when it's snoozed. Instead, it's simply snoozed, right?

I rewrote the second sentence because it seemed like leaking an implementation detail into the documentation. I hope this maintains the intent - reassure the user that they can snooze w/o negatively impacting their retry logic - w/o confusing them with how exactly snoozing is implemented.