### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:oban, "~> 2.1"}
+    {:oban, "~> 2.2"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ defmodule MyApp.Business do
   use Oban.Worker, queue: :events
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"id" => id}}) do
+  def perform(%Oban.Job{args: %{"id" => id} = args}) do
     model = MyApp.Repo.get(MyApp.Business.Man, id)
 
     case args do

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ end
 ```
 
 If you are running tests (which you should be) you'll want to disable plugins,
-enqueuing scheduled jobs and job dispatching altogether when testing:
+enqueueing scheduled jobs and job dispatching altogether when testing:
 
 ```elixir
 # config/test.exs
@@ -494,7 +494,7 @@ config :my_app, Oban,
 
 ### Unique Jobs
 
-The unique jobs feature lets you specify constraints to prevent enqueuing
+The unique jobs feature lets you specify constraints to prevent enqueueing
 duplicate jobs.  Uniqueness is based on a combination of `args`, `queue`,
 `worker`, `state` and insertion time. It is configured at the worker or job
 level using the following options:


### PR DESCRIPTION
While trying to find my bug with the 2.2 version I came across some minor things in the `README`
- fixed missing `args` binding in Job example
- bumped the Oban version in `Installation` to 2.2
- changed `enqueuing` to`enqueueing` to make it consistent