### PR TITLE
Individually validate crontab workers and raise descriptive errors

### DIFF
--- a/lib/oban/plugins/cron.ex
+++ b/lib/oban/plugins/cron.ex
@@ -179,7 +179,8 @@ defmodule Oban.Plugins.Cron do
     end
 
     unless Keyword.keyword?(opts) do
-      raise ArgumentError, "#{inspect(worker)} options must be a keyword list, got: #{inspect(opts)}"
+      raise ArgumentError,
+            "#{inspect(worker)} options must be a keyword list, got: #{inspect(opts)}"
     end
   end
 

--- a/lib/oban/plugins/cron.ex
+++ b/lib/oban/plugins/cron.ex
@@ -153,9 +153,7 @@ defmodule Oban.Plugins.Cron do
 
   defp validate_opt!({:crontab, crontab}) do
     unless is_list(crontab) do
-      raise ArgumentError,
-            "expected :crontab to be a list of {expression, worker} or " <>
-              "{expression, worker, options} tuples"
+      raise ArgumentError, "expected :crontab to be a list, got: #{inspect(crontab)}"
     end
 
     Enum.each(crontab, &validate_crontab!/1)
@@ -181,7 +179,7 @@ defmodule Oban.Plugins.Cron do
     end
 
     unless Keyword.keyword?(opts) do
-      raise ArgumentError, "options for #{inspect(worker)} must be as a keyword list"
+      raise ArgumentError, "#{inspect(worker)} options must be a keyword list, got: #{inspect(opts)}"
     end
   end
 
@@ -191,8 +189,8 @@ defmodule Oban.Plugins.Cron do
 
   defp validate_crontab!(invalid) do
     raise ArgumentError,
-          "#{inspect(invalid)} is invalid cronjob declaration, expected {expression, worker} or " <>
-            "{expression, worker, options} tuples"
+          "expected crontab entry to be an {expression, worker} or " <>
+            "{expression, worker, options} tuple, got: #{inspect(invalid)}"
   end
 
   # Inserting Helpers

--- a/lib/oban/plugins/cron.ex
+++ b/lib/oban/plugins/cron.ex
@@ -170,9 +170,17 @@ defmodule Oban.Plugins.Cron do
   defp valid_crontab?({expression, worker, opts}) do
     %Expression{} = Expression.parse!(expression)
 
-    Code.ensure_loaded?(worker) and
-      function_exported?(worker, :perform, 1) and
-      Keyword.keyword?(opts)
+    !Code.ensure_loaded?(worker) and
+      raise ArgumentError, "#{inspect(worker)} worker is not found or can't be loaded"
+
+    !function_exported?(worker, :perform, 1) and
+      raise ArgumentError, "#{inspect(worker)} worker does not implement `perform/1` callback"
+
+    !Keyword.keyword?(opts) and
+      raise ArgumentError,
+            "crontab options to #{inspect(worker)} worker should be provided as a keyword list"
+
+    true
   end
 
   defp valid_crontab?({expression, worker}), do: valid_crontab?({expression, worker, []})

--- a/test/oban/plugins/cron_test.exs
+++ b/test/oban/plugins/cron_test.exs
@@ -11,7 +11,7 @@ defmodule Oban.Plugins.CronTest do
 
   describe "validate/1" do
     test ":crontab is validated as a list of cron job expressions" do
-      assert_raise ArgumentError, "expected :crontab to be a list", fn ->
+      assert_raise ArgumentError, ~r/expected :crontab to be a list/, fn ->
         Cron.validate!(crontab: %{worker1: "foo"})
       end
     end
@@ -38,7 +38,7 @@ defmodule Oban.Plugins.CronTest do
     end
 
     test "worker options format is validated" do
-      assert_raise ArgumentError, ~r/Worker options must be as a keyword list/, fn ->
+      assert_raise ArgumentError, ~r/Worker options must be a keyword list/, fn ->
         Cron.validate!(crontab: [{"* * * * *", Worker, %{foo: "bar"}}])
       end
     end

--- a/test/oban/plugins/cron_test.exs
+++ b/test/oban/plugins/cron_test.exs
@@ -11,19 +11,15 @@ defmodule Oban.Plugins.CronTest do
 
   describe "validate/1" do
     test ":crontab is validated as a list of cron job expressions" do
-      assert_raise ArgumentError,
-                   "expected :crontab to be a list of {expression, worker} or {expression, worker, options} tuples",
-                   fn ->
-                     Cron.validate!(crontab: %{worker1: "foo"})
-                   end
+      assert_raise ArgumentError, "expected :crontab to be a list", fn ->
+        Cron.validate!(crontab: %{worker1: "foo"})
+      end
     end
 
     test "job format is validated" do
-      assert_raise ArgumentError,
-                   "\"* * * * *\" is invalid cronjob declaration, expected {expression, worker} or {expression, worker, options} tuples",
-                   fn ->
-                     Cron.validate!(crontab: ["* * * * *"])
-                   end
+      assert_raise ArgumentError, ~r/expected crontab entry to be an {expression, worker}/, fn ->
+        Cron.validate!(crontab: ["* * * * *"])
+      end
 
       assert_valid(crontab: [{"* * * * *", Worker}])
       assert_valid(crontab: [{"* * * * *", Worker, queue: "special"}])
@@ -36,19 +32,15 @@ defmodule Oban.Plugins.CronTest do
     end
 
     test "worker perform/1 callback is validated" do
-      assert_raise ArgumentError,
-                   "Oban.Plugins.CronTest.WorkerWithoutPerform does not implement `perform/1` callback",
-                   fn ->
-                     Cron.validate!(crontab: [{"* * * * *", WorkerWithoutPerform}])
-                   end
+      assert_raise ArgumentError, ~r|WorkerWithoutPerform does not implement `perform/1`|, fn ->
+        Cron.validate!(crontab: [{"* * * * *", WorkerWithoutPerform}])
+      end
     end
 
     test "worker options format is validated" do
-      assert_raise ArgumentError,
-                   "options for Oban.Integration.Worker must be as a keyword list",
-                   fn ->
-                     Cron.validate!(crontab: [{"* * * * *", Worker, %{foo: "bar"}}])
-                   end
+      assert_raise ArgumentError, ~r/Worker options must be as a keyword list/, fn ->
+        Cron.validate!(crontab: [{"* * * * *", Worker, %{foo: "bar"}}])
+      end
     end
 
     test ":timezone is validated as a known timezone" do


### PR DESCRIPTION
The other day we wasted quite some time on debugging a missing worker module listed only in the runtime config so I thought it might be useful to raise errors for individual workers.