### PR TITLE
Fix recursive jobs documentation

### DIFF
--- a/guides/recipes/recursive-jobs.md
+++ b/guides/recipes/recursive-jobs.md
@@ -53,7 +53,7 @@ defmodule MyApp.Workers.TimezoneWorker do
         next_id when is_integer(next_id) ->
           %{id: next_id, backfill: true}
           |> new(schedule_in: @backfill_delay)
-          |> Oban.insert!()
+          |> Oban.insert()
 
         nil ->
           :ok


### PR DESCRIPTION
Removing bang from `Oban.insert!`, otherwise the job results with a
non-expected return.