### PR TITLE
Added config to producer & circuit metrics metadata

### DIFF
--- a/lib/oban/breaker.ex
+++ b/lib/oban/breaker.ex
@@ -22,6 +22,7 @@ defmodule Oban.Breaker do
   @spec trip_circuit(Exception.t(), Exception.stacktrace(), state_struct()) :: state_struct()
   def trip_circuit(exception, stacktrace, state) do
     meta = %{
+      config: state.conf,
       error: exception,
       message: error_message(exception),
       name: state.name,
@@ -38,8 +39,8 @@ defmodule Oban.Breaker do
   end
 
   @spec open_circuit(state_struct()) :: state_struct()
-  def open_circuit(%{circuit: _, name: name} = state) do
-    Telemetry.execute([:oban, :circuit, :open], %{}, %{name: name})
+  def open_circuit(%{circuit: _, name: name, conf: conf} = state) do
+    Telemetry.execute([:oban, :circuit, :open], %{}, %{name: name, config: conf})
 
     %{state | circuit: :enabled}
   end

--- a/lib/oban/queue/producer.ex
+++ b/lib/oban/queue/producer.ex
@@ -238,7 +238,7 @@ defmodule Oban.Queue.Producer do
     Telemetry.span(
       :producer,
       fn -> Query.stage_scheduled_jobs(conf, queue) end,
-      %{action: :deschedule, queue: queue}
+      %{action: :deschedule, queue: queue, config: conf}
     )
 
     state
@@ -272,7 +272,7 @@ defmodule Oban.Queue.Producer do
               |> start_jobs(state)
               |> Map.merge(running)
             end,
-            %{action: :dispatch, queue: queue}
+            %{action: :dispatch, queue: queue, config: conf}
           )
 
         {:noreply, %{state | cooldown_ref: nil, dispatched_at: system_now(), running: running}}

--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -51,16 +51,17 @@ defmodule Oban.Telemetry do
   * `[:oban, :producer, :start | :stop | :exception]` — when a producer deschedules or dispatches
     new jobs
 
-  | event        | measures       | metadata          |
-  | ------------ | -------------- | ----------------- |
-  | `:start`     | `:system_time` | `:action, :queue` |
-  | `:stop`      | `:duration`    | `:action, :queue` |
-  | `:exception` | `:duration`    | `:action, :queue` |
+  | event        | measures       | metadata                   |
+  | ------------ | -------------- | -------------------------- |
+  | `:start`     | `:system_time` | `:action, :queue, :config` |
+  | `:stop`      | `:duration`    | `:action, :queue, :config` |
+  | `:exception` | `:duration`    | `:action, :queue, :config` |
 
   Metadata
 
   * `:action` — one of `:deschedule` or `:dispatch`
   * `:queue` — the name of the queue as a string, e.g. "default" or "mailers"
+  * `:config` — the config of the Oban supervisor that the producer is for
 
   ### Circuit Events
 

--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -69,10 +69,10 @@ defmodule Oban.Telemetry do
   crashing the entire supervision tree. Processes emit a `[:oban, :circuit, :trip]` event when a
   circuit is tripped and `[:oban, :circuit, :open]` when the breaker is subsequently opened again.
 
-  | event                      | measures | metadata                               |
-  | -------------------------- | -------- | -------------------------------------- |
-  | `[:oban, :circuit, :trip]` |          | `:error, :message, :name, :stacktrace` |
-  | `[:oban, :circuit, :open]` |          | `:name`                                |
+  | event                      | measures | metadata                                        |
+  | -------------------------- | -------- | ----------------------------------------------- |
+  | `[:oban, :circuit, :trip]` |          | `:error, :message, :name, :stacktrace, :config` |
+  | `[:oban, :circuit, :open]` |          | `:name, :config`                                |
 
   Metadata
 
@@ -80,6 +80,7 @@ defmodule Oban.Telemetry do
   * `:name` — the registered name of the process that tripped a circuit, i.e. `Oban.Notifier`
   * `:message` — a formatted error message describing what went wrong
   * `:stacktrace` — exception stacktrace, when available
+  * `:config` — the config of the Oban supervisor that the producer is for
 
   ## Default Logger
 


### PR DESCRIPTION
Continuing my work on the PromEx plugin, I came across a situation where I was unable to create accurate metrics for produced jobs when I had multiple Oban supervisors running since some of the queue names overlap, but I don't have the configuration available to determine which Oban supervisor this producer event was for.

This PR adds the config value to the producer event :).

I also added it to the circuit breaker events as it is nice to have that metric label there as well for reporting.