### PR TITLE
V9 migration: adds `meta` and `cancelled` state

### DIFF
--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -67,6 +67,7 @@ defmodule Oban.Job do
           attempted_at: DateTime.t(),
           completed_at: DateTime.t(),
           discarded_at: DateTime.t(),
+          cancelled_at: DateTime.t(),
           unique: %{fields: [unique_field()], period: unique_period(), states: [unique_state()]},
           unsaved_error: %{kind: atom(), reason: term(), stacktrace: Exception.stacktrace()}
         }
@@ -86,6 +87,7 @@ defmodule Oban.Job do
     field :attempted_at, :utc_datetime_usec
     field :completed_at, :utc_datetime_usec
     field :discarded_at, :utc_datetime_usec
+    field :cancelled_at, :utc_datetime_usec
     field :inserted_at, :utc_datetime_usec
     field :scheduled_at, :utc_datetime_usec
     field :unique, :map, virtual: true
@@ -100,6 +102,7 @@ defmodule Oban.Job do
     attempted_at
     completed_at
     discarded_at
+    cancelled_at
     errors
     inserted_at
     max_attempts

--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -38,6 +38,7 @@ defmodule Oban.Job do
   @type option ::
           {:args, args()}
           | {:max_attempts, pos_integer()}
+          | {:meta, map()}
           | {:priority, pos_integer()}
           | {:queue, atom() | binary()}
           | {:schedule_in, pos_integer()}
@@ -58,6 +59,7 @@ defmodule Oban.Job do
           attempt: non_neg_integer(),
           attempted_by: [binary()],
           max_attempts: pos_integer(),
+          meta: map(),
           priority: pos_integer(),
           inserted_at: DateTime.t(),
           scheduled_at: DateTime.t(),
@@ -78,6 +80,7 @@ defmodule Oban.Job do
     field :attempt, :integer, default: 0
     field :attempted_by, {:array, :string}
     field :max_attempts, :integer, default: 20
+    field :meta, :map, default: %{}
     field :priority, :integer, default: 0
     field :attempted_at, :utc_datetime_usec
     field :completed_at, :utc_datetime_usec
@@ -99,6 +102,7 @@ defmodule Oban.Job do
     errors
     inserted_at
     max_attempts
+    meta
     priority
     queue
     scheduled_at
@@ -117,6 +121,7 @@ defmodule Oban.Job do
 
     * `:max_attempts` — the maximum number of times a job can be retried if there are errors
       during execution
+    * `:meta` — a map containing additional information about the job
     * `:priority` — a numerical indicator from 0 to 3 of how important this job is relative to
       other jobs in the same queue. The lower the number, the higher priority the job.
     * `:queue` — a named queue to push the job into. Jobs may be pushed into any queue, regardless

--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -27,7 +27,7 @@ defmodule Oban.Job do
           | :retryable
           | :completed
           | :discarded
-          | :canceled
+          | :cancelled
         ]
 
   @type unique_option ::
@@ -208,10 +208,10 @@ defmodule Oban.Job do
   ## Examples
 
       iex> Oban.Job.states() -- [:completed, :discarded]
-      [:scheduled, :available, :executing, :retryable, :canceled]
+      [:scheduled, :available, :executing, :retryable, :cancelled]
   """
   @doc since: "2.1.0"
-  def states, do: @unique_states ++ [:discarded, :canceled]
+  def states, do: @unique_states ++ [:discarded, :cancelled]
 
   @doc """
   Convert a Job changeset into a map suitable for database insertion.

--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -27,6 +27,7 @@ defmodule Oban.Job do
           | :retryable
           | :completed
           | :discarded
+          | :canceled
         ]
 
   @type unique_option ::
@@ -207,10 +208,10 @@ defmodule Oban.Job do
   ## Examples
 
       iex> Oban.Job.states() -- [:completed, :discarded]
-      [:scheduled, :available, :executing, :retryable]
+      [:scheduled, :available, :executing, :retryable, :canceled]
   """
   @doc since: "2.1.0"
-  def states, do: @unique_states ++ [:discarded]
+  def states, do: @unique_states ++ [:discarded, :canceled]
 
   @doc """
   Convert a Job changeset into a map suitable for database insertion.

--- a/lib/oban/migrations.ex
+++ b/lib/oban/migrations.ex
@@ -4,7 +4,7 @@ defmodule Oban.Migrations do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 8
+  @current_version 9
   @default_prefix "public"
 
   def up(opts \\ []) when is_list(opts) do
@@ -439,6 +439,30 @@ defmodule Oban.Migrations do
       v1_oban_notify(prefix)
 
       record_version(prefix, 7)
+    end
+  end
+
+  defmodule V9 do
+    @moduledoc false
+
+    use Ecto.Migration
+
+    import Oban.Migrations.Helper
+
+    def up(prefix) do
+      alter table(:oban_jobs, prefix: prefix) do
+        add_if_not_exists(:meta, :map)
+      end
+
+      record_version(prefix, 9)
+    end
+
+    def down(prefix) do
+      alter table(:oban_jobs, prefix: prefix) do
+        add_if_not_exists(:meta, :map)
+      end
+
+      record_version(prefix, 8)
     end
   end
 end

--- a/lib/oban/migrations.ex
+++ b/lib/oban/migrations.ex
@@ -452,6 +452,7 @@ defmodule Oban.Migrations do
     def up(prefix) do
       alter table(:oban_jobs, prefix: prefix) do
         add_if_not_exists(:meta, :map)
+        add_if_not_exists(:cancelled_at, :utc_datetime_usec)
       end
 
       execute """
@@ -490,6 +491,7 @@ defmodule Oban.Migrations do
     def down(prefix) do
       alter table(:oban_jobs, prefix: prefix) do
         remove_if_exists(:meta, :map)
+        remove_if_exists(:cancelled_at, :utc_datetime_usec)
       end
 
       execute """

--- a/lib/oban/migrations.ex
+++ b/lib/oban/migrations.ex
@@ -469,7 +469,7 @@ defmodule Oban.Migrations do
             'retryable',
             'completed',
             'discarded',
-            'canceled'
+            'cancelled'
           );
 
           ALTER TABLE #{prefix}.oban_jobs RENAME column state TO _state;

--- a/lib/oban/query.ex
+++ b/lib/oban/query.ex
@@ -168,7 +168,7 @@ defmodule Oban.Query do
     end
   end
 
-  @spec cancel_running_job(Config.t(), pos_integer()) :: :ok | :ignored
+  @spec cancel_running_job(Config.t(), Job.t()) :: :ok
   def cancel_running_job(%Config{prefix: prefix, repo: repo, log: log}, job) do
     updates = [
       set: [state: "cancelled", discarded_at: utc_now()],

--- a/lib/oban/query.ex
+++ b/lib/oban/query.ex
@@ -160,7 +160,7 @@ defmodule Oban.Query do
   @spec cancel_job(Config.t(), pos_integer()) :: :ok | :ignored
   def cancel_job(%Config{prefix: prefix, repo: repo, log: log}, job_id) do
     query = where(Job, [j], j.id == ^job_id and j.state in @cancellable_states)
-    updates = [set: [state: "cancelled", discarded_at: utc_now()]]
+    updates = [set: [state: "cancelled", cancelled_at: utc_now()]]
 
     case repo.update_all(query, updates, log: log, prefix: prefix) do
       {1, nil} -> :ok
@@ -171,7 +171,7 @@ defmodule Oban.Query do
   @spec cancel_running_job(Config.t(), Job.t()) :: :ok
   def cancel_running_job(%Config{prefix: prefix, repo: repo, log: log}, job) do
     updates = [
-      set: [state: "cancelled", discarded_at: utc_now()],
+      set: [state: "cancelled", cancelled_at: utc_now()],
       push: [
         errors: %{attempt: job.attempt, at: utc_now(), error: format_blamed(job.unsaved_error)}
       ]

--- a/lib/oban/query.ex
+++ b/lib/oban/query.ex
@@ -160,12 +160,31 @@ defmodule Oban.Query do
   @spec cancel_job(Config.t(), pos_integer()) :: :ok | :ignored
   def cancel_job(%Config{prefix: prefix, repo: repo, log: log}, job_id) do
     query = where(Job, [j], j.id == ^job_id and j.state in @cancellable_states)
-    updates = [set: [state: "discarded", discarded_at: utc_now()]]
+    updates = [set: [state: "canceled", discarded_at: utc_now()]]
 
     case repo.update_all(query, updates, log: log, prefix: prefix) do
       {1, nil} -> :ok
       {0, nil} -> :ignored
     end
+  end
+
+  @spec cancel_running_job(Config.t(), pos_integer()) :: :ok | :ignored
+  def cancel_running_job(%Config{prefix: prefix, repo: repo, log: log}, job) do
+    updates = [
+      set: [state: "canceled", discarded_at: utc_now()],
+      push: [
+        errors: %{attempt: job.attempt, at: utc_now(), error: format_blamed(job.unsaved_error)}
+      ]
+    ]
+
+    repo.update_all(
+      where(Job, id: ^job.id),
+      updates,
+      log: log,
+      prefix: prefix
+    )
+
+    :ok
   end
 
   @spec snooze_job(Config.t(), Job.t(), pos_integer()) :: :ok

--- a/lib/oban/query.ex
+++ b/lib/oban/query.ex
@@ -160,7 +160,7 @@ defmodule Oban.Query do
   @spec cancel_job(Config.t(), pos_integer()) :: :ok | :ignored
   def cancel_job(%Config{prefix: prefix, repo: repo, log: log}, job_id) do
     query = where(Job, [j], j.id == ^job_id and j.state in @cancellable_states)
-    updates = [set: [state: "canceled", discarded_at: utc_now()]]
+    updates = [set: [state: "cancelled", discarded_at: utc_now()]]
 
     case repo.update_all(query, updates, log: log, prefix: prefix) do
       {1, nil} -> :ok
@@ -171,7 +171,7 @@ defmodule Oban.Query do
   @spec cancel_running_job(Config.t(), pos_integer()) :: :ok | :ignored
   def cancel_running_job(%Config{prefix: prefix, repo: repo, log: log}, job) do
     updates = [
-      set: [state: "canceled", discarded_at: utc_now()],
+      set: [state: "cancelled", discarded_at: utc_now()],
       push: [
         errors: %{attempt: job.attempt, at: utc_now(), error: format_blamed(job.unsaved_error)}
       ]

--- a/lib/oban/queue/producer.ex
+++ b/lib/oban/queue/producer.ex
@@ -148,7 +148,7 @@ defmodule Oban.Queue.Producer do
             with :ok <- DynamicSupervisor.terminate_child(foreman, pid) do
               uerror = %{kind: :error, reason: "None", stacktrace: []}
 
-              Query.discard_job(conf, %{exec.job | unsaved_error: uerror})
+              Query.cancel_running_job(conf, %{exec.job | unsaved_error: uerror})
             end
           end
 

--- a/test/integration/controlling_test.exs
+++ b/test/integration/controlling_test.exs
@@ -198,7 +198,7 @@ defmodule Oban.Integration.ControllingTest do
 
     refute_receive {:ok, 1}, 200
 
-    assert %Job{state: "canceled", discarded_at: %_{}, errors: [_]} = Repo.reload(job)
+    assert %Job{state: "cancelled", discarded_at: %_{}, errors: [_]} = Repo.reload(job)
 
     %{running: running} = :sys.get_state(Oban.Registry.whereis(name, {:producer, "alpha"}))
 
@@ -222,10 +222,10 @@ defmodule Oban.Integration.ControllingTest do
 
     refute_receive {:ok, 4}, 200
 
-    assert %Job{state: "canceled", discarded_at: %_{}} = Repo.reload(job_a)
-    assert %Job{state: "canceled", discarded_at: %_{}} = Repo.reload(job_b)
+    assert %Job{state: "cancelled", discarded_at: %_{}} = Repo.reload(job_a)
+    assert %Job{state: "cancelled", discarded_at: %_{}} = Repo.reload(job_b)
     assert %Job{state: "completed", discarded_at: nil} = Repo.reload(job_c)
-    assert %Job{state: "canceled", discarded_at: %_{}} = Repo.reload(job_d)
+    assert %Job{state: "cancelled", discarded_at: %_{}} = Repo.reload(job_d)
   end
 
   test "dispatching jobs from a queue via database trigger" do

--- a/test/integration/controlling_test.exs
+++ b/test/integration/controlling_test.exs
@@ -198,7 +198,7 @@ defmodule Oban.Integration.ControllingTest do
 
     refute_receive {:ok, 1}, 200
 
-    assert %Job{state: "discarded", discarded_at: %_{}, errors: [_]} = Repo.reload(job)
+    assert %Job{state: "canceled", discarded_at: %_{}, errors: [_]} = Repo.reload(job)
 
     %{running: running} = :sys.get_state(Oban.Registry.whereis(name, {:producer, "alpha"}))
 
@@ -222,10 +222,10 @@ defmodule Oban.Integration.ControllingTest do
 
     refute_receive {:ok, 4}, 200
 
-    assert %Job{state: "discarded", discarded_at: %_{}} = Repo.reload(job_a)
-    assert %Job{state: "discarded", discarded_at: %_{}} = Repo.reload(job_b)
+    assert %Job{state: "canceled", discarded_at: %_{}} = Repo.reload(job_a)
+    assert %Job{state: "canceled", discarded_at: %_{}} = Repo.reload(job_b)
     assert %Job{state: "completed", discarded_at: nil} = Repo.reload(job_c)
-    assert %Job{state: "discarded", discarded_at: %_{}} = Repo.reload(job_d)
+    assert %Job{state: "canceled", discarded_at: %_{}} = Repo.reload(job_d)
   end
 
   test "dispatching jobs from a queue via database trigger" do

--- a/test/integration/controlling_test.exs
+++ b/test/integration/controlling_test.exs
@@ -198,7 +198,7 @@ defmodule Oban.Integration.ControllingTest do
 
     refute_receive {:ok, 1}, 200
 
-    assert %Job{state: "cancelled", discarded_at: %_{}, errors: [_]} = Repo.reload(job)
+    assert %Job{state: "cancelled", cancelled_at: %_{}, errors: [_]} = Repo.reload(job)
 
     %{running: running} = :sys.get_state(Oban.Registry.whereis(name, {:producer, "alpha"}))
 
@@ -222,10 +222,10 @@ defmodule Oban.Integration.ControllingTest do
 
     refute_receive {:ok, 4}, 200
 
-    assert %Job{state: "cancelled", discarded_at: %_{}} = Repo.reload(job_a)
-    assert %Job{state: "cancelled", discarded_at: %_{}} = Repo.reload(job_b)
-    assert %Job{state: "completed", discarded_at: nil} = Repo.reload(job_c)
-    assert %Job{state: "cancelled", discarded_at: %_{}} = Repo.reload(job_d)
+    assert %Job{state: "cancelled", cancelled_at: %_{}} = Repo.reload(job_a)
+    assert %Job{state: "cancelled", cancelled_at: %_{}} = Repo.reload(job_b)
+    assert %Job{state: "completed", cancelled_at: nil} = Repo.reload(job_c)
+    assert %Job{state: "cancelled", cancelled_at: %_{}} = Repo.reload(job_d)
   end
 
   test "dispatching jobs from a queue via database trigger" do

--- a/test/oban/job_test.exs
+++ b/test/oban/job_test.exs
@@ -66,7 +66,7 @@ defmodule Oban.JobTest do
   end
 
   describe "to_map/1" do
-    @keys_with_defaults ~w(args attempt errors max_attempts priority queue state tags)a
+    @keys_with_defaults ~w(args attempt errors max_attempts meta priority queue state tags)a
 
     defp to_keys(opts) do
       %{}


### PR DESCRIPTION
Starting point for the #323 issue. As this requires a migration I ain't sure if it can be merged. 