### PR TITLE
Wrap worker crashes and tuples in exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,25 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   default of "None" is used. All discarded jobs will have an error now, whether
   discarded manually or automatically.
 
+### Changed
+
+- [Oban.Worker] Wrap `{:error, reason}` and `{:discard, reason}` in a proper
+  `Oban.PerformError` exception with a customized message. This ensures that the
+  `:error` value passed to telemetry handlers is an exception and not a raw
+  term.
+
+- [Oban.Worker] Wrap job timeouts in `Oban.TimeoutError` with a customized
+  message indicating the worker and timeout value. This replaces the raw
+  `:timeout` atom that was reported before.
+
+- [Oban.Worker] Wrap caught exits and throws in `Oban.CrashError` with a
+  formatted message. This means the `:error` value passed to telemetry is
+  _always_ a proper exception and easier to report.
+
+- [Oban.Worker] Stop reporting internal stacktraces for timeouts, discards or
+  error tuples. The stacktrace was useless and potentially misleading as it
+  appeared that the error originated from Oban rather than the worker module.
+
 ## [2.0.0] — 2020-07-10
 
 No changes from [2.0.0-rc.3][].

--- a/README.md
+++ b/README.md
@@ -897,11 +897,7 @@ defmodule ErrorReporter do
       |> Map.take([:id, :args, :queue, :worker])
       |> Map.merge(measure)
 
-    # Sentry.capture_exception/2 requires a proper exception, but the error may
-    # be any term. Be sure to normalize `meta.error` before reporting!
-    meta.kind
-    |> Exception.normalize(meta.error, meta.stacktrace)
-    |> Sentry.capture_exception(stracktrace: meta.stacktrace, extra: extra)
+    Sentry.capture_exception(meta.error, stracktrace: meta.stacktrace, extra: extra)
   end
 
   def handle_event([:oban, :circuit, :trip], _measure, meta, _) do

--- a/lib/oban/crash_error.ex
+++ b/lib/oban/crash_error.ex
@@ -3,10 +3,12 @@ defmodule Oban.CrashError do
   Wraps unhandled exits and throws that occur during job execution.
   """
 
-  defexception [:message]
+  defexception [:message, :reason]
 
   @impl Exception
   def exception({kind, reason, stacktrace}) do
-    %__MODULE__{message: Exception.format_banner(kind, reason, stacktrace)}
+    message = Exception.format_banner(kind, reason, stacktrace)
+
+    %__MODULE__{message: message, reason: reason}
   end
 end

--- a/lib/oban/crash_error.ex
+++ b/lib/oban/crash_error.ex
@@ -1,0 +1,12 @@
+defmodule Oban.CrashError do
+  @moduledoc """
+  Wraps unhandled exits and throws that occur during job execution.
+  """
+
+  defexception [:message]
+
+  @impl Exception
+  def exception({kind, reason, stacktrace}) do
+    %__MODULE__{message: Exception.format_banner(kind, reason, stacktrace)}
+  end
+end

--- a/lib/oban/perform_error.ex
+++ b/lib/oban/perform_error.ex
@@ -1,0 +1,14 @@
+defmodule Oban.PerformError do
+  @moduledoc """
+  Wraps the reason returned by `{:error, reason}`, `{:discard, reason}` in a proper exception.
+  """
+
+  alias Oban.Worker
+
+  defexception [:message]
+
+  @impl Exception
+  def exception({worker, reason}) do
+    %__MODULE__{message: "#{Worker.to_string(worker)} failed with #{inspect(reason)}"}
+  end
+end

--- a/lib/oban/perform_error.ex
+++ b/lib/oban/perform_error.ex
@@ -1,14 +1,18 @@
 defmodule Oban.PerformError do
   @moduledoc """
   Wraps the reason returned by `{:error, reason}`, `{:discard, reason}` in a proper exception.
+
+  The original return tuple is available in the `:reason` key.
   """
 
   alias Oban.Worker
 
-  defexception [:message]
+  defexception [:message, :reason]
 
   @impl Exception
   def exception({worker, reason}) do
-    %__MODULE__{message: "#{Worker.to_string(worker)} failed with #{inspect(reason)}"}
+    message = "#{Worker.to_string(worker)} failed with #{inspect(reason)}"
+
+    %__MODULE__{message: message, reason: reason}
   end
 end

--- a/lib/oban/queue/executor.ex
+++ b/lib/oban/queue/executor.ex
@@ -151,8 +151,8 @@ defmodule Oban.Queue.Executor do
     error ->
       %{exec | state: :failure, error: error, stacktrace: __STACKTRACE__}
   catch
-    kind, value ->
-      error = CrashError.exception({kind, value, __STACKTRACE__})
+    kind, reason ->
+      error = CrashError.exception({kind, reason, __STACKTRACE__})
 
       %{exec | state: :failure, error: error, stacktrace: __STACKTRACE__}
   end
@@ -169,10 +169,10 @@ defmodule Oban.Queue.Executor do
         %{exec | state: :discard, error: PerformError.exception({worker, :discard})}
 
       {:discard, reason} ->
-        %{exec | state: :discard, error: PerformError.exception({worker, reason})}
+        %{exec | state: :discard, error: PerformError.exception({worker, {:discard, reason}})}
 
       {:error, reason} ->
-        %{exec | state: :failure, error: PerformError.exception({worker, reason})}
+        %{exec | state: :failure, error: PerformError.exception({worker, {:error, reason}})}
 
       {:snooze, seconds} ->
         %{exec | state: :snoozed, snooze: seconds}

--- a/lib/oban/timeout_error.ex
+++ b/lib/oban/timeout_error.ex
@@ -1,0 +1,14 @@
+defmodule Oban.TimeoutError do
+  @moduledoc """
+  Returned when a job is terminated early due to a custom timeout.
+  """
+
+  alias Oban.Worker
+
+  defexception [:message]
+
+  @impl Exception
+  def exception({worker, timeout}) do
+    %__MODULE__{message: "#{Worker.to_string(worker)} timed out after #{timeout}ms"}
+  end
+end

--- a/lib/oban/timeout_error.ex
+++ b/lib/oban/timeout_error.ex
@@ -5,10 +5,12 @@ defmodule Oban.TimeoutError do
 
   alias Oban.Worker
 
-  defexception [:message]
+  defexception [:message, :reason]
 
   @impl Exception
   def exception({worker, timeout}) do
-    %__MODULE__{message: "#{Worker.to_string(worker)} timed out after #{timeout}ms"}
+    message = "#{Worker.to_string(worker)} timed out after #{timeout}ms"
+
+    %__MODULE__{message: message, reason: :timeout}
   end
 end

--- a/lib/oban/worker.ex
+++ b/lib/oban/worker.ex
@@ -69,6 +69,9 @@ defmodule Oban.Worker do
         end
       end
 
+  The error tuple is wrapped in an `Oban.PerformError` with a formatted message. The error tuple
+  itself is available through the exception's `:reason` field.
+
   ## Enqueuing Jobs
 
   All workers implement a `c:new/2` function that converts an args map into a job changeset

--- a/test/integration/telemetry_test.exs
+++ b/test/integration/telemetry_test.exs
@@ -3,7 +3,7 @@ defmodule Oban.Integration.TelemetryTest do
 
   import ExUnit.CaptureLog
 
-  alias Oban.Telemetry
+  alias Oban.{PerformError, Telemetry}
 
   @moduletag :integration
 
@@ -59,8 +59,8 @@ defmodule Oban.Integration.TelemetryTest do
              attempt: 1,
              max_attempts: 20,
              kind: :error,
-             error: "ERROR",
-             stacktrace: [_ | _]
+             error: %PerformError{},
+             stacktrace: []
            } = error_meta
 
     :ok = stop_supervised(Oban)

--- a/test/integration/timeouts_test.exs
+++ b/test/integration/timeouts_test.exs
@@ -12,6 +12,6 @@ defmodule Oban.Integration.TimeoutsTest do
     refute_receive {:ok, 1}
 
     assert %Job{state: "retryable", errors: [%{"error" => error}]} = Repo.reload(job)
-    assert error =~ "Erlang error: :timeout"
+    assert error == "** (Oban.TimeoutError) Oban.Integration.Worker timed out after 20ms"
   end
 end

--- a/test/oban/queue/executor_test.exs
+++ b/test/oban/queue/executor_test.exs
@@ -3,6 +3,7 @@ defmodule Oban.Queue.ExecutorTest do
 
   import ExUnit.CaptureLog
 
+  alias Oban.{CrashError, PerformError}
   alias Oban.Queue.Executor
 
   defmodule Worker do
@@ -26,8 +27,8 @@ defmodule Oban.Queue.ExecutorTest do
 
     test "raising, catching and error tuples are failures" do
       assert %{state: :failure} = call_with_mode("raise")
-      assert %{state: :failure, error: :no_reason} = call_with_mode("catch")
-      assert %{state: :failure, error: "no reason"} = call_with_mode("error")
+      assert %{state: :failure, error: %CrashError{}} = call_with_mode("catch")
+      assert %{state: :failure, error: %PerformError{}} = call_with_mode("error")
     end
 
     test "inability to resolve a worker is a failure" do


### PR DESCRIPTION
This makes several significant changes to how crahes, errors and timeouts are reported from `perform/1` calls:

* Timeouts are wrapped in `Oban.TimeoutError`
* Error and discard tuples are wrapped in `Oban.PerformError`
* Exits and throws are wrapped in `Oban.CrashError`
* Stacktraces are only included from code that is rescued or caught, not
  from error tuples or timeouts.

The goal is improve error formatting within a job's error array and to make error reporting to external services like Sentry entirely consistent.

Fixes #305

/cc @anthonator @coladarci 