### PR TITLE
Added init telemetry event and tweaked existing telemetry metadata

### DIFF
--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -11,7 +11,7 @@ defmodule Oban do
   use Supervisor
 
   alias Ecto.{Changeset, Multi}
-  alias Oban.{Config, Job, Midwife, Notifier, Query, Telemetry, Registry}
+  alias Oban.{Config, Job, Midwife, Notifier, Query, Registry, Telemetry}
   alias Oban.Crontab.Scheduler
   alias Oban.Queue.{Drainer, Producer}
   alias Oban.Queue.Supervisor, as: QueueSupervisor

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -11,7 +11,7 @@ defmodule Oban do
   use Supervisor
 
   alias Ecto.{Changeset, Multi}
-  alias Oban.{Config, Job, Midwife, Notifier, Query, Registry}
+  alias Oban.{Config, Job, Midwife, Notifier, Query, Telemetry, Registry}
   alias Oban.Crontab.Scheduler
   alias Oban.Queue.{Drainer, Producer}
   alias Oban.Queue.Supervisor, as: QueueSupervisor
@@ -185,7 +185,22 @@ defmodule Oban do
     children = children ++ Enum.map(plugins, &plugin_child_spec(&1, conf))
     children = children ++ Enum.map(queues, &QueueSupervisor.child_spec(&1, conf))
 
+    execute_init(conf)
+
     Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  defp execute_init(conf) do
+    measurements = %{
+      system_time: System.system_time()
+    }
+
+    metadata = %{
+      pid: self(),
+      config: conf
+    }
+
+    Telemetry.execute([:oban, :supervisor, :init], measurements, metadata)
   end
 
   defp plugin_child_spec({module, opts}, conf) do

--- a/lib/oban/queue/executor.ex
+++ b/lib/oban/queue/executor.ex
@@ -251,7 +251,7 @@ defmodule Oban.Queue.Executor do
     |> Map.take([:id, :args, :queue, :worker, :attempt, :max_attempts, :tags])
     |> Map.put(:job, job)
     |> Map.put(:prefix, conf.prefix)
-    |> Map.put(:name, conf.name)
+    |> Map.put(:config, conf)
   end
 
   defp job_with_unsaved_error(%__MODULE__{} = exec) do

--- a/lib/oban/queue/executor.ex
+++ b/lib/oban/queue/executor.ex
@@ -227,15 +227,21 @@ defmodule Oban.Queue.Executor do
 
   defp execute_stop(exec) do
     measurements = %{duration: exec.duration, queue_time: exec.queue_time}
+    metadata = Map.put(exec.meta, :state, exec.state)
 
-    Telemetry.execute([:oban, :job, :stop], measurements, exec.meta)
+    Telemetry.execute([:oban, :job, :stop], measurements, metadata)
   end
 
   defp execute_exception(exec) do
     measurements = %{duration: exec.duration, queue_time: exec.queue_time}
 
     meta =
-      Map.merge(exec.meta, %{kind: exec.kind, error: exec.error, stacktrace: exec.stacktrace})
+      Map.merge(exec.meta, %{
+        kind: exec.kind,
+        error: exec.error,
+        stacktrace: exec.stacktrace,
+        state: exec.state
+      })
 
     Telemetry.execute([:oban, :job, :exception], measurements, meta)
   end
@@ -245,6 +251,7 @@ defmodule Oban.Queue.Executor do
     |> Map.take([:id, :args, :queue, :worker, :attempt, :max_attempts, :tags])
     |> Map.put(:job, job)
     |> Map.put(:prefix, conf.prefix)
+    |> Map.put(:name, conf.name)
   end
 
   defp job_with_unsaved_error(%__MODULE__{} = exec) do

--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -29,11 +29,11 @@ defmodule Oban.Telemetry do
   provide the error type, the error itself, and the stacktrace. The following chart shows which
   metadata you can expect for each event:
 
-  | event        | measures                   | metadata                                    |
-  | ------------ | -------------------------- | ------------------------------------------- |
-  | `:start`     | `:system_time`             | `:job, :prefix`                             |
-  | `:stop`      | `:duration`, `:queue_time` | `:job, :prefix`                             |
-  | `:exception` | `:duration`, `:queue_time` | `:job, :prefix, :kind, :error, :stacktrace` |
+  | event        | measures                   | metadata                                            |
+  | ------------ | -------------------------- | --------------------------------------------------- |
+  | `:start`     | `:system_time`             | `:job, :config, :state`                             |
+  | `:stop`      | `:duration`, `:queue_time` | `:job, :config, :state`                             |
+  | `:exception` | `:duration`, `:queue_time` | `:job, :config, :state, :kind, :error, :stacktrace` |
 
   For `:exception` events the metadata includes details about what caused the failure. The `:kind`
   value is determined by how an error occurred. Here are the possible kinds:

--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -2,6 +2,21 @@ defmodule Oban.Telemetry do
   @moduledoc """
   Telemetry integration for event metrics, logging and error reporting.
 
+  ### Initialization Events
+
+  Oban emits the following telemetry event when an Oban supervisor is started:
+
+  * `[:oban, :supervisor, :init]` - when the Oban supervisor is started this will execute
+
+  The initialization event contains the following measurements:
+
+  * `:system_time` - The system's time when Oban was started
+
+  The initialization event contains the following metadata:
+
+  * `:config` - The configuration used for the Oban supervisor instance
+  * `:pid` - The PID of the supervisor instance
+
   ### Job Events
 
   Oban emits the following telemetry events for each job:
@@ -14,7 +29,7 @@ defmodule Oban.Telemetry do
   provide the error type, the error itself, and the stacktrace. The following chart shows which
   metadata you can expect for each event:
 
-  | event        | measures                   | metadata                                                                                                  |
+  | event        | measures                   | metadata                                    |
   | ------------ | -------------------------- | ------------------------------------------- |
   | `:start`     | `:system_time`             | `:job, :prefix`                             |
   | `:stop`      | `:duration`, `:queue_time` | `:job, :prefix`                             |

--- a/test/integration/telemetry_test.exs
+++ b/test/integration/telemetry_test.exs
@@ -67,7 +67,7 @@ defmodule Oban.Integration.TelemetryTest do
              prefix: "public",
              attempt: 1,
              max_attempts: 20,
-             name: ^name,
+             config: %Oban.Config{name: ^name},
              state: :success,
              tags: ["baz"]
            } = stop_meta
@@ -81,7 +81,7 @@ defmodule Oban.Integration.TelemetryTest do
              prefix: "public",
              attempt: 1,
              max_attempts: 20,
-             name: ^name,
+             config: %Oban.Config{name: ^name},
              kind: :error,
              error: %PerformError{},
              stacktrace: [],


### PR DESCRIPTION
Firstly, thanks for the awesome library! This was my first time using Oban and I must say it was super easy to get started and be productive :).

Next, I am currently working on the PromEx Oban plugin and while developing the plugin, I came across some situations where I needed additional metadata related to telemetry events. I added those additional bits to the job stop metadata. I also needed an `init` event (similarly to how Ecto has an 'init' event for repos) so that I can populate a drop down in Grafana for the Oban instance that you want to filter metrics for.

For reference if you want to see how I am using the Oban telemetry events: https://github.com/akoutmos/prom_ex/pull/21. More changes coming to that shortly as I will be using my fork for development.