### PR TITLE
Update Worker.from_string/1 to work with modules that are not loaded

### DIFF
--- a/lib/oban/worker.ex
+++ b/lib/oban/worker.ex
@@ -401,7 +401,7 @@ defmodule Oban.Worker do
       |> String.split(".")
       |> Module.safe_concat()
 
-    if function_exported?(module, :perform, 1) do
+    if Code.ensure_loaded?(module) && function_exported?(module, :perform, 1) do
       {:ok, module}
     else
       {:error, %RuntimeError{message: "module is not a worker: #{inspect(module)}"}}

--- a/test/oban/worker_test.exs
+++ b/test/oban/worker_test.exs
@@ -95,6 +95,16 @@ defmodule Oban.WorkerTest do
     end
   end
 
+  describe "from_string/1" do
+    test "finds workers that are not loaded" do
+      :code.delete(Oban.Integration.Worker)
+
+      {:ok, worker_module} = Worker.from_string("Oban.Integration.Worker")
+
+      assert worker_module == Oban.Integration.Worker
+    end
+  end
+
   test "validating __using__ macro options" do
     assert_raise ArgumentError, ~r/unknown option/, fn ->
       defmodule UnknownOption do

--- a/test/oban/worker_test.exs
+++ b/test/oban/worker_test.exs
@@ -1,5 +1,5 @@
 defmodule Oban.WorkerTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   doctest Oban.Worker
 
@@ -99,9 +99,7 @@ defmodule Oban.WorkerTest do
     test "finds workers that are not loaded" do
       :code.delete(Oban.Integration.Worker)
 
-      {:ok, worker_module} = Worker.from_string("Oban.Integration.Worker")
-
-      assert worker_module == Oban.Integration.Worker
+      assert {:ok, Oban.Integration.Worker} = Worker.from_string("Oban.Integration.Worker")
     end
   end
 


### PR DESCRIPTION
Stemming from this conversation in the Elixir slack: https://elixir-lang.slack.com/archives/CRDGH1XCM/p1606924009092100

To summarize: https://github.com/sorentwo/oban/commit/7b53223bf44a6025e93f5eec354a931c4d3a71dd caused Oban to be unable to execute workers that were valid but had not yet been loaded. This caused our test suite to be unable to execute jobs in certain workers.

The change ensures that a module is loaded before checking if it exports `perform/1`.