### PR TITLE
Fix Telemetry ErrorReporter example doc

### DIFF
--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -112,7 +112,7 @@ defmodule Oban.Telemetry do
       if attempt >= 3 do
         context = Map.take(meta, [:id, :args, :queue, :worker])
 
-        Honeybadger.notify(meta.error, context, meta.stack)
+        Honeybadger.notify(meta.error, context, meta.stacktrace)
       end
     end
   end


### PR DESCRIPTION
Oban 2.0 changed `meta.stack` to `meta.stacktrace`. The main docs were updated, but it looks like this one was missed.