### PR TITLE
fix test assertion for modules with multiple behaviours

### DIFF
--- a/lib/oban/testing.ex
+++ b/lib/oban/testing.ex
@@ -339,7 +339,8 @@ defmodule Oban.Testing do
   defp implements_worker?(worker) do
     :attributes
     |> worker.__info__()
-    |> Keyword.get(:behaviour, [])
+    |> Keyword.get_values(:behaviour)
+    |> Enum.flat_map(& &1)
     |> Enum.member?(Oban.Worker)
   end
 

--- a/test/oban/testing_test.exs
+++ b/test/oban/testing_test.exs
@@ -20,12 +20,23 @@ defmodule Oban.TestingTest do
     def perform(%{args: %{"action" => "bad_snooze"}}), do: {:snooze, true}
   end
 
+  defmodule MultiBehaviourWorker do
+    @behaviour SomeOtherBehaviour
+    use Oban.Worker
+
+    @impl Oban.Worker
+    def perform(_job), do: :ok
+  end
+
   describe "perform_job/3" do
     test "verifying that the worker implements the Oban.Worker behaviour" do
       message = "worker to be a module that implements"
 
       assert_perform_error(BogusWorker, message)
       assert_perform_error(InvalidWorker, message)
+
+      # not sure how to best test this
+      perform_job(MultiBehaviourWorker, %{})
     end
 
     test "creating a valid job out of the args and options" do


### PR DESCRIPTION
Fixes #300.

When a module implements multiple `@behaviour`s, calling `__info__(:attributes)` returns something like

```elixir
[
  vsn: [12345],
  behaviour: [MyBehaviour],
  behaviour: [Oban.Worker]
]
```

This PR takes all `:behaviour` keys into account when checking for `Oban.Worker`.

I wasn't sure of the best way to implement the test so I just put in a quick placeholder.