### PR TITLE
Fix typo in "mix ci" alias

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -166,7 +166,7 @@ defmodule Oban.MixProject do
       "test.setup": ["ecto.create", "ecto.migrate"],
       ci: [
         "format --check-formatted",
-        "deps.unlock -- check-unused",
+        "deps.unlock --check-unused",
         "credo --strict",
         "test --raise",
         "dialyzer"


### PR DESCRIPTION
I think this command was silently failing with exit code 0 due to this typo.

Thank you for reviewing.