### PR TITLE
Update elixir, otp and postgres version matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
   ci:
     strategy:
       matrix:
-        elixir: ['1.8', '1.9', '1.10']
-        otp: ['22.2']
-        postgres: ['11.7-alpine', '12.2-alpine']
+        elixir: ['1.10', '1.11']
+        otp: ['23.1']
+        postgres: ['12.5-alpine', '13.1-alpine']
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
To stay current we favor newer releases with compiler checks over older versions that have more limitations:

* To use Code.put_compiler_option we require Elixir 1.10 or above
* To get the latest code warnings we require Elixir 1.11 or above
* To check otp 23 we can no longer test Elixir 1.8 or below
* Technically PG 9.6 > is supported, but we've never tested 9 or 10 in
  the matrix before