### PR TITLE
Fix `listen/2` function in Notifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+
+- [Oban.Notifier] Fix resolution of `Oban.Notifier` child process in `Oban.Notifier.listen/2`.
+
 ## [2.2.0] — 2020-10-12
 
 ### Added

--- a/lib/oban/notifier.ex
+++ b/lib/oban/notifier.ex
@@ -128,7 +128,7 @@ defmodule Oban.Notifier do
       Oban.Notifier.listen([:gossip, :insert, :signal])
   """
   @spec listen(GenServer.server(), channels :: list(channel())) :: :ok
-  def listen(server \\ __MODULE__, channels)
+  def listen(server \\ Oban, channels)
 
   def listen(pid, channels) when is_pid(pid) and is_list(channels) do
     :ok = validate_channels!(channels)
@@ -136,10 +136,9 @@ defmodule Oban.Notifier do
     GenServer.call(pid, {:listen, channels})
   end
 
-  def listen(server, channels) when is_atom(server) and is_list(channels) do
-    Oban.config()
-    |> Map.get(:name, Oban)
-    |> Oban.Registry.whereis(server)
+  def listen(oban_name, channels) when is_atom(oban_name) and is_list(channels) do
+    oban_name
+    |> Oban.Registry.whereis(__MODULE__)
     |> listen(channels)
   end
 

--- a/lib/oban/notifier.ex
+++ b/lib/oban/notifier.ex
@@ -98,8 +98,6 @@ defmodule Oban.Notifier do
     ]
   end
 
-  defguardp is_server(server) when is_pid(server) or is_atom(server)
-
   defguardp is_channel(channel) when channel in @channels
 
   @doc false
@@ -130,10 +128,18 @@ defmodule Oban.Notifier do
       Oban.Notifier.listen([:gossip, :insert, :signal])
   """
   @spec listen(GenServer.server(), channels :: list(channel())) :: :ok
-  def listen(server \\ __MODULE__, channels) when is_server(server) and is_list(channels) do
+  def listen(server \\ __MODULE__, channels)
+  def listen(pid, channels) when is_pid(pid) and is_list(channels) do
     :ok = validate_channels!(channels)
 
-    GenServer.call(server, {:listen, channels})
+    GenServer.call(pid, {:listen, channels})
+  end
+
+  def listen(server, channels) when is_atom(server) and is_list(channels) do
+      Oban.config()
+      |> Map.get(:name, Oban)
+      |> Oban.Registry.whereis(server)
+      |> listen(channels)
   end
 
   @doc """

--- a/lib/oban/notifier.ex
+++ b/lib/oban/notifier.ex
@@ -129,6 +129,7 @@ defmodule Oban.Notifier do
   """
   @spec listen(GenServer.server(), channels :: list(channel())) :: :ok
   def listen(server \\ __MODULE__, channels)
+
   def listen(pid, channels) when is_pid(pid) and is_list(channels) do
     :ok = validate_channels!(channels)
 
@@ -136,10 +137,10 @@ defmodule Oban.Notifier do
   end
 
   def listen(server, channels) when is_atom(server) and is_list(channels) do
-      Oban.config()
-      |> Map.get(:name, Oban)
-      |> Oban.Registry.whereis(server)
-      |> listen(channels)
+    Oban.config()
+    |> Map.get(:name, Oban)
+    |> Oban.Registry.whereis(server)
+    |> listen(channels)
   end
 
   @doc """


### PR DESCRIPTION
Splitted the `listen/2` function to handle `pid` and `atom` separately.
The function handling `atom` resolves the `pid` using the registry's `whereis` function and then calls `listen/2` with the pid.

I am not sure if the fallback to `Oban` in line 140 is neccessary (the documentation states that the default name is always `Oban` so it could be omitted).

I also removed `is_server` guard because it isn't used anymore.