### PR TITLE
Replace local names with registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -982,9 +982,9 @@ def start(_type, _args) do
   children = [
     Repo,
     Endpoint,
-    Supervisor.child_spec({Oban, name: ObanA, repo: Repo}, id: ObanA),
-    Supervisor.child_spec({Oban, name: ObanB, repo: Repo, prefix: "special"}, id: ObanB),
-    Supervisor.child_spec({Oban, name: ObanC, repo: Repo, prefix: "private"}, id: ObanC)
+    {Oban, name: ObanA, repo: Repo},
+    {Oban, name: ObanB, repo: Repo, prefix: "special"},
+    {Oban, name: ObanC, repo: Repo, prefix: "private"}
   ]
 
   Supervisor.start_link(children, strategy: :one_for_one, name: MyApp.Supervisor)

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -137,6 +137,13 @@ defmodule Oban do
     Supervisor.start_link(__MODULE__, conf, name: Registry.via(conf.name, nil, conf))
   end
 
+  @spec child_spec([option]) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    opts
+    |> super()
+    |> Supervisor.child_spec(id: Keyword.get(opts, :name, __MODULE__))
+  end
+
   @doc "Returns the pid of the root oban process for the given name."
   @spec whereis(name) :: pid | nil
   def whereis(name), do: Registry.whereis(name)

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -158,7 +158,7 @@ defmodule Oban do
       Oban.whereis({:oban, 1})
   """
   @doc since: "2.2.0"
-  @spec whereis(name) :: pid | nil
+  @spec whereis(name()) :: pid() | nil
   def whereis(name), do: Registry.whereis(name)
 
   @impl Supervisor
@@ -194,7 +194,7 @@ defmodule Oban do
   Retrieve the config struct for a named Oban supervision tree.
   """
   @doc since: "0.2.0"
-  @spec config(name) :: Config.t()
+  @spec config(name()) :: Config.t()
   def config(name \\ __MODULE__), do: Registry.config(name)
 
   @doc """
@@ -216,7 +216,7 @@ defmodule Oban do
       {:ok, job} = Oban.insert(MyApp.Worker.new(%{id: 1}, unique: [period: 30]))
   """
   @doc since: "0.7.0"
-  @spec insert(name, changeset :: Changeset.t(Job.t())) ::
+  @spec insert(name(), changeset :: Changeset.t(Job.t())) ::
           {:ok, Job.t()} | {:error, Changeset.t()}
   def insert(name \\ __MODULE__, %Changeset{} = changeset) do
     name
@@ -268,7 +268,7 @@ defmodule Oban do
       job = Oban.insert!(MyApp.Worker.new(%{id: 1}))
   """
   @doc since: "0.7.0"
-  @spec insert!(name, changeset :: Changeset.t(Job.t())) :: Job.t()
+  @spec insert!(name(), changeset :: Changeset.t(Job.t())) :: Job.t()
   def insert!(name \\ __MODULE__, %Changeset{} = changeset) do
     case insert(name, changeset) do
       {:ok, job} ->
@@ -297,7 +297,7 @@ defmodule Oban do
       |> Oban.insert_all()
   """
   @doc since: "0.9.0"
-  @spec insert_all(name, jobs :: [Changeset.t(Job.t())]) :: [Job.t()]
+  @spec insert_all(name(), jobs :: [Changeset.t(Job.t())]) :: [Job.t()]
   def insert_all(name \\ __MODULE__, changesets) when is_list(changesets) do
     name
     |> config()
@@ -384,7 +384,7 @@ defmodule Oban do
       assert_raise RuntimeError, fn -> Oban.drain_queue(queue: :risky, with_safety: false) end
   """
   @doc since: "0.4.0"
-  @spec drain_queue(name, [Drainer.drain_option()]) :: Drainer.drain_result()
+  @spec drain_queue(name(), [Drainer.drain_option()]) :: Drainer.drain_result()
   def drain_queue(name \\ __MODULE__, [_ | _] = opts) do
     name
     |> config()
@@ -417,7 +417,7 @@ defmodule Oban do
       :ok
   """
   @doc since: "0.12.0"
-  @spec start_queue(name, opts :: [queue_option()]) :: :ok
+  @spec start_queue(name(), opts :: [queue_option()]) :: :ok
   def start_queue(name \\ __MODULE__, [_ | _] = opts) do
     Enum.each(opts, &validate_queue_opt!/1)
 
@@ -457,7 +457,7 @@ defmodule Oban do
       :ok
   """
   @doc since: "0.2.0"
-  @spec pause_queue(name, opts :: [queue_option()]) :: :ok
+  @spec pause_queue(name(), opts :: [queue_option()]) :: :ok
   def pause_queue(name \\ __MODULE__, [_ | _] = opts) do
     Enum.each(opts, &validate_queue_opt!/1)
 
@@ -488,7 +488,7 @@ defmodule Oban do
       :ok
   """
   @doc since: "0.2.0"
-  @spec resume_queue(name, opts :: [queue_option()]) :: :ok
+  @spec resume_queue(name(), opts :: [queue_option()]) :: :ok
   def resume_queue(name \\ __MODULE__, [_ | _] = opts) do
     Enum.each(opts, &validate_queue_opt!/1)
 
@@ -525,7 +525,7 @@ defmodule Oban do
       :ok
   """
   @doc since: "0.2.0"
-  @spec scale_queue(name, opts :: [queue_option()]) :: :ok
+  @spec scale_queue(name(), opts :: [queue_option()]) :: :ok
   def scale_queue(name \\ __MODULE__, [_ | _] = opts) do
     Enum.each(opts, &validate_queue_opt!/1)
 
@@ -565,7 +565,7 @@ defmodule Oban do
       :ok
   """
   @doc since: "0.12.0"
-  @spec stop_queue(name, opts :: [queue_option()]) :: :ok
+  @spec stop_queue(name(), opts :: [queue_option()]) :: :ok
   def stop_queue(name \\ __MODULE__, [_ | _] = opts) do
     Enum.each(opts, &validate_queue_opt!/1)
 
@@ -590,7 +590,7 @@ defmodule Oban do
       :ok
   """
   @doc since: "1.3.0"
-  @spec cancel_job(name, job_id :: pos_integer()) :: :ok
+  @spec cancel_job(name(), job_id :: pos_integer()) :: :ok
   def cancel_job(name \\ __MODULE__, job_id) when is_integer(job_id) do
     conf = config(name)
 

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -132,7 +132,7 @@ defmodule Oban do
   def start_link(opts) when is_list(opts) do
     conf = Config.new(opts)
 
-    Supervisor.start_link(__MODULE__, conf, name: conf.name)
+    Supervisor.start_link(__MODULE__, conf, name: Oban.Registry.via(conf.name))
   end
 
   @impl Supervisor

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -138,10 +138,10 @@ defmodule Oban do
   @impl Supervisor
   def init(%Config{plugins: plugins, queues: queues} = conf) do
     children = [
-      {Config, conf: conf, name: Oban.Registry.via(self(), Config)},
-      {Notifier, conf: conf, name: Oban.Registry.via(self(), Notifier)},
-      {Midwife, conf: conf, name: Oban.Registry.via(self(), Midwife)},
-      {Scheduler, conf: conf, name: Oban.Registry.via(self(), Scheduler)}
+      {Config, conf: conf, name: Oban.Registry.via(conf.name, Config)},
+      {Notifier, conf: conf, name: Oban.Registry.via(conf.name, Notifier)},
+      {Midwife, conf: conf, name: Oban.Registry.via(conf.name, Midwife)},
+      {Scheduler, conf: conf, name: Oban.Registry.via(conf.name, Scheduler)}
     ]
 
     children = children ++ Enum.map(plugins, &plugin_child_spec(&1, conf))
@@ -151,7 +151,7 @@ defmodule Oban do
   end
 
   defp plugin_child_spec({module, opts}, conf) do
-    name = Oban.Registry.via(self(), {:plugin, module})
+    name = Oban.Registry.via(conf.name, {:plugin, module})
 
     opts =
       opts

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -151,14 +151,14 @@ defmodule Oban do
   end
 
   defp plugin_child_spec({module, opts}, conf) do
-    name = Module.concat([conf.name, module])
+    name = Oban.Registry.via(self(), {:plugin, module})
 
     opts =
       opts
       |> Keyword.put_new(:conf, conf)
       |> Keyword.put_new(:name, name)
 
-    Supervisor.child_spec({module, opts}, id: name)
+    Supervisor.child_spec({module, opts}, id: {:plugin, module})
   end
 
   defp plugin_child_spec(module, conf) do

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -134,7 +134,7 @@ defmodule Oban do
   def start_link(opts) when is_list(opts) do
     conf = Config.new(opts)
 
-    Supervisor.start_link(__MODULE__, conf, name: Oban.Registry.via(conf.name))
+    Supervisor.start_link(__MODULE__, conf, name: Oban.Registry.via(conf.name, nil, conf))
   end
 
   @doc "Returns the pid of the root oban process for the given name."
@@ -144,7 +144,6 @@ defmodule Oban do
   @impl Supervisor
   def init(%Config{plugins: plugins, queues: queues} = conf) do
     children = [
-      {Config, conf: conf, name: Oban.Registry.via(conf.name, Config)},
       {Notifier, conf: conf, name: Oban.Registry.via(conf.name, Notifier)},
       {Midwife, conf: conf, name: Oban.Registry.via(conf.name, Midwife)},
       {Scheduler, conf: conf, name: Oban.Registry.via(conf.name, Scheduler)}
@@ -176,9 +175,7 @@ defmodule Oban do
   """
   @doc since: "0.2.0"
   @spec config(name) :: Config.t()
-  def config(name \\ __MODULE__) do
-    Config.get(Oban.Registry.via(name, Config))
-  end
+  def config(name \\ __MODULE__), do: Oban.Registry.config(name)
 
   @doc """
   Insert a new job into the database for execution.

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -29,7 +29,7 @@ defmodule Oban do
           {:circuit_backoff, timeout()}
           | {:crontab, [Config.cronjob()]}
           | {:dispatch_cooldown, pos_integer()}
-          | {:name, module()}
+          | {:name, name()}
           | {:node, binary()}
           | {:plugins, [module() | {module() | Keyword.t()}]}
           | {:poll_interval, pos_integer()}

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -144,7 +144,20 @@ defmodule Oban do
     |> Supervisor.child_spec(id: Keyword.get(opts, :name, __MODULE__))
   end
 
-  @doc "Returns the pid of the root oban process for the given name."
+  @doc """
+  Returns the pid of the root oban process for the given name.
+
+  ## Example
+
+  Find the default instance:
+
+      Oban.whereis(Oban)
+
+  Find a dynamically named instance:
+
+      Oban.whereis({:oban, 1})
+  """
+  @doc since: "2.2.0"
   @spec whereis(name) :: pid | nil
   def whereis(name), do: Registry.whereis(name)
 

--- a/lib/oban/application.ex
+++ b/lib/oban/application.ex
@@ -1,0 +1,12 @@
+defmodule Oban.Application do
+  @moduledoc false
+  use Application
+
+  def start(_type, _args) do
+    Supervisor.start_link(
+      [Oban.Registry],
+      strategy: :one_for_one,
+      name: __MODULE__
+    )
+  end
+end

--- a/lib/oban/application.ex
+++ b/lib/oban/application.ex
@@ -1,5 +1,6 @@
 defmodule Oban.Application do
   @moduledoc false
+
   use Application
 
   def start(_type, _args) do

--- a/lib/oban/breaker.ex
+++ b/lib/oban/breaker.ex
@@ -3,7 +3,7 @@ defmodule Oban.Breaker do
 
   require Logger
 
-  alias Oban.Config
+  alias Oban.{Config, Telemetry}
 
   @type state_struct :: %{
           :circuit => :enabled | :disabled,
@@ -28,7 +28,7 @@ defmodule Oban.Breaker do
       stacktrace: stacktrace
     }
 
-    Oban.Telemetry.execute([:oban, :circuit, :trip], %{}, meta)
+    Telemetry.execute([:oban, :circuit, :trip], %{}, meta)
 
     if is_reference(state.reset_timer), do: Process.cancel_timer(state.reset_timer)
 
@@ -39,7 +39,7 @@ defmodule Oban.Breaker do
 
   @spec open_circuit(state_struct()) :: state_struct()
   def open_circuit(%{circuit: _, name: name} = state) do
-    Oban.Telemetry.execute([:oban, :circuit, :open], %{}, %{name: name})
+    Telemetry.execute([:oban, :circuit, :open], %{}, %{name: name})
 
     %{state | circuit: :enabled}
   end

--- a/lib/oban/breaker.ex
+++ b/lib/oban/breaker.ex
@@ -28,7 +28,7 @@ defmodule Oban.Breaker do
       stacktrace: stacktrace
     }
 
-    :telemetry.execute([:oban, :circuit, :trip], %{}, meta)
+    Oban.Telemetry.execute([:oban, :circuit, :trip], %{}, meta)
 
     if is_reference(state.reset_timer), do: Process.cancel_timer(state.reset_timer)
 
@@ -39,7 +39,7 @@ defmodule Oban.Breaker do
 
   @spec open_circuit(state_struct()) :: state_struct()
   def open_circuit(%{circuit: _, name: name} = state) do
-    :telemetry.execute([:oban, :circuit, :open], %{}, %{name: name})
+    Oban.Telemetry.execute([:oban, :circuit, :open], %{}, %{name: name})
 
     %{state | circuit: :enabled}
   end

--- a/lib/oban/config.ex
+++ b/lib/oban/config.ex
@@ -11,7 +11,7 @@ defmodule Oban.Config do
           circuit_backoff: timeout(),
           crontab: [cronjob()],
           dispatch_cooldown: pos_integer(),
-          name: atom(),
+          name: Oban.name(),
           node: binary(),
           plugins: [module() | {module() | Keyword.t()}],
           poll_interval: pos_integer(),
@@ -117,11 +117,7 @@ defmodule Oban.Config do
     end
   end
 
-  defp validate_opt!({:name, name}) do
-    unless is_atom(name) do
-      raise ArgumentError, "expected :name to be a module or atom"
-    end
-  end
+  defp validate_opt!({:name, _}), do: :ok
 
   defp validate_opt!({:node, node}) do
     unless is_binary(node) and node != "" do

--- a/lib/oban/config.ex
+++ b/lib/oban/config.ex
@@ -66,7 +66,7 @@ defmodule Oban.Config do
     struct!(__MODULE__, opts)
   end
 
-  @spec get(atom()) :: t()
+  @spec get(GenServer.server()) :: t()
   def get(name), do: Agent.get(name, & &1)
 
   @spec node_name(%{optional(binary()) => binary()}) :: binary()

--- a/lib/oban/config.ex
+++ b/lib/oban/config.ex
@@ -87,7 +87,7 @@ defmodule Oban.Config do
 
   @spec to_ident(t()) :: binary()
   def to_ident(%__MODULE__{name: name, node: node}) do
-    to_string(name) <> "." <> to_string(node)
+    inspect(name) <> "." <> to_string(node)
   end
 
   @spec match_ident?(t(), binary()) :: boolean()

--- a/lib/oban/config.ex
+++ b/lib/oban/config.ex
@@ -3,8 +3,6 @@ defmodule Oban.Config do
 
   alias Oban.Crontab.Cron
 
-  use Agent
-
   @type cronjob :: {Cron.t(), module(), Keyword.t()}
 
   @type t :: %__MODULE__{
@@ -40,13 +38,6 @@ defmodule Oban.Config do
             timezone: "Etc/UTC",
             log: false
 
-  @spec start_link([option()]) :: GenServer.on_start()
-  def start_link(opts) when is_list(opts) do
-    {conf, opts} = Keyword.pop(opts, :conf)
-
-    Agent.start_link(fn -> conf end, opts)
-  end
-
   @spec new(Keyword.t()) :: t()
   def new(opts) when is_list(opts) do
     opts =
@@ -65,9 +56,6 @@ defmodule Oban.Config do
 
     struct!(__MODULE__, opts)
   end
-
-  @spec get(GenServer.server()) :: t()
-  def get(name), do: Agent.get(name, & &1)
 
   @spec node_name(%{optional(binary()) => binary()}) :: binary()
   def node_name(env \\ System.get_env()) do

--- a/lib/oban/midwife.ex
+++ b/lib/oban/midwife.ex
@@ -39,13 +39,13 @@ defmodule Oban.Midwife do
   def handle_info({:notification, :signal, payload}, %State{conf: conf} = state) do
     case payload do
       %{"action" => "start", "queue" => queue, "limit" => limit} ->
-        Supervisor.start_child(conf.name, queue_spec(queue, limit, conf))
+        Supervisor.start_child(Oban.Registry.via(conf.name), queue_spec(queue, limit, conf))
 
       %{"action" => "stop", "queue" => queue} ->
         %{id: child_id} = queue_spec(queue, 0, conf)
 
-        Supervisor.terminate_child(conf.name, child_id)
-        Supervisor.delete_child(conf.name, child_id)
+        Supervisor.terminate_child(Oban.Registry.via(conf.name), child_id)
+        Supervisor.delete_child(Oban.Registry.via(conf.name), child_id)
 
       _ ->
         :ok

--- a/lib/oban/midwife.ex
+++ b/lib/oban/midwife.ex
@@ -3,7 +3,7 @@ defmodule Oban.Midwife do
 
   use GenServer
 
-  alias Oban.{Config, Notifier}
+  alias Oban.{Config, Notifier, Registry}
   alias Oban.Queue.Supervisor, as: QueueSupervisor
 
   @type option :: {:name, module()} | {:conf, Config.t()}
@@ -29,7 +29,7 @@ defmodule Oban.Midwife do
   @impl GenServer
   def handle_continue(:start, %State{conf: conf} = state) do
     conf.name
-    |> Oban.Registry.whereis(Notifier)
+    |> Registry.whereis(Notifier)
     |> Notifier.listen([:signal])
 
     {:noreply, state}
@@ -39,13 +39,13 @@ defmodule Oban.Midwife do
   def handle_info({:notification, :signal, payload}, %State{conf: conf} = state) do
     case payload do
       %{"action" => "start", "queue" => queue, "limit" => limit} ->
-        Supervisor.start_child(Oban.Registry.via(conf.name), queue_spec(queue, limit, conf))
+        Supervisor.start_child(Registry.via(conf.name), queue_spec(queue, limit, conf))
 
       %{"action" => "stop", "queue" => queue} ->
         %{id: child_id} = queue_spec(queue, 0, conf)
 
-        Supervisor.terminate_child(Oban.Registry.via(conf.name), child_id)
-        Supervisor.delete_child(Oban.Registry.via(conf.name), child_id)
+        Supervisor.terminate_child(Registry.via(conf.name), child_id)
+        Supervisor.delete_child(Registry.via(conf.name), child_id)
 
       _ ->
         :ok

--- a/lib/oban/midwife.ex
+++ b/lib/oban/midwife.ex
@@ -29,7 +29,7 @@ defmodule Oban.Midwife do
   @impl GenServer
   def handle_continue(:start, %State{conf: conf} = state) do
     conf.name
-    |> Module.concat("Notifier")
+    |> Oban.Registry.whereis(Notifier)
     |> Notifier.listen([:signal])
 
     {:noreply, state}

--- a/lib/oban/queue/executor.ex
+++ b/lib/oban/queue/executor.ex
@@ -73,7 +73,7 @@ defmodule Oban.Queue.Executor do
   end
 
   def record_started(%__MODULE__{} = exec) do
-    :telemetry.execute([:oban, :job, :start], %{system_time: exec.start_time}, exec.meta)
+    Oban.Telemetry.execute([:oban, :job, :start], %{system_time: exec.start_time}, exec.meta)
 
     exec
   end
@@ -221,7 +221,7 @@ defmodule Oban.Queue.Executor do
   defp execute_stop(exec) do
     measurements = %{duration: exec.duration, queue_time: exec.queue_time}
 
-    :telemetry.execute([:oban, :job, :stop], measurements, exec.meta)
+    Oban.Telemetry.execute([:oban, :job, :stop], measurements, exec.meta)
   end
 
   defp execute_exception(exec) do
@@ -230,7 +230,7 @@ defmodule Oban.Queue.Executor do
     meta =
       Map.merge(exec.meta(), %{kind: exec.kind, error: exec.error, stacktrace: exec.stacktrace})
 
-    :telemetry.execute([:oban, :job, :exception], measurements, meta)
+    Oban.Telemetry.execute([:oban, :job, :exception], measurements, meta)
   end
 
   defp event_metadata(conf, job) do

--- a/lib/oban/queue/executor.ex
+++ b/lib/oban/queue/executor.ex
@@ -3,7 +3,17 @@ defmodule Oban.Queue.Executor do
 
   require Logger
 
-  alias Oban.{Breaker, Config, CrashError, Job, PerformError, Query, TimeoutError, Worker}
+  alias Oban.{
+    Breaker,
+    Config,
+    CrashError,
+    Job,
+    PerformError,
+    Query,
+    Telemetry,
+    TimeoutError,
+    Worker
+  }
 
   @type success :: {:success, Job.t()}
   @type failure :: {:failure, Job.t(), Worker.t(), atom(), term()}
@@ -73,7 +83,7 @@ defmodule Oban.Queue.Executor do
   end
 
   def record_started(%__MODULE__{} = exec) do
-    Oban.Telemetry.execute([:oban, :job, :start], %{system_time: exec.start_time}, exec.meta)
+    Telemetry.execute([:oban, :job, :start], %{system_time: exec.start_time}, exec.meta)
 
     exec
   end
@@ -221,7 +231,7 @@ defmodule Oban.Queue.Executor do
   defp execute_stop(exec) do
     measurements = %{duration: exec.duration, queue_time: exec.queue_time}
 
-    Oban.Telemetry.execute([:oban, :job, :stop], measurements, exec.meta)
+    Telemetry.execute([:oban, :job, :stop], measurements, exec.meta)
   end
 
   defp execute_exception(exec) do
@@ -230,7 +240,7 @@ defmodule Oban.Queue.Executor do
     meta =
       Map.merge(exec.meta(), %{kind: exec.kind, error: exec.error, stacktrace: exec.stacktrace})
 
-    Oban.Telemetry.execute([:oban, :job, :exception], measurements, meta)
+    Telemetry.execute([:oban, :job, :exception], measurements, meta)
   end
 
   defp event_metadata(conf, job) do

--- a/lib/oban/queue/producer.ex
+++ b/lib/oban/queue/producer.ex
@@ -199,7 +199,7 @@ defmodule Oban.Queue.Producer do
 
   defp start_listener(%State{conf: conf} = state) do
     conf.name
-    |> Module.concat("Notifier")
+    |> Oban.Registry.whereis(Notifier)
     |> Notifier.listen([:insert, :signal])
 
     state

--- a/lib/oban/queue/producer.ex
+++ b/lib/oban/queue/producer.ex
@@ -5,7 +5,7 @@ defmodule Oban.Queue.Producer do
 
   import Oban.Breaker, only: [open_circuit: 1, trip_errors: 0, trip_circuit: 3]
 
-  alias Oban.{Breaker, Config, Notifier, Query, Telemetry}
+  alias Oban.{Breaker, Config, Notifier, Query, Registry, Telemetry}
   alias Oban.Queue.Executor
 
   @type option ::
@@ -199,7 +199,7 @@ defmodule Oban.Queue.Producer do
 
   defp start_listener(%State{conf: conf} = state) do
     conf.name
-    |> Oban.Registry.whereis(Notifier)
+    |> Registry.whereis(Notifier)
     |> Notifier.listen([:insert, :signal])
 
     state

--- a/lib/oban/queue/supervisor.ex
+++ b/lib/oban/queue/supervisor.ex
@@ -3,7 +3,7 @@ defmodule Oban.Queue.Supervisor do
 
   use Supervisor
 
-  alias Oban.Config
+  alias Oban.{Config, Registry}
   alias Oban.Queue.{Producer, Watchman}
 
   @type option ::
@@ -25,7 +25,7 @@ defmodule Oban.Queue.Supervisor do
   @spec child_spec({queue_name(), queue_opts()}, Config.t()) :: Supervisor.child_spec()
   def child_spec({queue, opts}, conf) do
     queue = to_string(queue)
-    name = Oban.Registry.via(conf.name, {:supervisor, queue})
+    name = Registry.via(conf.name, {:supervisor, queue})
     opts = Keyword.merge(opts, conf: conf, queue: queue, name: name)
 
     Supervisor.child_spec({__MODULE__, opts}, id: queue)
@@ -36,9 +36,9 @@ defmodule Oban.Queue.Supervisor do
     conf = Keyword.fetch!(opts, :conf)
     queue = Keyword.fetch!(opts, :queue)
 
-    fore_name = Oban.Registry.via(conf.name, {:foreman, queue})
-    prod_name = Oban.Registry.via(conf.name, {:producer, queue})
-    watch_name = Oban.Registry.via(conf.name, {:watchman, queue})
+    fore_name = Registry.via(conf.name, {:foreman, queue})
+    prod_name = Registry.via(conf.name, {:producer, queue})
+    watch_name = Registry.via(conf.name, {:watchman, queue})
 
     fore_opts = [name: fore_name]
 

--- a/lib/oban/queue/supervisor.ex
+++ b/lib/oban/queue/supervisor.ex
@@ -25,20 +25,20 @@ defmodule Oban.Queue.Supervisor do
   @spec child_spec({queue_name(), queue_opts()}, Config.t()) :: Supervisor.child_spec()
   def child_spec({queue, opts}, conf) do
     queue = to_string(queue)
-    name = Module.concat([conf.name, "Queue", Macro.camelize(queue)])
+    name = Oban.Registry.via(conf.name, {:supervisor, queue})
     opts = Keyword.merge(opts, conf: conf, queue: queue, name: name)
 
-    Supervisor.child_spec({__MODULE__, opts}, id: name)
+    Supervisor.child_spec({__MODULE__, opts}, id: queue)
   end
 
   @impl Supervisor
   def init(opts) do
     conf = Keyword.fetch!(opts, :conf)
-    name = Keyword.fetch!(opts, :name)
+    queue = Keyword.fetch!(opts, :queue)
 
-    fore_name = Module.concat(name, "Foreman")
-    prod_name = Module.concat(name, "Producer")
-    watch_name = Module.concat(name, "Watchman")
+    fore_name = Oban.Registry.via(conf.name, {:foreman, queue})
+    prod_name = Oban.Registry.via(conf.name, {:producer, queue})
+    watch_name = Oban.Registry.via(conf.name, {:watchman, queue})
 
     fore_opts = [name: fore_name]
 

--- a/lib/oban/registry.ex
+++ b/lib/oban/registry.ex
@@ -1,9 +1,9 @@
 defmodule Oban.Registry do
   @moduledoc false
 
-  @type role :: term
-  @type key :: Oban.name() | {Oban.name(), role}
-  @type value :: term
+  @type role :: term()
+  @type key :: Oban.name() | {Oban.name(), role()}
+  @type value :: term()
 
   def child_spec(_arg) do
     Supervisor.child_spec(
@@ -18,10 +18,10 @@ defmodule Oban.Registry do
     config
   end
 
-  @spec whereis(Oban.name(), role) :: pid | nil
+  @spec whereis(Oban.name(), role()) :: pid() | nil
   def whereis(oban_name, role \\ nil), do: GenServer.whereis(via(oban_name, role))
 
-  @spec via(Oban.name(), role, value) :: {:via, Registry, {__MODULE__, key}}
+  @spec via(Oban.name(), role(), value()) :: {:via, Registry, {__MODULE__, key()}}
   def via(oban_name, role \\ nil, value \\ nil)
   def via(oban_name, role, nil), do: {:via, Registry, {__MODULE__, key(oban_name, role)}}
   def via(oban_name, role, value), do: {:via, Registry, {__MODULE__, key(oban_name, role), value}}

--- a/lib/oban/registry.ex
+++ b/lib/oban/registry.ex
@@ -3,6 +3,7 @@ defmodule Oban.Registry do
 
   @type role :: term
   @type key :: Oban.name() | {Oban.name(), role}
+  @type value :: term
 
   def child_spec(_arg) do
     Supervisor.child_spec(
@@ -11,11 +12,19 @@ defmodule Oban.Registry do
     )
   end
 
+  @spec config(Oban.name()) :: Oban.Config.t()
+  def config(oban_name) do
+    [{_pid, config}] = Registry.lookup(__MODULE__, oban_name)
+    config
+  end
+
   @spec whereis(Oban.name(), role) :: pid | nil
   def whereis(oban_name, role \\ nil), do: GenServer.whereis(via(oban_name, role))
 
-  @spec via(Oban.name(), role) :: {:via, Registry, {__MODULE__, key}}
-  def via(oban_name, role \\ nil), do: {:via, Registry, {__MODULE__, key(oban_name, role)}}
+  @spec via(Oban.name(), role, value) :: {:via, Registry, {__MODULE__, key}}
+  def via(oban_name, role \\ nil, value \\ nil)
+  def via(oban_name, role, nil), do: {:via, Registry, {__MODULE__, key(oban_name, role)}}
+  def via(oban_name, role, value), do: {:via, Registry, {__MODULE__, key(oban_name, role), value}}
 
   defp key(oban_name, nil), do: oban_name
   defp key(oban_name, role), do: {oban_name, role}

--- a/lib/oban/registry.ex
+++ b/lib/oban/registry.ex
@@ -1,6 +1,9 @@
 defmodule Oban.Registry do
   @moduledoc false
 
+  @type role :: term
+  @type key :: Oban.name() | {Oban.name(), role}
+
   def child_spec(_arg) do
     Supervisor.child_spec(
       Registry.child_spec(keys: :unique, name: __MODULE__),
@@ -8,8 +11,10 @@ defmodule Oban.Registry do
     )
   end
 
+  @spec whereis(Oban.name(), role) :: pid | nil
   def whereis(oban_name, role \\ nil), do: GenServer.whereis(via(oban_name, role))
 
+  @spec via(Oban.name(), role) :: {:via, Registry, {__MODULE__, key}}
   def via(oban_name, role \\ nil), do: {:via, Registry, {__MODULE__, key(oban_name, role)}}
 
   defp key(oban_name, nil), do: oban_name

--- a/lib/oban/registry.ex
+++ b/lib/oban/registry.ex
@@ -10,8 +10,5 @@ defmodule Oban.Registry do
 
   def whereis(root_process, role), do: GenServer.whereis(via(root_process, role))
 
-  def via(root_process, role) do
-    root_pid = GenServer.whereis(root_process)
-    {:via, Registry, {__MODULE__, {root_pid, role}}}
-  end
+  def via(oban_name, role), do: {:via, Registry, {__MODULE__, {oban_name, role}}}
 end

--- a/lib/oban/registry.ex
+++ b/lib/oban/registry.ex
@@ -8,7 +8,10 @@ defmodule Oban.Registry do
     )
   end
 
-  def whereis(root_process, role), do: GenServer.whereis(via(root_process, role))
+  def whereis(oban_name, role \\ nil), do: GenServer.whereis(via(oban_name, role))
 
-  def via(oban_name, role), do: {:via, Registry, {__MODULE__, {oban_name, role}}}
+  def via(oban_name, role \\ nil), do: {:via, Registry, {__MODULE__, key(oban_name, role)}}
+
+  defp key(oban_name, nil), do: oban_name
+  defp key(oban_name, role), do: {oban_name, role}
 end

--- a/lib/oban/registry.ex
+++ b/lib/oban/registry.ex
@@ -1,0 +1,17 @@
+defmodule Oban.Registry do
+  @moduledoc false
+
+  def child_spec(_arg) do
+    Supervisor.child_spec(
+      Registry.child_spec(keys: :unique, name: __MODULE__),
+      id: __MODULE__
+    )
+  end
+
+  def whereis(root_process, role), do: GenServer.whereis(via(root_process, role))
+
+  def via(root_process, role) do
+    root_pid = GenServer.whereis(root_process)
+    {:via, Registry, {__MODULE__, {root_pid, role}}}
+  end
+end

--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -231,7 +231,13 @@ defmodule Oban.Telemetry do
       message
       |> Map.put(:event, event)
       |> Map.put(:source, "oban")
+      |> update_name()
       |> Jason.encode_to_iodata!()
     end)
+  end
+
+  defp update_name(message) do
+    with %{name: {:via, Registry, {Oban.Registry, {_pid, role}}}} <- message,
+         do: %{message | name: role}
   end
 end

--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -210,8 +210,18 @@ defmodule Oban.Telemetry do
     :telemetry.execute(event_name, measurements, normalize_meta(meta))
   end
 
-  defp normalize_meta(%{name: {:via, Registry, {Oban.Registry, {_pid, name}}}} = meta),
-    do: %{meta | name: name}
+  defp normalize_meta(%{name: {:via, Registry, {Oban.Registry, {_pid, name}}}} = meta) do
+    name =
+      with {role, name} <- name do
+        Module.concat([
+          Oban.Queue,
+          Macro.camelize(to_string(name)),
+          Macro.camelize(to_string(role))
+        ])
+      end
+
+    %{meta | name: name}
+  end
 
   defp normalize_meta(meta), do: meta
 

--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,10 @@ defmodule Oban.MixProject do
   end
 
   def application do
-    [extra_applications: [:logger]]
+    [
+      mod: {Oban.Application, []},
+      extra_applications: [:logger]
+    ]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]

--- a/test/integration/controlling_test.exs
+++ b/test/integration/controlling_test.exs
@@ -243,6 +243,7 @@ defmodule Oban.Integration.ControllingTest do
 
   defp supervised_queue?(sup \\ Oban, queue_name) do
     sup
+    |> Oban.Registry.via()
     |> Supervisor.which_children()
     |> Enum.any?(fn {name, _, _, _} -> name == queue_name end)
   end

--- a/test/integration/controlling_test.exs
+++ b/test/integration/controlling_test.exs
@@ -12,7 +12,7 @@ defmodule Oban.Integration.ControllingTest do
     end
 
     test "starting individual queues dynamically" do
-      name = start_supervised_oban!(queues: [alpha: 10]).name
+      name = start_supervised_oban!(queues: [alpha: 10])
 
       insert!(%{ref: 1, action: "OK"}, queue: :gamma)
       insert!(%{ref: 2, action: "OK"}, queue: :delta)
@@ -29,8 +29,8 @@ defmodule Oban.Integration.ControllingTest do
     end
 
     test "starting individual queues only on the local node" do
-      name1 = start_supervised_oban!(queues: []).name
-      name2 = start_supervised_oban!(queues: []).name
+      name1 = start_supervised_oban!(queues: [])
+      name2 = start_supervised_oban!(queues: [])
 
       sleep_for_notifier()
 
@@ -50,7 +50,7 @@ defmodule Oban.Integration.ControllingTest do
     end
 
     test "stopping individual queues" do
-      name = start_supervised_oban!(queues: [alpha: 5, delta: 5, gamma: 5]).name
+      name = start_supervised_oban!(queues: [alpha: 5, delta: 5, gamma: 5])
 
       assert supervised_queue?(name, "delta")
       assert supervised_queue?(name, "gamma")
@@ -79,8 +79,8 @@ defmodule Oban.Integration.ControllingTest do
     end
 
     test "stopping individual queues only on the local node" do
-      name1 = start_supervised_oban!(queues: [alpha: 1]).name
-      name2 = start_supervised_oban!(queues: [alpha: 1]).name
+      name1 = start_supervised_oban!(queues: [alpha: 1])
+      name2 = start_supervised_oban!(queues: [alpha: 1])
 
       sleep_for_notifier()
 
@@ -103,7 +103,7 @@ defmodule Oban.Integration.ControllingTest do
     end
 
     test "pausing and resuming individual queues" do
-      name = start_supervised_oban!(queues: [alpha: 5], poll_interval: 1_000).name
+      name = start_supervised_oban!(queues: [alpha: 5], poll_interval: 1_000)
 
       sleep_for_notifier()
 
@@ -120,7 +120,7 @@ defmodule Oban.Integration.ControllingTest do
 
     test "pausing queues only on the local node" do
       start_supervised_oban!(queues: [alpha: 1])
-      name2 = start_supervised_oban!(queues: [alpha: 1]).name
+      name2 = start_supervised_oban!(queues: [alpha: 1])
 
       sleep_for_notifier()
 
@@ -134,7 +134,7 @@ defmodule Oban.Integration.ControllingTest do
     end
 
     test "resuming queues only on the local node" do
-      name1 = start_supervised_oban!(queues: [alpha: 1]).name
+      name1 = start_supervised_oban!(queues: [alpha: 1])
       start_supervised_oban!(queues: [alpha: 1])
 
       sleep_for_notifier()
@@ -158,7 +158,7 @@ defmodule Oban.Integration.ControllingTest do
     end
 
     test "scaling individual queues" do
-      name = start_supervised_oban!(queues: [alpha: 1]).name
+      name = start_supervised_oban!(queues: [alpha: 1])
 
       sleep_for_notifier()
 
@@ -171,7 +171,7 @@ defmodule Oban.Integration.ControllingTest do
 
     test "scaling queues only on the local node" do
       start_supervised_oban!(queues: [alpha: 2])
-      name2 = start_supervised_oban!(queues: [alpha: 2]).name
+      name2 = start_supervised_oban!(queues: [alpha: 2])
 
       sleep_for_notifier()
 
@@ -187,7 +187,7 @@ defmodule Oban.Integration.ControllingTest do
   end
 
   test "killing an executing job by its id" do
-    name = start_supervised_oban!(queues: [alpha: 5]).name
+    name = start_supervised_oban!(queues: [alpha: 5])
 
     job = insert!(ref: 1, sleep: 100)
 
@@ -205,7 +205,7 @@ defmodule Oban.Integration.ControllingTest do
   end
 
   test "cancelling jobs that may or may not be executing" do
-    name = start_supervised_oban!(queues: [alpha: 5]).name
+    name = start_supervised_oban!(queues: [alpha: 5])
 
     job_a = insert!(%{ref: 1}, schedule_in: 10)
     job_b = insert!(%{ref: 2}, schedule_in: 10, state: "retryable")

--- a/test/integration/controlling_test.exs
+++ b/test/integration/controlling_test.exs
@@ -37,8 +37,8 @@ defmodule Oban.Integration.ControllingTest do
       assert :ok = Oban.start_queue(ObanA, queue: :alpha, limit: 1, local_only: true)
 
       with_backoff(fn ->
-        assert supervised_queue?(ObanA, ObanA.Queue.Alpha)
-        refute supervised_queue?(ObanB, ObanB.Queue.Alpha)
+        assert supervised_queue?(ObanA, "alpha")
+        refute supervised_queue?(ObanB, "alpha")
       end)
     end
   end
@@ -52,8 +52,8 @@ defmodule Oban.Integration.ControllingTest do
     test "stopping individual queues" do
       start_supervised_oban!(queues: [alpha: 5, delta: 5, gamma: 5])
 
-      assert supervised_queue?(Oban.Queue.Delta)
-      assert supervised_queue?(Oban.Queue.Gamma)
+      assert supervised_queue?("delta")
+      assert supervised_queue?("gamma")
 
       insert!(%{ref: 1, action: "OK"}, queue: :delta)
       insert!(%{ref: 2, action: "OK"}, queue: :gamma)
@@ -65,8 +65,8 @@ defmodule Oban.Integration.ControllingTest do
       assert :ok = Oban.stop_queue(queue: :gamma)
 
       with_backoff(fn ->
-        refute supervised_queue?(Oban.Queue.Delta)
-        refute supervised_queue?(Oban.Queue.Gamma)
+        refute supervised_queue?("delta")
+        refute supervised_queue?("gamma")
       end)
 
       insert!(%{ref: 3, action: "OK"}, queue: :alpha)
@@ -87,8 +87,8 @@ defmodule Oban.Integration.ControllingTest do
       assert :ok = Oban.stop_queue(ObanB, queue: :alpha, local_only: true)
 
       with_backoff(fn ->
-        assert supervised_queue?(ObanA, ObanA.Queue.Alpha)
-        refute supervised_queue?(ObanB, Oban.Queue.Alpha)
+        assert supervised_queue?(ObanA, "alpha")
+        refute supervised_queue?(ObanB, "alpha")
       end)
     end
   end
@@ -199,7 +199,7 @@ defmodule Oban.Integration.ControllingTest do
 
     assert %Job{state: "discarded", discarded_at: %_{}, errors: [_]} = Repo.reload(job)
 
-    %{running: running} = :sys.get_state(Oban.Queue.Alpha.Producer)
+    %{running: running} = :sys.get_state(Oban.Registry.whereis(Oban, {:producer, "alpha"}))
 
     assert Enum.empty?(running)
   end

--- a/test/integration/controlling_test.exs
+++ b/test/integration/controlling_test.exs
@@ -12,7 +12,7 @@ defmodule Oban.Integration.ControllingTest do
     end
 
     test "starting individual queues dynamically" do
-      start_supervised_oban!(queues: [alpha: 10])
+      name = start_supervised_oban!(queues: [alpha: 10]).name
 
       insert!(%{ref: 1, action: "OK"}, queue: :gamma)
       insert!(%{ref: 2, action: "OK"}, queue: :delta)
@@ -20,25 +20,25 @@ defmodule Oban.Integration.ControllingTest do
       refute_receive {:ok, 1}
       refute_receive {:ok, 2}
 
-      assert :ok = Oban.start_queue(queue: :gamma, limit: 5)
-      assert :ok = Oban.start_queue(queue: :delta, limit: 6)
-      assert :ok = Oban.start_queue(queue: :alpha, limit: 5)
+      assert :ok = Oban.start_queue(name, queue: :gamma, limit: 5)
+      assert :ok = Oban.start_queue(name, queue: :delta, limit: 6)
+      assert :ok = Oban.start_queue(name, queue: :alpha, limit: 5)
 
       assert_receive {:ok, 1}
       assert_receive {:ok, 2}
     end
 
     test "starting individual queues only on the local node" do
-      start_supervised_oban!(name: ObanA, queues: [])
-      start_supervised_oban!(name: ObanB, queues: [])
+      name1 = start_supervised_oban!(queues: []).name
+      name2 = start_supervised_oban!(queues: []).name
 
       sleep_for_notifier()
 
-      assert :ok = Oban.start_queue(ObanA, queue: :alpha, limit: 1, local_only: true)
+      assert :ok = Oban.start_queue(name1, queue: :alpha, limit: 1, local_only: true)
 
       with_backoff(fn ->
-        assert supervised_queue?(ObanA, "alpha")
-        refute supervised_queue?(ObanB, "alpha")
+        assert supervised_queue?(name1, "alpha")
+        refute supervised_queue?(name2, "alpha")
       end)
     end
   end
@@ -50,10 +50,10 @@ defmodule Oban.Integration.ControllingTest do
     end
 
     test "stopping individual queues" do
-      start_supervised_oban!(queues: [alpha: 5, delta: 5, gamma: 5])
+      name = start_supervised_oban!(queues: [alpha: 5, delta: 5, gamma: 5]).name
 
-      assert supervised_queue?("delta")
-      assert supervised_queue?("gamma")
+      assert supervised_queue?(name, "delta")
+      assert supervised_queue?(name, "gamma")
 
       insert!(%{ref: 1, action: "OK"}, queue: :delta)
       insert!(%{ref: 2, action: "OK"}, queue: :gamma)
@@ -61,12 +61,12 @@ defmodule Oban.Integration.ControllingTest do
       assert_receive {:ok, 1}
       assert_receive {:ok, 2}
 
-      assert :ok = Oban.stop_queue(queue: :delta)
-      assert :ok = Oban.stop_queue(queue: :gamma)
+      assert :ok = Oban.stop_queue(name, queue: :delta)
+      assert :ok = Oban.stop_queue(name, queue: :gamma)
 
       with_backoff(fn ->
-        refute supervised_queue?("delta")
-        refute supervised_queue?("gamma")
+        refute supervised_queue?(name, "delta")
+        refute supervised_queue?(name, "gamma")
       end)
 
       insert!(%{ref: 3, action: "OK"}, queue: :alpha)
@@ -79,16 +79,16 @@ defmodule Oban.Integration.ControllingTest do
     end
 
     test "stopping individual queues only on the local node" do
-      start_supervised_oban!(name: ObanA, queues: [alpha: 1])
-      start_supervised_oban!(name: ObanB, queues: [alpha: 1])
+      name1 = start_supervised_oban!(queues: [alpha: 1]).name
+      name2 = start_supervised_oban!(queues: [alpha: 1]).name
 
       sleep_for_notifier()
 
-      assert :ok = Oban.stop_queue(ObanB, queue: :alpha, local_only: true)
+      assert :ok = Oban.stop_queue(name2, queue: :alpha, local_only: true)
 
       with_backoff(fn ->
-        assert supervised_queue?(ObanA, "alpha")
-        refute supervised_queue?(ObanB, "alpha")
+        assert supervised_queue?(name1, "alpha")
+        refute supervised_queue?(name2, "alpha")
       end)
     end
   end
@@ -103,28 +103,28 @@ defmodule Oban.Integration.ControllingTest do
     end
 
     test "pausing and resuming individual queues" do
-      start_supervised_oban!(queues: [alpha: 5], poll_interval: 1_000)
+      name = start_supervised_oban!(queues: [alpha: 5], poll_interval: 1_000).name
 
       sleep_for_notifier()
 
-      assert :ok = Oban.pause_queue(queue: :alpha)
+      assert :ok = Oban.pause_queue(name, queue: :alpha)
 
       insert!(ref: 1, action: "OK")
 
       refute_receive {:ok, 1}
 
-      assert :ok = Oban.resume_queue(queue: :alpha)
+      assert :ok = Oban.resume_queue(name, queue: :alpha)
 
       assert_receive {:ok, 1}
     end
 
     test "pausing queues only on the local node" do
-      start_supervised_oban!(name: ObanA, queues: [alpha: 1])
-      start_supervised_oban!(name: ObanB, queues: [alpha: 1])
+      start_supervised_oban!(queues: [alpha: 1])
+      name2 = start_supervised_oban!(queues: [alpha: 1]).name
 
       sleep_for_notifier()
 
-      assert :ok = Oban.pause_queue(ObanB, queue: :alpha, local_only: true)
+      assert :ok = Oban.pause_queue(name2, queue: :alpha, local_only: true)
 
       insert!(%{ref: 1, sleep: 500}, queue: :alpha)
       insert!(%{ref: 2, sleep: 500}, queue: :alpha)
@@ -134,13 +134,13 @@ defmodule Oban.Integration.ControllingTest do
     end
 
     test "resuming queues only on the local node" do
-      start_supervised_oban!(name: ObanA, queues: [alpha: 1])
-      start_supervised_oban!(name: ObanB, queues: [alpha: 1])
+      name1 = start_supervised_oban!(queues: [alpha: 1]).name
+      start_supervised_oban!(queues: [alpha: 1])
 
       sleep_for_notifier()
 
-      assert :ok = Oban.pause_queue(ObanA, queue: :alpha)
-      assert :ok = Oban.resume_queue(ObanA, queue: :alpha, local_only: true)
+      assert :ok = Oban.pause_queue(name1, queue: :alpha)
+      assert :ok = Oban.resume_queue(name1, queue: :alpha, local_only: true)
 
       insert!(%{ref: 1, sleep: 500}, queue: :alpha)
       insert!(%{ref: 2, sleep: 500}, queue: :alpha)
@@ -158,24 +158,24 @@ defmodule Oban.Integration.ControllingTest do
     end
 
     test "scaling individual queues" do
-      start_supervised_oban!(queues: [alpha: 1])
+      name = start_supervised_oban!(queues: [alpha: 1]).name
 
       sleep_for_notifier()
 
       for ref <- 1..20, do: insert!(ref: ref, sleep: 500)
 
-      assert :ok = Oban.scale_queue(queue: :alpha, limit: 20)
+      assert :ok = Oban.scale_queue(name, queue: :alpha, limit: 20)
 
       assert_receive {:started, 20}
     end
 
     test "scaling queues only on the local node" do
-      start_supervised_oban!(name: ObanA, queues: [alpha: 2])
-      start_supervised_oban!(name: ObanB, queues: [alpha: 2])
+      start_supervised_oban!(queues: [alpha: 2])
+      name2 = start_supervised_oban!(queues: [alpha: 2]).name
 
       sleep_for_notifier()
 
-      assert :ok = Oban.scale_queue(ObanB, queue: :alpha, limit: 1, local_only: true)
+      assert :ok = Oban.scale_queue(name2, queue: :alpha, limit: 1, local_only: true)
 
       for ref <- 1..4, do: insert!(ref: ref, sleep: 1000)
 
@@ -187,25 +187,25 @@ defmodule Oban.Integration.ControllingTest do
   end
 
   test "killing an executing job by its id" do
-    start_supervised_oban!(queues: [alpha: 5])
+    name = start_supervised_oban!(queues: [alpha: 5]).name
 
     job = insert!(ref: 1, sleep: 100)
 
     assert_receive {:started, 1}
 
-    Oban.cancel_job(job.id)
+    Oban.cancel_job(name, job.id)
 
     refute_receive {:ok, 1}, 200
 
     assert %Job{state: "discarded", discarded_at: %_{}, errors: [_]} = Repo.reload(job)
 
-    %{running: running} = :sys.get_state(Oban.Registry.whereis(Oban, {:producer, "alpha"}))
+    %{running: running} = :sys.get_state(Oban.Registry.whereis(name, {:producer, "alpha"}))
 
     assert Enum.empty?(running)
   end
 
   test "cancelling jobs that may or may not be executing" do
-    start_supervised_oban!(queues: [alpha: 5])
+    name = start_supervised_oban!(queues: [alpha: 5]).name
 
     job_a = insert!(%{ref: 1}, schedule_in: 10)
     job_b = insert!(%{ref: 2}, schedule_in: 10, state: "retryable")
@@ -214,10 +214,10 @@ defmodule Oban.Integration.ControllingTest do
 
     assert_receive {:started, 4}
 
-    assert :ok = Oban.cancel_job(job_a.id)
-    assert :ok = Oban.cancel_job(job_b.id)
-    assert :ok = Oban.cancel_job(job_c.id)
-    assert :ok = Oban.cancel_job(job_d.id)
+    assert :ok = Oban.cancel_job(name, job_a.id)
+    assert :ok = Oban.cancel_job(name, job_b.id)
+    assert :ok = Oban.cancel_job(name, job_c.id)
+    assert :ok = Oban.cancel_job(name, job_d.id)
 
     refute_receive {:ok, 4}, 200
 
@@ -237,13 +237,11 @@ defmodule Oban.Integration.ControllingTest do
     insert!(ref: 1, action: "OK")
 
     assert_receive {:ok, 1}
-
-    :ok = stop_supervised(Oban)
   end
 
-  defp supervised_queue?(sup \\ Oban, queue_name) do
-    sup
-    |> Oban.Registry.via()
+  defp supervised_queue?(oban_name, queue_name) do
+    oban_name
+    |> Oban.whereis()
     |> Supervisor.which_children()
     |> Enum.any?(fn {name, _, _, _} -> name == queue_name end)
   end

--- a/test/integration/crontab_test.exs
+++ b/test/integration/crontab_test.exs
@@ -28,7 +28,7 @@ defmodule Oban.Integration.CrontabTest do
       crontab: [{"* * * * *", Worker, args: worker_args(1)}]
     ]
 
-    name = start_supervised_oban!(oban_opts).name
+    name = start_supervised_oban!(oban_opts)
 
     assert_receive {:ok, 1}
 
@@ -45,8 +45,8 @@ defmodule Oban.Integration.CrontabTest do
       crontab: [{"* * * * *", Worker, args: worker_args(1)}]
     ]
 
-    name1 = start_supervised_oban!(base_opts).name
-    name2 = start_supervised_oban!(base_opts).name
+    name1 = start_supervised_oban!(base_opts)
+    name2 = start_supervised_oban!(base_opts)
 
     assert_receive {:ok, 1}
 
@@ -62,8 +62,8 @@ defmodule Oban.Integration.CrontabTest do
       crontab: [{"* * * * *", Worker, args: worker_args(1)}]
     ]
 
-    name1 = start_supervised_oban!(base_opts ++ [prefix: "public"]).name
-    name2 = start_supervised_oban!(base_opts ++ [prefix: "private"]).name
+    name1 = start_supervised_oban!(base_opts ++ [prefix: "public"])
+    name2 = start_supervised_oban!(base_opts ++ [prefix: "private"])
 
     assert_receive {:ok, 1}
     assert_receive {:ok, 1}
@@ -97,7 +97,7 @@ defmodule Oban.Integration.CrontabTest do
       start_supervised_oban!(
         queues: false,
         crontab: [{"@reboot", Worker, args: worker_args(1)}]
-      ).name
+      )
 
     :ok = stop_supervised(name)
 
@@ -110,8 +110,8 @@ defmodule Oban.Integration.CrontabTest do
       crontab: [{"@reboot", Worker, args: worker_args(1)}]
     ]
 
-    name1 = start_supervised_oban!(base_opts).name
-    name2 = start_supervised_oban!(base_opts).name
+    name1 = start_supervised_oban!(base_opts)
+    name2 = start_supervised_oban!(base_opts)
 
     :ok = stop_supervised(name1)
     :ok = stop_supervised(name2)

--- a/test/integration/draining_test.exs
+++ b/test/integration/draining_test.exs
@@ -4,7 +4,7 @@ defmodule Oban.Integration.DrainingTest do
   @moduletag :integration
 
   test "all jobs in a queue can be drained and executed synchronously" do
-    name = start_supervised_oban!(queues: false).name
+    name = start_supervised_oban!(queues: false)
 
     insert!(ref: 1, action: "OK")
     insert!(ref: 2, action: "FAIL")
@@ -18,7 +18,7 @@ defmodule Oban.Integration.DrainingTest do
   end
 
   test "scheduled jobs are executed when given the :with_scheduled flag" do
-    name = start_supervised_oban!(queues: false).name
+    name = start_supervised_oban!(queues: false)
 
     insert!(%{ref: 1, action: "OK"}, scheduled_at: seconds_from_now(3600))
 
@@ -27,7 +27,7 @@ defmodule Oban.Integration.DrainingTest do
   end
 
   test "job errors bubble up when :with_safety is false" do
-    name = start_supervised_oban!(queues: false).name
+    name = start_supervised_oban!(queues: false)
 
     insert!(ref: 1, action: "FAIL")
 
@@ -39,7 +39,7 @@ defmodule Oban.Integration.DrainingTest do
   end
 
   test "job crashes bubble up when :with_safety is false" do
-    name = start_supervised_oban!(queues: false).name
+    name = start_supervised_oban!(queues: false)
 
     insert!(ref: 1, action: "EXIT")
 

--- a/test/integration/draining_test.exs
+++ b/test/integration/draining_test.exs
@@ -4,13 +4,13 @@ defmodule Oban.Integration.DrainingTest do
   @moduletag :integration
 
   test "all jobs in a queue can be drained and executed synchronously" do
-    start_supervised_oban!(queues: false)
+    name = start_supervised_oban!(queues: false).name
 
     insert!(ref: 1, action: "OK")
     insert!(ref: 2, action: "FAIL")
     insert!(ref: 3, action: "OK")
 
-    assert %{success: 2, failure: 1} = Oban.drain_queue(queue: :alpha)
+    assert %{success: 2, failure: 1} = Oban.drain_queue(name, queue: :alpha)
 
     assert_received {:ok, 3}
     assert_received {:fail, 2}
@@ -18,32 +18,32 @@ defmodule Oban.Integration.DrainingTest do
   end
 
   test "scheduled jobs are executed when given the :with_scheduled flag" do
-    start_supervised_oban!(queues: false)
+    name = start_supervised_oban!(queues: false).name
 
     insert!(%{ref: 1, action: "OK"}, scheduled_at: seconds_from_now(3600))
 
-    assert %{success: 0, failure: 0} = Oban.drain_queue(queue: :alpha)
-    assert %{success: 1, failure: 0} = Oban.drain_queue(queue: :alpha, with_scheduled: true)
+    assert %{success: 0, failure: 0} = Oban.drain_queue(name, queue: :alpha)
+    assert %{success: 1, failure: 0} = Oban.drain_queue(name, queue: :alpha, with_scheduled: true)
   end
 
   test "job errors bubble up when :with_safety is false" do
-    start_supervised_oban!(queues: false)
+    name = start_supervised_oban!(queues: false).name
 
     insert!(ref: 1, action: "FAIL")
 
     assert_raise RuntimeError, "FAILED", fn ->
-      Oban.drain_queue(queue: :alpha, with_safety: false)
+      Oban.drain_queue(name, queue: :alpha, with_safety: false)
     end
 
     assert_received {:fail, 1}
   end
 
   test "job crashes bubble up when :with_safety is false" do
-    start_supervised_oban!(queues: false)
+    name = start_supervised_oban!(queues: false).name
 
     insert!(ref: 1, action: "EXIT")
 
-    assert catch_exit(Oban.drain_queue(queue: :alpha, with_safety: false))
+    assert catch_exit(Oban.drain_queue(name, queue: :alpha, with_safety: false))
 
     assert_received {:exit, 1}
   end

--- a/test/integration/executing_test.exs
+++ b/test/integration/executing_test.exs
@@ -6,15 +6,15 @@ defmodule Oban.Integration.ExecutingTest do
   @moduletag :integration
 
   setup do
-    start_supervised_oban!(queues: [alpha: 3, beta: 3, gamma: 3, delta: 3])
+    name = start_supervised_oban!(queues: [alpha: 3, beta: 3, gamma: 3, delta: 3]).name
 
-    :ok
+    {:ok, name: name}
   end
 
-  property "individual jobs inserted into running queues are executed" do
+  property "individual jobs inserted into running queues are executed", context do
     check all jobs <- list_of(job()), max_runs: 20 do
       capture_log(fn ->
-        for job <- Oban.insert_all(jobs) do
+        for job <- Oban.insert_all(context.name, jobs) do
           %{args: %{"ref" => ref, "action" => action}, id: id, max_attempts: max} = job
 
           assert_receive {_, ^ref}

--- a/test/integration/executing_test.exs
+++ b/test/integration/executing_test.exs
@@ -6,7 +6,7 @@ defmodule Oban.Integration.ExecutingTest do
   @moduletag :integration
 
   setup do
-    name = start_supervised_oban!(queues: [alpha: 3, beta: 3, gamma: 3, delta: 3]).name
+    name = start_supervised_oban!(queues: [alpha: 3, beta: 3, gamma: 3, delta: 3])
 
     {:ok, name: name}
   end

--- a/test/integration/inserting_test.exs
+++ b/test/integration/inserting_test.exs
@@ -4,7 +4,7 @@ defmodule Oban.Integration.InsertingTest do
   alias Ecto.Multi
 
   test "inserting multiple jobs within a multi using insert/3" do
-    name = start_supervised_oban!(queues: false).name
+    name = start_supervised_oban!(queues: false)
 
     multi = Multi.new()
     multi = Oban.insert(name, multi, :job_1, Worker.new(%{ref: 1}))
@@ -20,7 +20,7 @@ defmodule Oban.Integration.InsertingTest do
   end
 
   test "inserting multiple jobs with insert_all/2" do
-    name = start_supervised_oban!(queues: false).name
+    name = start_supervised_oban!(queues: false)
 
     changesets = Enum.map(0..4, &Worker.new(%{ref: &1}, queue: "special", schedule_in: 10))
     jobs = Oban.insert_all(name, changesets)
@@ -38,7 +38,7 @@ defmodule Oban.Integration.InsertingTest do
   end
 
   test "inserting multiple jobs within a multi using insert_all/4" do
-    name = start_supervised_oban!(queues: false).name
+    name = start_supervised_oban!(queues: false)
 
     changesets_1 = Enum.map(1..2, &Worker.new(%{ref: &1}))
     changesets_2 = Enum.map(3..4, &Worker.new(%{ref: &1}))

--- a/test/integration/isolation_test.exs
+++ b/test/integration/isolation_test.exs
@@ -5,15 +5,6 @@ defmodule Oban.Integration.IsolationTest do
 
   @moduletag :integration
 
-  test "multiple supervisors can be run simultaneously" do
-    name1 = start_supervised_oban!(queues: [alpha: 1], plugins: [Oban.Plugins.Pruner])
-    start_supervised_oban!(queues: [gamma: 1], plugins: [Oban.Plugins.Pruner])
-
-    insert!(name1, %{ref: 1, action: "OK"}, [])
-
-    assert_receive {:ok, 1}
-  end
-
   test "inserting and executing jobs with a custom prefix" do
     name = start_supervised_oban!(prefix: "private", queues: [alpha: 5])
 

--- a/test/integration/isolation_test.exs
+++ b/test/integration/isolation_test.exs
@@ -6,7 +6,7 @@ defmodule Oban.Integration.IsolationTest do
   @moduletag :integration
 
   test "multiple supervisors can be run simultaneously" do
-    name1 = start_supervised_oban!(queues: [alpha: 1], plugins: [Oban.Plugins.Pruner]).name
+    name1 = start_supervised_oban!(queues: [alpha: 1], plugins: [Oban.Plugins.Pruner])
     start_supervised_oban!(queues: [gamma: 1], plugins: [Oban.Plugins.Pruner])
 
     insert!(name1, %{ref: 1, action: "OK"}, [])
@@ -15,7 +15,7 @@ defmodule Oban.Integration.IsolationTest do
   end
 
   test "inserting and executing jobs with a custom prefix" do
-    name = start_supervised_oban!(prefix: "private", queues: [alpha: 5]).name
+    name = start_supervised_oban!(prefix: "private", queues: [alpha: 5])
 
     job = insert!(name, %{ref: 1, action: "OK"}, [])
 
@@ -28,7 +28,7 @@ defmodule Oban.Integration.IsolationTest do
     # Make sure the public table isn't available when we're attempting to query
     mangle_jobs_table!()
 
-    name = start_supervised_oban!(prefix: "private", queues: [alpha: 5]).name
+    name = start_supervised_oban!(prefix: "private", queues: [alpha: 5])
 
     insert!(name, %{ref: 1, action: "OK"}, unique: [period: 60, fields: [:worker]])
     insert!(name, %{ref: 2, action: "OK"}, unique: [period: 60, fields: [:worker]])

--- a/test/integration/resiliency_test.exs
+++ b/test/integration/resiliency_test.exs
@@ -29,7 +29,7 @@ defmodule Oban.Integration.ResiliencyTest do
   end
 
   test "reporting notification connection errors" do
-    name = start_supervised_oban!(queues: [alpha: 1]).name
+    name = start_supervised_oban!(queues: [alpha: 1])
 
     assert %{conn: conn} = :sys.get_state(Oban.Registry.whereis(name, Oban.Notifier))
     assert Process.exit(conn, :forced_exit)

--- a/test/integration/resiliency_test.exs
+++ b/test/integration/resiliency_test.exs
@@ -23,7 +23,7 @@ defmodule Oban.Integration.ResiliencyTest do
     assert_receive {:tripped, %{message: message, name: name}}
 
     assert message =~ ~s|ERROR 42P01 (undefined_table)|
-    assert name == {:producer, "alpha"}
+    assert name == Oban.Queue.Alpha.Producer
   after
     reform_jobs_table!()
   end

--- a/test/integration/resiliency_test.exs
+++ b/test/integration/resiliency_test.exs
@@ -23,7 +23,9 @@ defmodule Oban.Integration.ResiliencyTest do
     assert_receive {:tripped, %{message: message, name: name}}
 
     assert message =~ ~s|ERROR 42P01 (undefined_table)|
-    assert name == Oban.Queue.Alpha.Producer
+
+    # TODO: remove via noise
+    assert {:via, Registry, {Oban.Registry, {_pid, {:producer, "alpha"}}}} = name
   after
     reform_jobs_table!()
   end

--- a/test/integration/resiliency_test.exs
+++ b/test/integration/resiliency_test.exs
@@ -31,7 +31,7 @@ defmodule Oban.Integration.ResiliencyTest do
   test "reporting notification connection errors" do
     start_supervised_oban!(queues: [alpha: 1])
 
-    assert %{conn: conn} = :sys.get_state(Oban.Notifier)
+    assert %{conn: conn} = :sys.get_state(Oban.Registry.whereis(Oban, Oban.Notifier))
     assert Process.exit(conn, :forced_exit)
 
     # This verifies that producer's are isolated from the notifier

--- a/test/integration/resiliency_test.exs
+++ b/test/integration/resiliency_test.exs
@@ -23,9 +23,7 @@ defmodule Oban.Integration.ResiliencyTest do
     assert_receive {:tripped, %{message: message, name: name}}
 
     assert message =~ ~s|ERROR 42P01 (undefined_table)|
-
-    # TODO: remove via noise
-    assert {:via, Registry, {Oban.Registry, {_pid, {:producer, "alpha"}}}} = name
+    assert name == {:producer, "alpha"}
   after
     reform_jobs_table!()
   end

--- a/test/integration/resiliency_test.exs
+++ b/test/integration/resiliency_test.exs
@@ -29,9 +29,9 @@ defmodule Oban.Integration.ResiliencyTest do
   end
 
   test "reporting notification connection errors" do
-    start_supervised_oban!(queues: [alpha: 1])
+    name = start_supervised_oban!(queues: [alpha: 1]).name
 
-    assert %{conn: conn} = :sys.get_state(Oban.Registry.whereis(Oban, Oban.Notifier))
+    assert %{conn: conn} = :sys.get_state(Oban.Registry.whereis(name, Oban.Notifier))
     assert Process.exit(conn, :forced_exit)
 
     # This verifies that producer's are isolated from the notifier

--- a/test/integration/scheduling_test.exs
+++ b/test/integration/scheduling_test.exs
@@ -10,7 +10,7 @@ defmodule Oban.Integration.SchedulingTest do
     job_4 = insert!([ref: 4, sleep: 5000], schedule_in: -1, queue: :gamma)
     job_5 = insert!([ref: 5, sleep: 5000], schedule_in: 10, queue: :alpha)
 
-    name = start_supervised_oban!(queues: [alpha: 2]).name
+    name = start_supervised_oban!(queues: [alpha: 2])
 
     assert_receive {:started, 1}
     assert_receive {:started, 2}

--- a/test/integration/scheduling_test.exs
+++ b/test/integration/scheduling_test.exs
@@ -10,7 +10,7 @@ defmodule Oban.Integration.SchedulingTest do
     job_4 = insert!([ref: 4, sleep: 5000], schedule_in: -1, queue: :gamma)
     job_5 = insert!([ref: 5, sleep: 5000], schedule_in: 10, queue: :alpha)
 
-    start_supervised_oban!(queues: [alpha: 2])
+    name = start_supervised_oban!(queues: [alpha: 2]).name
 
     assert_receive {:started, 1}
     assert_receive {:started, 2}
@@ -24,7 +24,7 @@ defmodule Oban.Integration.SchedulingTest do
     # Not descheduled because it is in the future
     refute_received {:started, 5}
 
-    stop_supervised(Oban)
+    :ok = stop_supervised(name)
 
     assert %{state: "available"} = Repo.reload(job_3)
     assert %{state: "scheduled"} = Repo.reload(job_4)

--- a/test/integration/shutdown_test.exs
+++ b/test/integration/shutdown_test.exs
@@ -4,7 +4,7 @@ defmodule Oban.Integration.ShutdownTest do
   @moduletag :integration
 
   test "slow jobs are allowed to complete within the shutdown grace period" do
-    start_supervised_oban!(queues: [alpha: 3], shutdown_grace_period: 50)
+    name = start_supervised_oban!(queues: [alpha: 3], shutdown_grace_period: 50).name
 
     %Job{id: id_1} = insert!(ref: 1, sleep: 10)
     %Job{id: id_2} = insert!(ref: 2, sleep: 4000)
@@ -12,7 +12,7 @@ defmodule Oban.Integration.ShutdownTest do
     assert_receive {:ok, 1}
     refute_receive {:ok, 2}, 100
 
-    :ok = stop_supervised(Oban)
+    :ok = stop_supervised(name)
 
     assert Repo.get(Job, id_1).state == "completed"
     assert Repo.get(Job, id_2).state == "executing"

--- a/test/integration/shutdown_test.exs
+++ b/test/integration/shutdown_test.exs
@@ -4,7 +4,7 @@ defmodule Oban.Integration.ShutdownTest do
   @moduletag :integration
 
   test "slow jobs are allowed to complete within the shutdown grace period" do
-    name = start_supervised_oban!(queues: [alpha: 3], shutdown_grace_period: 50).name
+    name = start_supervised_oban!(queues: [alpha: 3], shutdown_grace_period: 50)
 
     %Job{id: id_1} = insert!(ref: 1, sleep: 10)
     %Job{id: id_2} = insert!(ref: 2, sleep: 4000)

--- a/test/integration/telemetry_test.exs
+++ b/test/integration/telemetry_test.exs
@@ -99,7 +99,7 @@ defmodule Oban.Integration.TelemetryTest do
   end
 
   test "the default handler logs circuit breaker information" do
-    name = start_supervised_oban!(queues: [alpha: 3]).name
+    name = start_supervised_oban!(queues: [alpha: 3])
 
     :ok = Telemetry.attach_default_logger(:warn)
 

--- a/test/integration/telemetry_test.exs
+++ b/test/integration/telemetry_test.exs
@@ -107,7 +107,7 @@ defmodule Oban.Integration.TelemetryTest do
 
     logged =
       capture_log(fn ->
-        assert %{conn: conn} = :sys.get_state(Oban.Notifier)
+        assert %{conn: conn} = :sys.get_state(Oban.Registry.whereis(Oban, Oban.Notifier))
         assert Process.exit(conn, :forced_exit)
 
         # Give it time to log

--- a/test/integration/telemetry_test.exs
+++ b/test/integration/telemetry_test.exs
@@ -62,8 +62,6 @@ defmodule Oban.Integration.TelemetryTest do
              error: %PerformError{},
              stacktrace: []
            } = error_meta
-
-    :ok = stop_supervised(Oban)
   after
     :telemetry.detach("job-handler")
   end
@@ -101,13 +99,13 @@ defmodule Oban.Integration.TelemetryTest do
   end
 
   test "the default handler logs circuit breaker information" do
-    start_supervised_oban!(queues: [alpha: 3])
+    name = start_supervised_oban!(queues: [alpha: 3]).name
 
     :ok = Telemetry.attach_default_logger(:warn)
 
     logged =
       capture_log(fn ->
-        assert %{conn: conn} = :sys.get_state(Oban.Registry.whereis(Oban, Oban.Notifier))
+        assert %{conn: conn} = :sys.get_state(Oban.Registry.whereis(name, Oban.Notifier))
         assert Process.exit(conn, :forced_exit)
 
         # Give it time to log

--- a/test/integration/uniqueness_test.exs
+++ b/test/integration/uniqueness_test.exs
@@ -15,7 +15,7 @@ defmodule Oban.Integration.UniquenessTest do
   end
 
   setup do
-    name = start_supervised_oban!(queues: [alpha: 5]).name
+    name = start_supervised_oban!(queues: [alpha: 5])
 
     {:ok, name: name}
   end

--- a/test/integration/uniqueness_test.exs
+++ b/test/integration/uniqueness_test.exs
@@ -15,14 +15,14 @@ defmodule Oban.Integration.UniquenessTest do
   end
 
   setup do
-    start_supervised_oban!(queues: [alpha: 5])
+    name = start_supervised_oban!(queues: [alpha: 5]).name
 
-    :ok
+    {:ok, name: name}
   end
 
-  property "preventing the same job from being enqueued multiple times" do
+  property "preventing the same job from being enqueued multiple times", context do
     check all args <- arg_map(), runs <- integer(1..3), max_runs: 20 do
-      fun = fn -> unique_insert!(args) end
+      fun = fn -> unique_insert!(context.name, args) end
 
       ids =
         1..runs
@@ -36,71 +36,93 @@ defmodule Oban.Integration.UniquenessTest do
     end
   end
 
-  test "scoping uniqueness to particular fields" do
-    assert %Job{id: id_1} = unique_insert!(%{id: 1}, queue: "default")
-    assert %Job{id: id_2} = unique_insert!(%{id: 2}, queue: "delta")
-    assert %Job{id: ^id_2} = unique_insert!(%{id: 1}, unique: [fields: [:worker]])
+  test "scoping uniqueness to particular fields", context do
+    assert %Job{id: id_1} = unique_insert!(context.name, %{id: 1}, queue: "default")
+    assert %Job{id: id_2} = unique_insert!(context.name, %{id: 2}, queue: "delta")
+    assert %Job{id: ^id_2} = unique_insert!(context.name, %{id: 1}, unique: [fields: [:worker]])
 
     assert %Job{id: ^id_1} =
-             unique_insert!(%{id: 3}, queue: "default", unique: [fields: [:queue, :worker]])
+             unique_insert!(context.name, %{id: 3},
+               queue: "default",
+               unique: [fields: [:queue, :worker]]
+             )
 
     assert %Job{id: ^id_2} =
-             unique_insert!(%{id: 3}, queue: "delta", unique: [fields: [:queue, :worker]])
+             unique_insert!(context.name, %{id: 3},
+               queue: "delta",
+               unique: [fields: [:queue, :worker]]
+             )
 
     assert count_jobs() == 2
   end
 
-  test "scoping uniqueness to specific argument keys" do
-    assert %Job{id: id_1} = unique_insert!(%{id: 1, url: "https://a.co"})
-    assert %Job{id: id_2} = unique_insert!(%{id: 2, url: "https://b.co"})
+  test "scoping uniqueness to specific argument keys", context do
+    assert %Job{id: id_1} = unique_insert!(context.name, %{id: 1, url: "https://a.co"})
+    assert %Job{id: id_2} = unique_insert!(context.name, %{id: 2, url: "https://b.co"})
 
-    assert %Job{id: ^id_1} = unique_insert!(%{id: 3, url: "https://a.co"}, unique: [keys: [:url]])
-    assert %Job{id: ^id_2} = unique_insert!(%{id: 2, url: "https://a.co"}, unique: [keys: [:id]])
-    assert %Job{id: ^id_2} = unique_insert!(%{"id" => 2}, unique: [keys: [:id]])
+    assert %Job{id: ^id_1} =
+             unique_insert!(context.name, %{id: 3, url: "https://a.co"}, unique: [keys: [:url]])
+
+    assert %Job{id: ^id_2} =
+             unique_insert!(context.name, %{id: 2, url: "https://a.co"}, unique: [keys: [:id]])
+
+    assert %Job{id: ^id_2} = unique_insert!(context.name, %{"id" => 2}, unique: [keys: [:id]])
 
     assert count_jobs() == 2
   end
 
-  test "scoping uniqueness by state" do
-    assert %Job{id: id_1} = unique_insert!(%{id: 1}, state: "available")
-    assert %Job{id: id_2} = unique_insert!(%{id: 2}, state: "completed")
-    assert %Job{id: id_3} = unique_insert!(%{id: 3}, state: "executing")
-    assert %Job{id: ^id_1} = unique_insert!(%{id: 1}, unique: [states: [:available]])
-    assert %Job{id: ^id_2} = unique_insert!(%{id: 2}, unique: [states: [:available, :completed]])
-    assert %Job{id: ^id_2} = unique_insert!(%{id: 2}, unique: [states: [:completed, :discarded]])
-    assert %Job{id: ^id_3} = unique_insert!(%{id: 3}, unique: [states: [:completed, :executing]])
+  test "scoping uniqueness by state", context do
+    assert %Job{id: id_1} = unique_insert!(context.name, %{id: 1}, state: "available")
+    assert %Job{id: id_2} = unique_insert!(context.name, %{id: 2}, state: "completed")
+    assert %Job{id: id_3} = unique_insert!(context.name, %{id: 3}, state: "executing")
+
+    assert %Job{id: ^id_1} =
+             unique_insert!(context.name, %{id: 1}, unique: [states: [:available]])
+
+    assert %Job{id: ^id_2} =
+             unique_insert!(context.name, %{id: 2}, unique: [states: [:available, :completed]])
+
+    assert %Job{id: ^id_2} =
+             unique_insert!(context.name, %{id: 2}, unique: [states: [:completed, :discarded]])
+
+    assert %Job{id: ^id_3} =
+             unique_insert!(context.name, %{id: 3}, unique: [states: [:completed, :executing]])
 
     assert count_jobs() == 3
   end
 
-  test "scoping uniqueness by period" do
+  test "scoping uniqueness by period", context do
     now = DateTime.utc_now()
     two_minutes_ago = DateTime.add(now, -120, :second)
     five_minutes_ago = DateTime.add(now, -300, :second)
     one_thousand_years_ago = Map.put(now, :year, now.year - 1000)
     ten_years_in_seconds = 100 * 365 * 24 * 60 * 60
 
-    assert %Job{id: _id} = unique_insert!(%{id: 1}, inserted_at: two_minutes_ago)
-    assert %Job{id: _id} = unique_insert!(%{id: 2}, inserted_at: five_minutes_ago)
-    assert %Job{id: _id} = unique_insert!(%{id: 3}, inserted_at: one_thousand_years_ago)
-    assert %Job{id: id_1} = unique_insert!(%{id: 1}, unique: [period: 110])
-    assert %Job{id: id_2} = unique_insert!(%{id: 2}, unique: [period: 290])
-    assert %Job{id: id_3} = unique_insert!(%{id: 3}, unique: [period: ten_years_in_seconds])
+    assert %Job{id: _id} = unique_insert!(context.name, %{id: 1}, inserted_at: two_minutes_ago)
+    assert %Job{id: _id} = unique_insert!(context.name, %{id: 2}, inserted_at: five_minutes_ago)
 
-    assert %Job{id: ^id_1} = unique_insert!(%{id: 1}, unique: [period: 180])
-    assert %Job{id: ^id_2} = unique_insert!(%{id: 2}, unique: [period: 400])
-    assert %Job{id: ^id_3} = unique_insert!(%{id: 3}, unique: [period: :infinity])
+    assert %Job{id: _id} =
+             unique_insert!(context.name, %{id: 3}, inserted_at: one_thousand_years_ago)
+
+    assert %Job{id: id_1} = unique_insert!(context.name, %{id: 1}, unique: [period: 110])
+    assert %Job{id: id_2} = unique_insert!(context.name, %{id: 2}, unique: [period: 290])
+
+    assert %Job{id: id_3} =
+             unique_insert!(context.name, %{id: 3}, unique: [period: ten_years_in_seconds])
+
+    assert %Job{id: ^id_1} = unique_insert!(context.name, %{id: 1}, unique: [period: 180])
+    assert %Job{id: ^id_2} = unique_insert!(context.name, %{id: 2}, unique: [period: 400])
+    assert %Job{id: ^id_3} = unique_insert!(context.name, %{id: 3}, unique: [period: :infinity])
 
     assert count_jobs() == 6
   end
 
-  test "inserting unique jobs within a multi transaction" do
-    assert {:ok, %{job_1: job_1, job_2: job_2, job_3: job_3}} =
-             Multi.new()
-             |> Oban.insert(:job_1, UniqueWorker.new(%{id: 1}))
-             |> Oban.insert(:job_2, UniqueWorker.new(%{id: 2}))
-             |> Oban.insert(:job_3, UniqueWorker.new(%{id: 1}))
-             |> Repo.transaction()
+  test "inserting unique jobs within a multi transaction", context do
+    multi = Multi.new()
+    multi = Oban.insert(context.name, multi, :job_1, UniqueWorker.new(%{id: 1}))
+    multi = Oban.insert(context.name, multi, :job_2, UniqueWorker.new(%{id: 2}))
+    multi = Oban.insert(context.name, multi, :job_3, UniqueWorker.new(%{id: 1}))
+    assert {:ok, %{job_1: job_1, job_2: job_2, job_3: job_3}} = Repo.transaction(multi)
 
     assert job_1.id != job_2.id
     assert job_1.id == job_3.id
@@ -112,10 +134,8 @@ defmodule Oban.Integration.UniquenessTest do
   def arg_key, do: one_of([integer(), string(:ascii)])
   def arg_val, do: one_of([integer(), string(:ascii), list_of(integer())])
 
-  defp unique_insert!(args, opts \\ []) do
-    args
-    |> UniqueWorker.new(opts)
-    |> Oban.insert!()
+  defp unique_insert!(name, args, opts \\ []) do
+    Oban.insert!(name, UniqueWorker.new(args, opts))
   end
 
   defp count_jobs do

--- a/test/oban/config_test.exs
+++ b/test/oban/config_test.exs
@@ -38,13 +38,6 @@ defmodule Oban.ConfigTest do
       assert %Config{crontab: []} = conf(crontab: false)
     end
 
-    test ":name is validated as a module" do
-      assert_invalid(name: "Oban")
-      assert_invalid(name: {:via, :whatever})
-
-      assert_valid(name: MyOban)
-    end
-
     test ":node is validated as a binary" do
       assert_invalid(node: nil)
       assert_invalid(node: '')

--- a/test/oban/config_test.exs
+++ b/test/oban/config_test.exs
@@ -4,16 +4,6 @@ defmodule Oban.ConfigTest do
   alias Oban.Config
   alias Oban.Plugins.Pruner
 
-  describe "start_link/1" do
-    test "a config struct is stored for retreival" do
-      conf = Config.new(repo: Repo)
-
-      {:ok, pid} = Config.start_link(conf: conf)
-
-      assert %Config{} = Config.get(pid)
-    end
-  end
-
   describe "new/1" do
     test ":circuit_backoff is validated as an integer" do
       assert_invalid(circuit_backoff: -1)

--- a/test/oban_test.exs
+++ b/test/oban_test.exs
@@ -18,15 +18,20 @@ defmodule ObanTest do
       assert Oban.start_link(name: name, repo: Oban.Test.Repo) ==
                {:error, {:already_started, pid}}
     end
+
+    test "is used as a default child id" do
+      assert Supervisor.child_spec(Oban, []).id == Oban
+      assert Supervisor.child_spec({Oban, name: :foo}, []).id == :foo
+    end
   end
 
   describe "whereis/1" do
     test "returns pid of the oban root process" do
       name1 = make_ref()
-      {:ok, oban1} = start_supervised({Oban, name: name1, repo: Oban.Test.Repo}, id: :oban1)
+      {:ok, oban1} = start_supervised({Oban, name: name1, repo: Oban.Test.Repo})
 
       name2 = make_ref()
-      {:ok, oban2} = start_supervised({Oban, name: name2, repo: Oban.Test.Repo}, id: :oban2)
+      {:ok, oban2} = start_supervised({Oban, name: name2, repo: Oban.Test.Repo})
 
       assert Oban.whereis(name1) == oban1
       assert Oban.whereis(name2) == oban2

--- a/test/oban_test.exs
+++ b/test/oban_test.exs
@@ -1,0 +1,39 @@
+defmodule ObanTest do
+  use ExUnit.Case, async: true
+
+  describe "name" do
+    test "can be an arbitrary term" do
+      assert {:ok, _} = start_supervised({Oban, name: make_ref(), repo: Oban.Test.Repo})
+    end
+
+    test "is by default `Oban`" do
+      assert {:ok, pid} = start_supervised({Oban, repo: Oban.Test.Repo})
+      assert Oban.whereis(Oban) == pid
+    end
+
+    test "must be unique" do
+      name = make_ref()
+      {:ok, pid} = start_supervised({Oban, name: name, repo: Oban.Test.Repo})
+
+      assert Oban.start_link(name: name, repo: Oban.Test.Repo) ==
+               {:error, {:already_started, pid}}
+    end
+  end
+
+  describe "whereis/1" do
+    test "returns pid of the oban root process" do
+      name1 = make_ref()
+      {:ok, oban1} = start_supervised({Oban, name: name1, repo: Oban.Test.Repo}, id: :oban1)
+
+      name2 = make_ref()
+      {:ok, oban2} = start_supervised({Oban, name: name2, repo: Oban.Test.Repo}, id: :oban2)
+
+      assert Oban.whereis(name1) == oban1
+      assert Oban.whereis(name2) == oban2
+    end
+
+    test "returns nil if root process not found" do
+      assert is_nil(Oban.whereis(make_ref()))
+    end
+  end
+end

--- a/test/oban_test.exs
+++ b/test/oban_test.exs
@@ -33,6 +33,7 @@ defmodule ObanTest do
       name2 = make_ref()
       {:ok, oban2} = start_supervised({Oban, name: name2, repo: Oban.Test.Repo})
 
+      refute oban1 == oban2
       assert Oban.whereis(name1) == oban1
       assert Oban.whereis(name2) == oban2
     end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -50,9 +50,8 @@ defmodule Oban.Case do
       |> Keyword.put_new(:shutdown_grace_period, 1)
 
     name = opts[:name]
-    pid = start_supervised!({Oban, opts}, id: name)
-
-    %{name: name, pid: pid}
+    start_supervised!({Oban, opts})
+    name
   end
 
   def build(args, opts \\ []) do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -44,12 +44,15 @@ defmodule Oban.Case do
   def start_supervised_oban!(opts) do
     opts =
       opts
-      |> Keyword.put_new(:name, Oban)
+      |> Keyword.put_new(:name, make_ref())
       |> Keyword.put_new(:repo, Repo)
       |> Keyword.put_new(:poll_interval, 25)
       |> Keyword.put_new(:shutdown_grace_period, 1)
 
-    start_supervised!({Oban, opts}, id: opts[:name])
+    name = opts[:name]
+    pid = start_supervised!({Oban, opts}, id: name)
+
+    %{name: name, pid: pid}
   end
 
   def build(args, opts \\ []) do


### PR DESCRIPTION
This replaces locally registered names with Registry based names, which allows us to use arbitrary terms as oban instance names, e.g. `{Oban, name: {:tenant, 1}}`. This is the preparation for supporting running dynamic Oban instances which can work with dynamic Ecto repos, as discussed in #326.

In terms of function signatures, the change should be backwards compatible. However, if the client code relied on the previous name registration, it will break.

Summary of changes:

- Oban now has its own supervision tree with a registry which is used for process discovery.
- Any term can be used as name. Note that name still has to be unique, i.e. it's not possible to start two instances with the same name.
- Configuration is also managed in the registry.
- To improve confidence, integration tests are adapted to use a unique non-atom name.
- Name is also used as the default child id in `Oban.child_spec`.