### PR TITLE
Align migration module with command in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ mix ecto.gen.migration upgrade_oban_jobs_to_v10
 Next, call `Oban.Migrations` in the generated migration:
 
 ```elixir
-defmodule MyApp.Repo.Migrations.UpdateObanJobsToV9 do
+defmodule MyApp.Repo.Migrations.UpdateObanJobsToV10 do
   use Ecto.Migration
 
   defdelegate up, to: Oban.Migrations


### PR DESCRIPTION
The command run was `mix ecto.gen.migration upgrade_oban_jobs_to_v10` which would generate `Repo.Migrations.UpdateObanJobsToV10`