### PR TITLE
Adding telemetry events to the plugins

### DIFF
--- a/lib/oban/plugins/cron.ex
+++ b/lib/oban/plugins/cron.ex
@@ -29,6 +29,12 @@ defmodule Oban.Plugins.Cron do
 
   [tzdata]: https://hexdocs.pm/tzdata
   [perjob]: oban.html#module-periodic-jobs
+
+  ## Instrumenting with Telemetry
+
+  The `Oban.Plugins.Cron` plugin adds the following metadata to the `[:oban, :plugin, :stop]` event:
+
+  * :jobs - a list of jobs that were inserted into the database for processes
   """
 
   use GenServer

--- a/lib/oban/plugins/cron.ex
+++ b/lib/oban/plugins/cron.ex
@@ -128,19 +128,18 @@ defmodule Oban.Plugins.Cron do
 
     start_metadata = %{config: state.conf, plugin: __MODULE__}
 
-    :telemetry.span(
-      [:oban, :plugin],
-      start_metadata,
-      fn ->
-        case lock_and_insert_jobs(state) do
-          {:ok, inserted_jobs} when is_list(inserted_jobs) ->
-            {:ok, Map.put(start_metadata, :jobs, inserted_jobs)}
+    :telemetry.span([:oban, :plugin], start_metadata, fn ->
+      case lock_and_insert_jobs(state) do
+        {:ok, inserted_jobs} when is_list(inserted_jobs) ->
+          {:ok, Map.put(start_metadata, :jobs, inserted_jobs)}
 
-          error ->
-            {:error, Map.put(start_metadata, :error, error)}
-        end
+        {:ok, false} ->
+          {:ok, Map.put(start_metadata, :jobs, [])}
+
+        error ->
+          {:error, Map.put(start_metadata, :error, error)}
       end
-    )
+    end)
 
     {:noreply, state}
   end

--- a/lib/oban/plugins/cron.ex
+++ b/lib/oban/plugins/cron.ex
@@ -29,25 +29,6 @@ defmodule Oban.Plugins.Cron do
 
   [tzdata]: https://hexdocs.pm/tzdata
   [perjob]: oban.html#module-periodic-jobs
-
-  ## Instrumenting with Telemetry
-
-  Given that all the Oban plugins emit telemetry events under the `[:oban, :plugin, *]` pattern,
-  you can filter out for `Cron` specific events by filtering for telemetry events with a metadata
-  key/value of `plugin: Oban.Plugins.Cron`. Oban emits the following telemetry event whenever the
-  `Cron` plugin executes.
-
-  * `[:oban, :plugin, :start]` — at the point that the `Cron` plugin begins evaluating what cron jobs to enqueue
-  * `[:oban, :plugin, :stop]` — after the `Cron` plugin has enqueued any cron jobs
-  * `[:oban, :plugin, :exception]` — after the `Cron` plugin fails to insert cron jobs
-
-  The following chart shows which metadata you can expect for each event:
-
-  | event        | measures       | metadata                                       |
-  | ------------ | ---------------| -----------------------------------------------|
-  | `:start`     | `:system_time` | `:config, :plugin`                             |
-  | `:stop`      | `:duration`    | `:jobs, :config, :plugin`                      |
-  | `:exception` | `:duration`    | `:error, :kind, :stacktrace, :config, :plugin` |
   """
 
   use GenServer

--- a/lib/oban/plugins/pruner.ex
+++ b/lib/oban/plugins/pruner.ex
@@ -23,6 +23,12 @@ defmodule Oban.Plugins.Pruner do
   * `:limit` — the maximum number of jobs to prune at one time. The default is 10,000 to prevent
     request timeouts. Applications that steadily generate more than 10k jobs a minute should increase
     this value.
+
+  ## Instrumenting with Telemetry
+
+  The `Oban.Plugins.Pruner` plugin adds the following metadata to the `[:oban, :plugin, :stop]` event:
+
+  * :pruned_count - the number of jobs that were pruned from the database
   """
 
   use GenServer

--- a/lib/oban/plugins/pruner.ex
+++ b/lib/oban/plugins/pruner.ex
@@ -23,25 +23,6 @@ defmodule Oban.Plugins.Pruner do
   * `:limit` — the maximum number of jobs to prune at one time. The default is 10,000 to prevent
     request timeouts. Applications that steadily generate more than 10k jobs a minute should increase
     this value.
-
-  ## Instrumenting with Telemetry
-
-  Given that all the Oban plugins emit telemetry events under the `[:oban, :plugin, *]` pattern,
-  you can filter out for `Pruner` specific events by filtering for telemetry events with a metadata
-  key/value of `plugin: Oban.Plugins.Pruner`. Oban emits the following telemetry event whenever the
-  `Pruner` plugin executes.
-
-  * `[:oban, :plugin, :start]` — at the point that the `Pruner` plugin begins evaluating what old jobs to prune
-  * `[:oban, :plugin, :stop]` — after the `Pruner` plugin has deleted any old jobs
-  * `[:oban, :plugin, :exception]` — after the `Pruner` plugin fails to delete old jobs
-
-  The following chart shows which metadata you can expect for each event:
-
-  | event        | measures       | metadata                                       |
-  | ------------ | ---------------| -----------------------------------------------|
-  | `:start`     | `:system_time` | `:config, :plugin`                             |
-  | `:stop`      | `:duration`    | `:pruned_count, :config, :plugin`         |
-  | `:exception` | `:duration`    | `:error, :kind, :stacktrace, :config, :plugin` |
   """
 
   use GenServer

--- a/lib/oban/plugins/pruner.ex
+++ b/lib/oban/plugins/pruner.ex
@@ -107,7 +107,7 @@ defmodule Oban.Plugins.Pruner do
           {:ok, {pruned_count, _}} ->
             {:ok, Map.put(start_metadata, :pruned_count, pruned_count)}
 
-          false ->
+          {:ok, false} ->
             {:ok, Map.put(start_metadata, :pruned_count, 0)}
 
           error ->

--- a/lib/oban/plugins/stager.ex
+++ b/lib/oban/plugins/stager.ex
@@ -9,25 +9,6 @@ defmodule Oban.Plugins.Stager do
   * `:interval` - the number of milliseconds between database updates. This is directly tied to
     the resolution of _scheduled_ jobs. For example, with an `interval` of `5_000ms`, scheduled
     jobs are checked every 5 seconds. The default is `1_000ms`.
-
-  ## Instrumenting with Telemetry
-
-  Given that all the Oban plugins emit telemetry events under the `[:oban, :plugin, *]` pattern,
-  you can filter out for `Stager` specific events by filtering for telemetry events with a metadata
-  key/value of `plugin: Oban.Plugins.Stager`. Oban emits the following telemetry event whenever the
-  `Stager` plugin executes.
-
-  * `[:oban, :plugin, :start]` — at the point that the `Stager` plugin begins evaluating what jobs need to be staged
-  * `[:oban, :plugin, :stop]` — after the `Stager` plugin has completed transition jobs to the available state
-  * `[:oban, :plugin, :exception]` — after the `Stager` plugin fails to transition jobs to the available state
-
-  The following chart shows which metadata you can expect for each event:
-
-  | event        | measures       | metadata                                       |
-  | ------------ | ---------------| -----------------------------------------------|
-  | `:start`     | `:system_time` | `:config, :plugin`                             |
-  | `:stop`      | `:duration`    | `:staged_count, :config, :plugin`         |
-  | `:exception` | `:duration`    | `:error, :kind, :stacktrace, :config, :plugin` |
   """
 
   use GenServer

--- a/lib/oban/plugins/stager.ex
+++ b/lib/oban/plugins/stager.ex
@@ -9,6 +9,12 @@ defmodule Oban.Plugins.Stager do
   * `:interval` - the number of milliseconds between database updates. This is directly tied to
     the resolution of _scheduled_ jobs. For example, with an `interval` of `5_000ms`, scheduled
     jobs are checked every 5 seconds. The default is `1_000ms`.
+
+  ## Instrumenting with Telemetry
+
+  The `Oban.Plugins.Stager` plugin adds the following metadata to the `[:oban, :plugin, :stop]` event:
+
+  * :staged_count - the number of jobs that were staged in the database
   """
 
   use GenServer

--- a/lib/oban/query.ex
+++ b/lib/oban/query.ex
@@ -90,7 +90,7 @@ defmodule Oban.Query do
       |> select([j], j.queue)
 
     case Repo.update_all(conf, query, set: [state: "available"]) do
-      {0, _} -> []
+      {0, []} -> []
       {count, queues} -> {count, queues}
     end
   end

--- a/lib/oban/query.ex
+++ b/lib/oban/query.ex
@@ -78,7 +78,7 @@ defmodule Oban.Query do
     end)
   end
 
-  @spec stage_scheduled_jobs(Config.t(), opts :: keyword()) :: [binary()]
+  @spec stage_scheduled_jobs(Config.t(), opts :: keyword()) :: {non_neg_integer(), [binary()]}
   def stage_scheduled_jobs(%Config{} = conf, opts \\ []) do
     max_scheduled_at = Keyword.get(opts, :max_scheduled_at, utc_now())
 

--- a/lib/oban/query.ex
+++ b/lib/oban/query.ex
@@ -90,7 +90,7 @@ defmodule Oban.Query do
       |> select([j], j.queue)
 
     case Repo.update_all(conf, query, set: [state: "available"]) do
-      {0, []} -> []
+      {0, _} -> {0, []}
       {count, queues} -> {count, queues}
     end
   end

--- a/lib/oban/query.ex
+++ b/lib/oban/query.ex
@@ -91,7 +91,7 @@ defmodule Oban.Query do
 
     case Repo.update_all(conf, query, set: [state: "available"]) do
       {0, _} -> []
-      {_, queues} -> queues
+      {count, queues} -> {count, queues}
     end
   end
 

--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -82,6 +82,27 @@ defmodule Oban.Telemetry do
   * `:stacktrace` — exception stacktrace, when available
   * `:config` — the config of the Oban supervisor that the producer is for
 
+  ### Plugin Events
+
+  All the Oban plugins emit telemetry events under the `[:oban, :plugin, *]` pattern (where `*` is either `:start`, `:stop`, or `:exception`).
+  You can filter out for plugin events by looking into the metadata of the event and checking the value of `:plugin`. The `:plugin` key will contain
+  the module name of the plugin module that emitted the event. For example, to get `Oban.Plugins.Cron` specific events, you can filter for telemetry events with a metadata
+  key/value of `plugin: Oban.Plugins.Cron`.
+
+  Oban emits the following telemetry event whenever a plugin executes.
+
+  * `[:oban, :plugin, :start]` — when the plugin beings performing its work
+  * `[:oban, :plugin, :stop]` —  after the plugin completes its work
+  * `[:oban, :plugin, :exception]` — when the plugin encounters an error
+
+  The following chart shows which metadata you can expect for each event:
+
+  | event        | measures       | metadata                                       |
+  | ------------ | ---------------| -----------------------------------------------|
+  | `:start`     | `:system_time` | `:config, :plugin`                             |
+  | `:stop`      | `:duration`    | `:jobs, :config, :plugin`                      |
+  | `:exception` | `:duration`    | `:error, :kind, :stacktrace, :config, :plugin` |
+
   ## Default Logger
 
   A default log handler that emits structured JSON is provided, see `attach_default_logger/0` for

--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -84,10 +84,12 @@ defmodule Oban.Telemetry do
 
   ### Plugin Events
 
-  All the Oban plugins emit telemetry events under the `[:oban, :plugin, *]` pattern (where `*` is either `:start`, `:stop`, or `:exception`).
-  You can filter out for plugin events by looking into the metadata of the event and checking the value of `:plugin`. The `:plugin` key will contain
-  the module name of the plugin module that emitted the event. For example, to get `Oban.Plugins.Cron` specific events, you can filter for telemetry events with a metadata
-  key/value of `plugin: Oban.Plugins.Cron`.
+  All the Oban plugins emit telemetry events under the `[:oban, :plugin, *]` pattern (where `*` is
+  either `:start`, `:stop`, or `:exception`).  You can filter out for plugin events by looking into
+  the metadata of the event and checking the value of `:plugin`. The `:plugin` key will contain the
+  module name of the plugin module that emitted the event. For example, to get `Oban.Plugins.Cron`
+  specific events, you can filter for telemetry events with a metadata key/value of
+  `plugin: Oban.Plugins.Cron`.
 
   Oban emits the following telemetry event whenever a plugin executes.
 

--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -85,13 +85,15 @@ defmodule Oban.Telemetry do
   ### Plugin Events
 
   All the Oban plugins emit telemetry events under the `[:oban, :plugin, *]` pattern (where `*` is
-  either `:start`, `:stop`, or `:exception`).  You can filter out for plugin events by looking into
+  either `:start`, `:stop`, or `:exception`). You can filter out for plugin events by looking into
   the metadata of the event and checking the value of `:plugin`. The `:plugin` key will contain the
   module name of the plugin module that emitted the event. For example, to get `Oban.Plugins.Cron`
   specific events, you can filter for telemetry events with a metadata key/value of
   `plugin: Oban.Plugins.Cron`.
 
-  Oban emits the following telemetry event whenever a plugin executes.
+  Oban emits the following telemetry event whenever a plugin executes (be sure to check the
+  documentation for each plugin as each plugin can also add additional metadata specific to
+  the plugin):
 
   * `[:oban, :plugin, :start]` — when the plugin beings performing its work
   * `[:oban, :plugin, :stop]` —  after the plugin completes its work
@@ -102,7 +104,7 @@ defmodule Oban.Telemetry do
   | event        | measures       | metadata                                       |
   | ------------ | ---------------| -----------------------------------------------|
   | `:start`     | `:system_time` | `:config, :plugin`                             |
-  | `:stop`      | `:duration`    | `:jobs, :config, :plugin`                      |
+  | `:stop`      | `:duration`    | `:config, :plugin`                             |
   | `:exception` | `:duration`    | `:error, :kind, :stacktrace, :config, :plugin` |
 
   ## Default Logger

--- a/test/integration/isolation_test.exs
+++ b/test/integration/isolation_test.exs
@@ -10,7 +10,7 @@ defmodule Oban.Integration.IsolationTest do
 
     insert!(name, %{ref: 1, action: "OK"}, [])
 
-    assert_enqueued [worker: Worker], 250
+    assert_enqueued worker: Worker
   end
 
   test "inserting and executing unique jobs with a custom prefix" do

--- a/test/integration/isolation_test.exs
+++ b/test/integration/isolation_test.exs
@@ -10,7 +10,7 @@ defmodule Oban.Integration.IsolationTest do
 
     insert!(name, %{ref: 1, action: "OK"}, [])
 
-    assert_enqueued worker: Worker
+    assert_enqueued [worker: Worker], 250
   end
 
   test "inserting and executing unique jobs with a custom prefix" do

--- a/test/oban/plugins/pruner_test.exs
+++ b/test/oban/plugins/pruner_test.exs
@@ -35,8 +35,7 @@ defmodule Oban.Plugins.PrunerTest do
 
     assert_receive {:event, :start, %{system_time: _}, %{config: _, plugin: Pruner}}
 
-    assert_receive {:event, :stop, %{duration: _},
-                    %{config: _, plugin: Pruner, jobs_pruned_count: 4}}
+    assert_receive {:event, :stop, %{duration: _}, %{config: _, plugin: Pruner, pruned_count: 4}}
   after
     :telemetry.detach("plugin-pruner-handler")
   end

--- a/test/oban/plugins/stager_test.exs
+++ b/test/oban/plugins/stager_test.exs
@@ -2,11 +2,24 @@ defmodule Oban.Plugins.StagerTest do
   use Oban.Case
 
   alias Oban.Plugins.Stager
-  alias Oban.Registry
+  alias Oban.{PluginTelemetryHandler, Registry}
 
   @moduletag :integration
 
   test "descheduling jobs to make them available for execution" do
+    events = [
+      [:oban, :plugin, :start],
+      [:oban, :plugin, :stop],
+      [:oban, :plugin, :exception]
+    ]
+
+    :telemetry.attach_many(
+      "plugin-stager-handler",
+      events,
+      &PluginTelemetryHandler.handle/4,
+      self()
+    )
+
     job_1 = insert!([ref: 1, action: "OK"], schedule_in: -9, queue: :alpha)
     job_2 = insert!([ref: 2, action: "OK"], schedule_in: -5, queue: :alpha)
     job_3 = insert!([ref: 3, action: "OK"], schedule_in: 10, queue: :alpha)
@@ -18,6 +31,13 @@ defmodule Oban.Plugins.StagerTest do
       assert %{state: "available"} = Repo.reload(job_2)
       assert %{state: "scheduled"} = Repo.reload(job_3)
     end)
+
+    assert_receive {:event, :start, %{system_time: _}, %{config: _, plugin: Stager}}
+
+    assert_receive {:event, :stop, %{duration: _},
+                    %{config: _, plugin: Stager, jobs_staged_count: 2}}
+  after
+    :telemetry.detach("plugin-stager-handler")
   end
 
   test "translating poll_interval config into plugin usage" do

--- a/test/oban/plugins/stager_test.exs
+++ b/test/oban/plugins/stager_test.exs
@@ -34,8 +34,7 @@ defmodule Oban.Plugins.StagerTest do
 
     assert_receive {:event, :start, %{system_time: _}, %{config: _, plugin: Stager}}
 
-    assert_receive {:event, :stop, %{duration: _},
-                    %{config: _, plugin: Stager, jobs_staged_count: 2}}
+    assert_receive {:event, :stop, %{duration: _}, %{config: _, plugin: Stager, staged_count: 2}}
   after
     :telemetry.detach("plugin-stager-handler")
   end

--- a/test/oban/plugins/stager_test.exs
+++ b/test/oban/plugins/stager_test.exs
@@ -19,7 +19,7 @@ defmodule Oban.Plugins.StagerTest do
       &PluginTelemetryHandler.handle/4,
       self()
     )
-    
+
     then = DateTime.add(DateTime.utc_now(), -30)
 
     job_1 = insert!([ref: 1, action: "OK"], inserted_at: then, schedule_in: -9, queue: :alpha)

--- a/test/support/plugin_telemetry_handler.ex
+++ b/test/support/plugin_telemetry_handler.ex
@@ -1,0 +1,18 @@
+defmodule Oban.PluginTelemetryHandler do
+  @moduledoc """
+  This utility module is used during plugin tests to capture telemetry events
+  and send them back to the test processes that registered the handler.
+  """
+
+  def handle([:oban, :plugin, :start], measurements, meta, pid) do
+    send(pid, {:event, :start, measurements, meta})
+  end
+
+  def handle([:oban, :plugin, :stop], measurements, meta, pid) do
+    send(pid, {:event, :stop, measurements, meta})
+  end
+
+  def handle([:oban, :plugin, :exception], measurements, meta, pid) do
+    send(pid, {:event, :exception, measurements, meta})
+  end
+end


### PR DESCRIPTION
Currently the PR only has telemetry events for the Cron plugin, but the Stager and Pruner changes are under way.