### PR TITLE
Allow returning `{:discard, reason}` from perform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   possible to define per-queue options such as `:poll_interval`,
   `:dispatch_cooldown`, `:paused`, and even override the `:producer` module.
 
+- [Oban] Cancelling a running job now records an error on the job if it was
+  _running_ at the time it was cancelled.
+
 - [Oban.Job] Allow using `:discarded` as a unique state and expose all possible
   states through `Oban.Job.states/0`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [Oban.Job] Allow using `:discarded` as a unique state and expose all possible
   states through `Oban.Job.states/0`.
 
+- [Oban.Worker] Allow returning `{:discard, reason}` from `perform/1`, where the
+  reason is recorded in the job's errors array. If no reason is provided then a
+  default of "None" is used. All discarded jobs will have an error now, whether
+  discarded manually or automatically.
+
 ## [2.0.0] — 2020-07-10
 
 No changes from [2.0.0-rc.3][].

--- a/lib/oban/query.ex
+++ b/lib/oban/query.ex
@@ -141,9 +141,9 @@ defmodule Oban.Query do
   @spec cancel_job(Config.t(), pos_integer()) :: :ok | :ignored
   def cancel_job(%Config{prefix: prefix, repo: repo, log: log}, job_id) do
     query = where(Job, [j], j.id == ^job_id and j.state in @cancellable_states)
-    update = [set: [state: "discarded", discarded_at: utc_now()]]
+    updates = [set: [state: "discarded", discarded_at: utc_now()]]
 
-    case repo.update_all(query, update, log: log, prefix: prefix) do
+    case repo.update_all(query, updates, log: log, prefix: prefix) do
       {1, nil} -> :ok
       {0, nil} -> :ignored
     end

--- a/lib/oban/query.ex
+++ b/lib/oban/query.ex
@@ -118,10 +118,17 @@ defmodule Oban.Query do
   end
 
   @spec discard_job(Config.t(), Job.t()) :: :ok
-  def discard_job(%Config{prefix: prefix, repo: repo, log: log}, %Job{id: id}) do
+  def discard_job(%Config{prefix: prefix, repo: repo, log: log}, %Job{} = job) do
+    updates = [
+      set: [state: "discarded", discarded_at: utc_now()],
+      push: [
+        errors: %{attempt: job.attempt, at: utc_now(), error: format_blamed(job.unsaved_error)}
+      ]
+    ]
+
     repo.update_all(
-      where(Job, id: ^id),
-      [set: [state: "discarded", discarded_at: utc_now()]],
+      where(Job, id: ^job.id),
+      updates,
       log: log,
       prefix: prefix
     )

--- a/lib/oban/queue/producer.ex
+++ b/lib/oban/queue/producer.ex
@@ -139,7 +139,10 @@ defmodule Oban.Queue.Producer do
         %{"action" => "pkill", "job_id" => kid} ->
           for {_ref, {exec, pid}} <- running, exec.job.id == kid do
             with :ok <- DynamicSupervisor.terminate_child(foreman, pid) do
-              Query.discard_job(conf, exec.job)
+              reason = %RuntimeError{message: "job killed"}
+              uerror = %{kind: :error, reason: reason, stacktrace: []}
+
+              Query.discard_job(conf, %{exec.job | unsaved_error: uerror})
             end
           end
 

--- a/lib/oban/queue/producer.ex
+++ b/lib/oban/queue/producer.ex
@@ -139,8 +139,7 @@ defmodule Oban.Queue.Producer do
         %{"action" => "pkill", "job_id" => kid} ->
           for {_ref, {exec, pid}} <- running, exec.job.id == kid do
             with :ok <- DynamicSupervisor.terminate_child(foreman, pid) do
-              reason = %RuntimeError{message: "job killed"}
-              uerror = %{kind: :error, reason: reason, stacktrace: []}
+              uerror = %{kind: :error, reason: "None", stacktrace: []}
 
               Query.discard_job(conf, %{exec.job | unsaved_error: uerror})
             end

--- a/lib/oban/testing.ex
+++ b/lib/oban/testing.ex
@@ -377,14 +377,23 @@ defmodule Oban.Testing do
         :ok -> true
         {:ok, _value} -> true
         {:error, _value} -> true
+        {:discard, _value} -> true
         {:snooze, snooze} when is_integer(snooze) -> true
         :discard -> true
         _ -> false
       end
 
     assert valid?, """
-    Expected result to be one of `:ok`, `{:ok, value}`, `{:error, reason}`, `{:snooze, duration}
-    or `:discard`, got:
+    Expected result to be one of
+
+      - `:ok`
+      - `:discard`
+      - `{:ok, value}`
+      - `{:error, reason}`
+      - `{:discard, reason}`
+      - `{:snooze, duration}
+
+    Instead received:
 
     #{inspect(result, pretty: true)}
     """

--- a/lib/oban/worker.ex
+++ b/lib/oban/worker.ex
@@ -44,7 +44,8 @@ defmodule Oban.Worker do
   The value returned from `c:perform/1` can control whether the job is a success or a failure:
 
   * `:ok` or `{:ok, value}` — the job is successful; for success tuples the `value` is ignored
-  * `:discard` — discard the job and prevent it from being retried again
+  * `:discard` or `{:discard, reason}` — discard the job and prevent it from being retried again.
+    An error is recorded using the optional reason, though the job is still successful
   * `{:error, error}` — the job failed, record the error and schedule a retry if possible
   * `{:snooze, seconds}` — mark the job as `snoozed` and schedule it to run again `seconds` in the
     future. Snoozing a job does not change the number of retries remaining on the job.
@@ -196,6 +197,7 @@ defmodule Oban.Worker do
   @type result ::
           :ok
           | :discard
+          | {:discard, reason :: term()}
           | {:ok, ignored :: term()}
           | {:error, reason :: term()}
           | {:snooze, seconds :: pos_integer()}

--- a/test/integration/controlling_test.exs
+++ b/test/integration/controlling_test.exs
@@ -197,8 +197,7 @@ defmodule Oban.Integration.ControllingTest do
 
     refute_receive {:ok, 1}, 200
 
-    assert %Job{state: "discarded", discarded_at: %_{}, errors: errors} = Repo.reload(job)
-    assert [%{"error" => "** (RuntimeError) job killed"}] = errors
+    assert %Job{state: "discarded", discarded_at: %_{}, errors: [_]} = Repo.reload(job)
 
     %{running: running} = :sys.get_state(Oban.Queue.Alpha.Producer)
 
@@ -222,10 +221,10 @@ defmodule Oban.Integration.ControllingTest do
 
     refute_receive {:ok, 4}, 200
 
-    assert %Job{state: "discarded", discarded_at: %DateTime{}} = Repo.reload(job_a)
-    assert %Job{state: "discarded", discarded_at: %DateTime{}} = Repo.reload(job_b)
+    assert %Job{state: "discarded", discarded_at: %_{}} = Repo.reload(job_a)
+    assert %Job{state: "discarded", discarded_at: %_{}} = Repo.reload(job_b)
     assert %Job{state: "completed", discarded_at: nil} = Repo.reload(job_c)
-    assert %Job{state: "discarded", discarded_at: %DateTime{}} = Repo.reload(job_d)
+    assert %Job{state: "discarded", discarded_at: %_{}} = Repo.reload(job_d)
   end
 
   test "dispatching jobs from a queue via database trigger" do

--- a/test/integration/controlling_test.exs
+++ b/test/integration/controlling_test.exs
@@ -197,7 +197,8 @@ defmodule Oban.Integration.ControllingTest do
 
     refute_receive {:ok, 1}, 200
 
-    assert %Job{state: "discarded", discarded_at: %DateTime{}} = Repo.reload(job)
+    assert %Job{state: "discarded", discarded_at: %_{}, errors: errors} = Repo.reload(job)
+    assert [%{"error" => "** (RuntimeError) job killed"}] = errors
 
     %{running: running} = :sys.get_state(Oban.Queue.Alpha.Producer)
 

--- a/test/integration/executing_test.exs
+++ b/test/integration/executing_test.exs
@@ -33,6 +33,7 @@ defmodule Oban.Integration.ExecutingTest do
               "discarded" ->
                 refute job.completed_at
                 assert job.discarded_at
+                assert [%{"attempt" => _, "at" => _, "error" => _} | _] = job.errors
 
               "retryable" ->
                 refute job.completed_at

--- a/test/oban/testing_test.exs
+++ b/test/oban/testing_test.exs
@@ -65,7 +65,7 @@ defmodule Oban.TestingTest do
     end
 
     test "validating the return value of the worker's perform/1 function" do
-      message = "result to be one of `:ok`"
+      message = "result to be one of"
 
       assert_perform_error(MisbehavedWorker, %{"action" => "bad_atom"}, message)
       assert_perform_error(MisbehavedWorker, %{"action" => "bad_string"}, message)
@@ -76,7 +76,7 @@ defmodule Oban.TestingTest do
 
     test "returning the value of worker's perform/1 function" do
       assert :ok = perform_job(Worker, %{ref: 1, action: "OK"})
-      assert :discard = perform_job(Worker, %{ref: 1, action: "DISCARD"})
+      assert {:discard, _} = perform_job(Worker, %{ref: 1, action: "DISCARD"})
       assert {:error, _} = perform_job(Worker, %{ref: 1, action: "ERROR"})
     end
   end

--- a/test/oban/testing_test.exs
+++ b/test/oban/testing_test.exs
@@ -76,7 +76,7 @@ defmodule Oban.TestingTest do
 
     test "returning the value of worker's perform/1 function" do
       assert :ok = perform_job(Worker, %{ref: 1, action: "OK"})
-      assert {:discard, _} = perform_job(Worker, %{ref: 1, action: "DISCARD"})
+      assert :discard = perform_job(Worker, %{ref: 1, action: "DISCARD"})
       assert {:error, _} = perform_job(Worker, %{ref: 1, action: "ERROR"})
     end
   end


### PR DESCRIPTION
The reason is recorded in the job's errors array. If no reason is provided then a default of "None" is used. All discarded jobs will have an error now, whether discarded manually or automatically.

Closes #296

/cc @jc00ke 