### PR TITLE
Add tags as part of the job event metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+
+- [Oban.Telemetry] Include `tags` as part of the metadata for job events.
+
 ## [2.1.0] — 2020-08-21
 
 ### Fixed

--- a/lib/oban/queue/executor.ex
+++ b/lib/oban/queue/executor.ex
@@ -245,7 +245,7 @@ defmodule Oban.Queue.Executor do
 
   defp event_metadata(conf, job) do
     job
-    |> Map.take([:id, :args, :queue, :worker, :attempt, :max_attempts])
+    |> Map.take([:id, :args, :queue, :worker, :attempt, :max_attempts, :tags])
     |> Map.put(:prefix, conf.prefix)
   end
 

--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -14,11 +14,11 @@ defmodule Oban.Telemetry do
   provide the error type, the error itself, and the stacktrace. The following chart shows which
   metadata you can expect for each event:
 
-  | event        | measures                   | metadata                                                                                      |
-  | ------------ | -------------------------- | --------------------------------------------------------------------------------------------- |
-  | `:start`     | `:system_time`             | `:id, :args, :queue, :worker, :attempt, :max_attempts, :prefix`                               |
-  | `:stop`      | `:duration`, `:queue_time` | `:id, :args, :queue, :worker, :attempt, :max_attempts, :prefix`                               |
-  | `:exception` | `:duration`, `:queue_time` | `:id, :args, :queue, :worker, :attempt, :max_attempts, :prefix, :kind, :error, :stacktrace` |
+  | event        | measures                   | metadata                                                                                           |
+  | ------------ | -------------------------- | -------------------------------------------------------------------------------------------------- |
+  | `:start`     | `:system_time`             | `:id, :args, :queue, :worker, :attempt, :max_attempts, :prefix, :tags`                             |
+  | `:stop`      | `:duration`, `:queue_time` | `:id, :args, :queue, :worker, :attempt, :max_attempts, :prefix, :tags`                             |
+  | `:exception` | `:duration`, `:queue_time` | `:id, :args, :queue, :worker, :attempt, :max_attempts, :prefix, :kind, :error, :stacktrace, :tags` |
 
   For `:exception` events the metadata includes details about what caused the failure. The `:kind`
   value is determined by how an error occurred. Here are the possible kinds:

--- a/test/integration/telemetry_test.exs
+++ b/test/integration/telemetry_test.exs
@@ -28,8 +28,8 @@ defmodule Oban.Integration.TelemetryTest do
 
     start_supervised_oban!(queues: [alpha: 2])
 
-    %Job{id: stop_id} = insert!(ref: 1, action: "OK")
-    %Job{id: error_id} = insert!(ref: 2, action: "ERROR")
+    %Job{id: stop_id} = insert!([ref: 1, action: "OK"], tags: ["baz"])
+    %Job{id: error_id} = insert!([ref: 2, action: "ERROR"], tags: ["foo"])
 
     assert_receive {:event, :start, started_time, stop_meta}
     assert_receive {:event, :stop, %{duration: stop_duration, queue_time: queue_time}, stop_meta}
@@ -47,7 +47,8 @@ defmodule Oban.Integration.TelemetryTest do
              worker: "Oban.Integration.Worker",
              prefix: "public",
              attempt: 1,
-             max_attempts: 20
+             max_attempts: 20,
+             tags: ["baz"]
            } = stop_meta
 
     assert %{
@@ -60,7 +61,8 @@ defmodule Oban.Integration.TelemetryTest do
              max_attempts: 20,
              kind: :error,
              error: %PerformError{},
-             stacktrace: []
+             stacktrace: [],
+             tags: ["foo"]
            } = error_meta
   after
     :telemetry.detach("job-handler")

--- a/test/oban/queue/executor_test.exs
+++ b/test/oban/queue/executor_test.exs
@@ -72,6 +72,22 @@ defmodule Oban.Queue.ExecutorTest do
     end
   end
 
+  describe "new/2" do
+    test "tags are included in the job metadata" do
+      now = DateTime.utc_now()
+
+      job = %Job{
+        args: %{"mode" => "sleep"},
+        worker: to_string(Worker),
+        tags: ["my_tag"],
+        attempted_at: DateTime.add(now, 30, :millisecond),
+        scheduled_at: now
+      }
+
+      assert %{meta: %{args: %{"mode" => "sleep"}, tags: ["my_tag"]}} = Executor.new(@conf, job)
+    end
+  end
+
   defp call_with_mode(mode) do
     job = %Job{args: %{"mode" => mode}, worker: to_string(Worker)}
 

--- a/test/oban/queue/executor_test.exs
+++ b/test/oban/queue/executor_test.exs
@@ -72,22 +72,6 @@ defmodule Oban.Queue.ExecutorTest do
     end
   end
 
-  describe "new/2" do
-    test "tags are included in the job metadata" do
-      now = DateTime.utc_now()
-
-      job = %Job{
-        args: %{"mode" => "sleep"},
-        worker: to_string(Worker),
-        tags: ["my_tag"],
-        attempted_at: DateTime.add(now, 30, :millisecond),
-        scheduled_at: now
-      }
-
-      assert %{meta: %{args: %{"mode" => "sleep"}, tags: ["my_tag"]}} = Executor.new(@conf, job)
-    end
-  end
-
   defp call_with_mode(mode) do
     job = %Job{args: %{"mode" => mode}, worker: to_string(Worker)}
 


### PR DESCRIPTION
Now the `[:oban, :job, {:start|:stop|:exception}]` telemetry events include the Job tags as part of their metadata.