### PR TITLE
Provide repeater plugin as notification workaround

### DIFF
--- a/guides/troubleshooting.md
+++ b/guides/troubleshooting.md
@@ -1,16 +1,29 @@
 # Troubleshooting
 
-## Querying the Jobs Table
+## PG Bouncer
 
-`Oban.Job` defines an Ecto schema and the jobs table can therefore be queried as usual, e.g.:
+### No Notifications with Transaction Pooling
 
+Using PG Bouncer's "Transaction Pooling" setup disables all of PostgreSQL's
+`LISTEN` and `NOTIFY` activity. Some functionality, such as triggering job
+execution, scaling queues, canceling jobs, etc. rely on those notifications.
+
+To ensure full functionality you must use a Repo that connects directly to the
+database, or use another mode like "Session Pooling" if possible.
+
+If you **must** use "Transaction Pooling" you can use the [Repeater][repe]
+plugin to ensure that queues keep processing jobs:
+
+```elixir
+config :my_app, Oban,
+  plugins: [Oban.Plugins.Pruner, Oban.Plugins.Stager, Oban.Plugins.Repeater],
+  ...
 ```
-MyApp.Repo.all(
-  from j in Oban.Job,
-    where: j.worker == "MyApp.Business",
-    where: j.state == "discarded"
-)
-```
+
+_Note: The Repeater plugin keeps jobs processing, it will not faciliate other
+notification based functionality, e.g. scaling queues._
+
+[repe]: Oban.Plugins.Repeater.html
 
 ## Heroku
 
@@ -29,7 +42,9 @@ elixir_version=1.9.0
 erlang_version=22.0.3
 ```
 
-Available Erlang versions are available [here](https://github.com/HashNuke/heroku-buildpack-elixir-otp-builds/blob/master/otp-versions).
+Available Erlang versions are available [here][versions].
+
+[versions]: https://github.com/HashNuke/heroku-buildpack-elixir-otp-builds/blob/master/otp-versions.
 
 ### Database Connections
 
@@ -37,17 +52,7 @@ Make sure that you have enough available database connections when running on
 Heroku. Oban uses a database connection in order to listen for pubsub
 notifications. This is in addition to your Ecto Repo `pool_size` setting.
 
-Heroku's [Hobby tier Postgres plans](https://devcenter.heroku.com/articles/heroku-postgres-plans#hobby-tier)
-have a maximum of 20 connections, so if you're using one of those plan
-accordingly.
+Heroku's [Hobby tier Postgres plans][plans] have a maximum of 20 connections, so
+if you're using one of those plan accordingly.
 
-## PG Bouncer
-
-### No Notifications with Transaction Pooling
-
-Using PG Bouncer's "Transaction Pooling" setup disables all of PostgreSQL's
-`LISTEN` and `NOTIFY` activity. Some functionality, such as scaling queues,
-canceling jobs, etc. rely on those notifications.
-
-To ensure full functionality you must use a Repo that connects directly to the
-database, or use another mode like "Session Pooling" if possible.
+[plans]: https://devcenter.heroku.com/articles/heroku-postgres-plans#hobby-tier

--- a/lib/oban/plugins/repeater.ex
+++ b/lib/oban/plugins/repeater.ex
@@ -1,0 +1,65 @@
+defmodule Oban.Plugins.Repeater do
+  @moduledoc """
+  Repeatedly send inserted messages to all registered producers to simulate polling.
+
+  This plugin is only necessary if you're running Oban in an environment where Postgres
+  notifications don't work, notably one of:
+
+  * Using a database connection pooler in transaction mode, i.e. pg_bouncer.
+  * Integration testing within the Ecto sandbox, i.e. developing Oban plugins
+
+  ## Options
+
+  * `:interval` — the number of milliseconds between notifications. The default is `1_000ms`.
+  """
+
+  use GenServer
+
+  defmodule State do
+    @moduledoc false
+
+    defstruct [:conf, :name, :timer, interval: 1_000]
+  end
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: opts[:name])
+  end
+
+  @impl GenServer
+  def init(opts) do
+    Process.flag(:trap_exit, true)
+
+    state = struct!(State, opts)
+
+    {:ok, schedule_notify(state)}
+  end
+
+  @impl GenServer
+  def terminate(_reason, %State{timer: timer}) do
+    if is_reference(timer), do: Process.cancel_timer(timer)
+
+    :ok
+  end
+
+  @impl GenServer
+  def handle_info(:notify, %State{} = state) do
+    match = [{{{state.conf.name, {:producer, :"$1"}}, :"$2", :_}, [], [{{:"$1", :"$2"}}]}]
+    meta = %{conf: state.conf, plugin: __MODULE__}
+
+    :telemetry.span([:oban, :plugin], meta, fn ->
+      for {queue, pid} <- Registry.select(Oban.Registry, match) do
+        send(pid, {:notification, :insert, %{"queue" => queue}})
+      end
+
+      {:ok, meta}
+    end)
+
+    {:noreply, schedule_notify(state)}
+  end
+
+  defp schedule_notify(state) do
+    timer = Process.send_after(self(), :notify, state.interval)
+
+    %{state | timer: timer}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -125,6 +125,7 @@ defmodule Oban.MixProject do
       Plugins: [
         Oban.Plugins.Cron,
         Oban.Plugins.Pruner,
+        Oban.Plugins.Repeater,
         Oban.Plugins.Stager
       ],
       Extending: [

--- a/test/oban/plugins/cron_test.exs
+++ b/test/oban/plugins/cron_test.exs
@@ -56,18 +56,7 @@ defmodule Oban.Plugins.CronTest do
   end
 
   test "cron jobs are enqueued on startup and telemetry events are emitted" do
-    events = [
-      [:oban, :plugin, :start],
-      [:oban, :plugin, :stop],
-      [:oban, :plugin, :exception]
-    ]
-
-    :telemetry.attach_many(
-      "plugin-cron-handler",
-      events,
-      &PluginTelemetryHandler.handle/4,
-      self()
-    )
+    PluginTelemetryHandler.attach_plugin_events("plugin-cron-handler")
 
     run_with_opts(
       crontab: [

--- a/test/oban/plugins/repeater_test.exs
+++ b/test/oban/plugins/repeater_test.exs
@@ -1,0 +1,42 @@
+defmodule Oban.Plugins.RepeaterTest do
+  use Oban.Case, async: true
+
+  alias Oban.Plugins.Repeater
+  alias Oban.{PluginTelemetryHandler, Registry}
+
+  defmodule RepeaterRelay do
+    use GenServer
+
+    def start_link(name: name, test: test) do
+      GenServer.start_link(__MODULE__, test, name: name)
+    end
+
+    @impl true
+    def init(test) do
+      {:ok, test}
+    end
+
+    @impl true
+    def handle_info({:notification, _, _} = message, test) do
+      send(test, message)
+
+      {:noreply, test}
+    end
+  end
+
+  test "broadcasting insert messages to producers to trigger dispatch" do
+    PluginTelemetryHandler.attach_plugin_events("plugin-repeater-handler")
+
+    oban_name = start_supervised_oban!(plugins: [{Repeater, interval: 10}])
+    prod_name = Registry.via(oban_name, {:producer, "default"})
+
+    start_supervised({RepeaterRelay, name: prod_name, test: self()})
+
+    assert_receive {:notification, :insert, %{"queue" => "default"}}
+
+    assert_receive {:event, :start, %{system_time: _}, %{conf: _, plugin: Repeater}}
+    assert_receive {:event, :stop, %{duration: _}, %{conf: _, plugin: Repeater}}
+  after
+    :telemetry.detach("plugin-repeater-handler")
+  end
+end

--- a/test/oban/plugins/stager_test.exs
+++ b/test/oban/plugins/stager_test.exs
@@ -7,18 +7,7 @@ defmodule Oban.Plugins.StagerTest do
   @moduletag :integration
 
   test "descheduling jobs to make them available for execution" do
-    events = [
-      [:oban, :plugin, :start],
-      [:oban, :plugin, :stop],
-      [:oban, :plugin, :exception]
-    ]
-
-    :telemetry.attach_many(
-      "plugin-stager-handler",
-      events,
-      &PluginTelemetryHandler.handle/4,
-      self()
-    )
+    PluginTelemetryHandler.attach_plugin_events("plugin-stager-handler")
 
     then = DateTime.add(DateTime.utc_now(), -30)
 

--- a/test/support/plugin_telemetry_handler.ex
+++ b/test/support/plugin_telemetry_handler.ex
@@ -4,6 +4,16 @@ defmodule Oban.PluginTelemetryHandler do
   and send them back to the test processes that registered the handler.
   """
 
+  def attach_plugin_events(name) do
+    events = [
+      [:oban, :plugin, :start],
+      [:oban, :plugin, :stop],
+      [:oban, :plugin, :exception]
+    ]
+
+    :telemetry.attach_many(name, events, &handle/4, self())
+  end
+
   def handle([:oban, :plugin, :start], measurements, meta, pid) do
     send(pid, {:event, :start, measurements, meta})
   end


### PR DESCRIPTION
Environments that can't make use of PG notifications won't process available jobs reliably. The Repeater plugin provides a work-around that simulates polling functionality for producers.

Closes #418