### PR TITLE
Allow replacing the arguments of a unique job

### DIFF
--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -41,6 +41,7 @@ defmodule Oban.Job do
           | {:priority, pos_integer()}
           | {:queue, atom() | binary()}
           | {:schedule_in, pos_integer()}
+          | {:replace_args, boolean()}
           | {:scheduled_at, DateTime.t()}
           | {:tags, tags()}
           | {:unique, [unique_option()]}
@@ -84,6 +85,7 @@ defmodule Oban.Job do
     field :inserted_at, :utc_datetime_usec
     field :scheduled_at, :utc_datetime_usec
     field :unique, :map, virtual: true
+    field :replace_args, :boolean, virtual: true
     field :unsaved_error, :map, virtual: true
   end
 
@@ -100,6 +102,7 @@ defmodule Oban.Job do
     priority
     queue
     scheduled_at
+    replace_args
     state
     tags
     worker
@@ -119,6 +122,7 @@ defmodule Oban.Job do
     * `:queue` — a named queue to push the job into. Jobs may be pushed into any queue, regardless
       of whether jobs are currently being processed for the queue.
     * `:schedule_in` - the number of seconds until the job should be executed
+    * `:replace_args` - if the arguments should be replaced on a unique conflict
     * `:scheduled_at` - a time in the future after which the job should be executed
     * `:tags` — a list of tags to group and organize related jobs, i.e. to identify scheduled jobs
     * `:unique` — a keyword list of options specifying how uniqueness will be calculated. The

--- a/test/integration/uniqueness_test.exs
+++ b/test/integration/uniqueness_test.exs
@@ -91,6 +91,16 @@ defmodule Oban.Integration.UniquenessTest do
     assert count_jobs() == 3
   end
 
+  test "replace allows replacing the args for the same job id", context do
+    assert %Job{id: id_1} = unique_insert!(context.name, %{id: 1, url: "https://a.co"})
+
+    assert %Job{id: ^id_1, args: %{url: "https://b.co"}} =
+             unique_insert!(context.name, %{id: 1, url: "https://b.co"},
+               unique: [keys: [:id]],
+               replace_args: true
+             )
+  end
+
   test "scoping uniqueness by period", context do
     now = DateTime.utc_now()
     two_minutes_ago = DateTime.add(now, -120, :second)


### PR DESCRIPTION
This commit allows queing a unique job and replacing the args in a
subsequent insert. For example, given the following:

```
%{some_value: 1, id: "123"}
|> MyJob.new(schedule_in: 10, unique: [keys: [:id]])
|> Oban.insert()
```

Calling

```
%{some_value: 2, id: "123"}
|> MyJob.new(schedule_in: 10, replace_args: true unique: [keys: [:id]])
|> Oban.insert()
```

Would replace the job args with `%{some_value: 2, id: "123"}`

I haven't really considered the API too much, I just wanted to start a discussion around this feature. The use case for me is that there is a relatively expensive operation that I don't want to call too frequently, however I do want it to always be called with the most recent arguments.

There are also some scheduling issues with the above. For example, if you wanted it to "debounce" then it would be necessary to allow `schedule_in` to be modified.