### PR TITLE
Support Oban.insert_all/4 with a changes function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,8 @@ end
   raised as an error. When `insert!/2` was called in a transaction the error
   could be `:rollback`, which wasn't a valid error.
 
+- [Oban] Update `insert_all/4` to accept a changes function.
+
 ## [2.3.4] — 2020-12-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,8 +139,6 @@ end
   raised as an error. When `insert!/2` was called in a transaction the error
   could be `:rollback`, which wasn't a valid error.
 
-- [Oban] Update `insert_all/4` to accept a changes function.
-
 ## [2.3.4] — 2020-12-02
 
 ### Fixed

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -343,7 +343,7 @@ defmodule Oban do
 
   ## Example
 
-      changesets = Enum.map(0..100, MyApp.Worker.new(%{id: &1}))
+      changesets = Enum.map(0..100, &MyApp.Worker.new(%{id: &1}))
 
       Ecto.Multi.new()
       |> Oban.insert_all(:jobs, changesets)
@@ -354,7 +354,8 @@ defmodule Oban do
           name(),
           multi :: Multi.t(),
           multi_name :: Multi.name(),
-          changesets_or_wrapper :: [job_changeset()] | %{changesets: [job_changeset()]}
+          changesets_or_wrapper ::
+            [job_changeset()] | %{changesets: [job_changeset()]} | (map -> [job_changeset()])
         ) :: Multi.t()
   def insert_all(name \\ __MODULE__, multi, multi_name, changesets_or_wrapper)
 
@@ -362,7 +363,8 @@ defmodule Oban do
     insert_all(name, multi, multi_name, changesets)
   end
 
-  def insert_all(name, %Multi{} = multi, multi_name, changesets) when is_list(changesets) do
+  def insert_all(name, %Multi{} = multi, multi_name, changesets)
+      when is_list(changesets) or is_function(changesets, 1) do
     name
     |> config()
     |> Query.insert_all_jobs(multi, multi_name, changesets)

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -54,7 +54,7 @@ defmodule Oban do
 
   @type drain_result :: %{failure: non_neg_integer(), success: non_neg_integer()}
 
-  @type job_changeset :: Changeset.t(Job.t())
+  @type changesets_or_wrapper :: Job.changeset_list() | %{changesets: Job.changeset_list()}
 
   @version Mix.Project.config()[:version]
 
@@ -236,8 +236,8 @@ defmodule Oban do
       {:ok, job} = Oban.insert(MyApp.Worker.new(%{id: 1}, unique: [period: 30]))
   """
   @doc since: "0.7.0"
-  @spec insert(name(), job_changeset()) ::
-          {:ok, Job.t()} | {:error, job_changeset()} | {:error, term()}
+  @spec insert(name(), Job.changeset()) ::
+          {:ok, Job.t()} | {:error, Job.changeset()} | {:error, term()}
   def insert(name \\ __MODULE__, %Changeset{} = changeset) do
     name
     |> config()
@@ -264,7 +264,7 @@ defmodule Oban do
           name,
           multi :: Multi.t(),
           multi_name :: Multi.name(),
-          changeset_or_fun :: job_changeset() | fun()
+          changeset_or_fun :: Job.changeset() | Job.changeset_fun()
         ) :: Multi.t()
   def insert(name \\ __MODULE__, multi, multi_name, changeset_or_fun)
 
@@ -288,7 +288,7 @@ defmodule Oban do
       job = Oban.insert!(MyApp.Worker.new(%{id: 1}))
   """
   @doc since: "0.7.0"
-  @spec insert!(name(), job_changeset()) :: Job.t()
+  @spec insert!(name(), Job.changeset()) :: Job.t()
   def insert!(name \\ __MODULE__, %Changeset{} = changeset) do
     case insert(name, changeset) do
       {:ok, job} ->
@@ -320,10 +320,7 @@ defmodule Oban do
       |> Oban.insert_all()
   """
   @doc since: "0.9.0"
-  @spec insert_all(
-          name(),
-          changesets_or_wrapper :: [job_changeset()] | %{changesets: [job_changeset()]}
-        ) :: [Job.t()]
+  @spec insert_all(name(), changesets_or_wrapper()) :: [Job.t()]
   def insert_all(name \\ __MODULE__, changesets_or_wrapper)
 
   def insert_all(name, %{changesets: [_ | _] = changesets}) do
@@ -354,8 +351,7 @@ defmodule Oban do
           name(),
           multi :: Multi.t(),
           multi_name :: Multi.name(),
-          changesets_or_wrapper ::
-            [job_changeset()] | %{changesets: [job_changeset()]} | (map -> [job_changeset()])
+          changesets_or_wrapper() | Job.changeset_list_fun()
         ) :: Multi.t()
   def insert_all(name \\ __MODULE__, multi, multi_name, changesets_or_wrapper)
 

--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -72,6 +72,11 @@ defmodule Oban.Job do
           unsaved_error: %{kind: atom(), reason: term(), stacktrace: Exception.stacktrace()}
         }
 
+  @type changeset :: Ecto.Changeset.t(t())
+  @type changeset_fun :: (map() -> changeset())
+  @type changeset_list :: [changeset()]
+  @type changeset_list_fun :: (map() -> changeset_list())
+
   schema "oban_jobs" do
     field :state, :string, default: "available"
     field :queue, :string, default: "default"

--- a/lib/oban/query.ex
+++ b/lib/oban/query.ex
@@ -71,10 +71,21 @@ defmodule Oban.Query do
     end
   end
 
-  @spec insert_all_jobs(Config.t(), Multi.t(), Multi.name(), [Changeset.t()]) :: Multi.t()
+  @spec insert_all_jobs(
+          Config.t(),
+          Multi.t(),
+          Multi.name(),
+          [Changeset.t()] | (map -> [Changeset.t()])
+        ) :: Multi.t()
   def insert_all_jobs(conf, multi, name, changesets) when is_list(changesets) do
     Multi.run(multi, name, fn repo, _changes ->
       {:ok, insert_all_jobs(%{conf | repo: repo}, changesets)}
+    end)
+  end
+
+  def insert_all_jobs(conf, multi, name, changeset_fn) when is_function(changeset_fn, 1) do
+    Multi.run(multi, name, fn repo, changes ->
+      {:ok, insert_all_jobs(%{conf | repo: repo}, changeset_fn.(changes))}
     end)
   end
 

--- a/lib/oban/query.ex
+++ b/lib/oban/query.ex
@@ -41,13 +41,18 @@ defmodule Oban.Query do
     )
   end
 
-  @spec fetch_or_insert_job(Config.t(), Changeset.t()) :: {:ok, Job.t()} | {:error, term()}
+  @spec fetch_or_insert_job(Config.t(), Job.changeset()) :: {:ok, Job.t()} | {:error, term()}
   def fetch_or_insert_job(conf, changeset) do
     fun = fn -> insert_unique(conf, changeset) end
     with {:ok, result} <- Repo.transaction(conf, fun), do: result
   end
 
-  @spec fetch_or_insert_job(Config.t(), Multi.t(), Multi.name(), fun() | Changeset.t()) ::
+  @spec fetch_or_insert_job(
+          Config.t(),
+          Multi.t(),
+          Multi.name(),
+          Job.changeset() | Job.changeset_fun()
+        ) ::
           Multi.t()
   def fetch_or_insert_job(conf, multi, name, fun) when is_function(fun, 1) do
     Multi.run(multi, name, fn repo, changes ->
@@ -61,7 +66,7 @@ defmodule Oban.Query do
     end)
   end
 
-  @spec insert_all_jobs(Config.t(), [Changeset.t(Job.t())]) :: [Job.t()]
+  @spec insert_all_jobs(Config.t(), Job.changeset_list()) :: [Job.t()]
   def insert_all_jobs(%Config{} = conf, changesets) when is_list(changesets) do
     entries = Enum.map(changesets, &Job.to_map/1)
 
@@ -75,7 +80,7 @@ defmodule Oban.Query do
           Config.t(),
           Multi.t(),
           Multi.name(),
-          [Changeset.t()] | (map -> [Changeset.t()])
+          Job.changeset_list() | Job.changeset_list_fun()
         ) :: Multi.t()
   def insert_all_jobs(conf, multi, name, changesets) when is_list(changesets) do
     Multi.run(multi, name, fn repo, _changes ->
@@ -83,9 +88,9 @@ defmodule Oban.Query do
     end)
   end
 
-  def insert_all_jobs(conf, multi, name, changeset_fn) when is_function(changeset_fn, 1) do
+  def insert_all_jobs(conf, multi, name, changesets_fun) when is_function(changesets_fun, 1) do
     Multi.run(multi, name, fn repo, changes ->
-      {:ok, insert_all_jobs(%{conf | repo: repo}, changeset_fn.(changes))}
+      {:ok, insert_all_jobs(%{conf | repo: repo}, changesets_fun.(changes))}
     end)
   end
 

--- a/lib/oban/worker.ex
+++ b/lib/oban/worker.ex
@@ -212,7 +212,7 @@ defmodule Oban.Worker do
 
   See `Oban.Job.new/2` for the available options.
   """
-  @callback new(args :: Job.args(), opts :: [Job.option()]) :: Ecto.Changeset.t()
+  @callback new(args :: Job.args(), opts :: [Job.option()]) :: Job.changeset()
 
   @doc """
   Calculate the execution backoff.


### PR DESCRIPTION
- Ecto.Multi supports `insert_all` where the changeset list can be provided as a function/1 that reads from the changes. This adds the same to `Oban.insert_all/4`.