### PR TITLE
Upgrade minimum Elixir version to 1.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,23 @@ on:
 jobs:
   ci:
     strategy:
+      fail-fast: false
       matrix:
-        elixir: ['1.10', '1.11']
-        otp: ['23.1']
-        postgres: ['12.5-alpine', '13.1-alpine']
+        include:
+          - pair:
+              elixir: '1.9'
+              otp: '21.3'
+              postgres: '9.6-alpine'
+          - pair:
+              elixir: '1.11'
+              otp: '23.2'
+              postgres: '13.2-alpine'
 
     runs-on: ubuntu-latest
 
     services:
       postgres:
-        image: postgres:${{ matrix.postgres }}
+        image: postgres:${{matrix.pair.postgres}}
         env:
           POSTGRES_DB: oban_test
           POSTGRES_PASSWORD: postgres
@@ -38,18 +45,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-elixir@v1
+      - uses: erlef/setup-elixir@v1
         with:
-          elixir-version: ${{ matrix.elixir }}
-          otp-version: ${{ matrix.otp }}
+          otp-version: ${{matrix.pair.otp}}
+          elixir-version: ${{matrix.pair.elixir}}
 
       - uses: actions/cache@v1
         with:
-          key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+          key: ${{runner.os}}-${{matrix.pair.otp}}-${{matrix.pair.elixir}}-mix-${{hashFiles(format('{0}{1}', github.workspace, '/mix.lock'))}}
           path: _build
 
       - name: Run mix deps.get
-        run: mix deps.get
+        run: mix deps.get --only test
 
       - name: Run mix compile
         env:
@@ -58,12 +65,12 @@ jobs:
 
       - name: Run mix ecto.migrate
         env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/oban_test
+          DATABASE_URL: postgresql://postgres:postgres@localhost:${{job.services.postgres.ports[5432]}}/oban_test
           MIX_ENV: test
         run: mix ecto.migrate -r Oban.Test.Repo
 
       - name: Run mix ci
         env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/oban_test
+          DATABASE_URL: postgresql://postgres:postgres@localhost:${{job.services.postgres.ports[5432]}}/oban_test
           MIX_ENV: test
         run: mix ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   ci:
+    env:
+      MIX_ENV: test
     strategy:
       fail-fast: false
       matrix:
@@ -24,6 +26,7 @@ jobs:
               elixir: '1.11'
               otp: '23.2'
               postgres: '13.2-alpine'
+            lint: lint
 
     runs-on: ubuntu-latest
 
@@ -58,19 +61,35 @@ jobs:
       - name: Run mix deps.get
         run: mix deps.get --only test
 
+      - name: Run mix format
+        run: mix format --check-formatted
+        if: ${{ matrix.lint }}
+
+      - name: Run mix deps.unlock
+        run: mix deps.unlock --check-unused
+        if: ${{ matrix.lint }}
+
+      - name: Run mix deps.compile
+        run: mix deps.compile
+
       - name: Run mix compile
-        env:
-          MIX_ENV: test
         run: mix compile --warnings-as-errors
+        if: ${{ matrix.lint }}
+
+      - name: Run credo
+        run: mix credo --strict
+        if: ${{ matrix.lint }}
 
       - name: Run mix ecto.migrate
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:${{job.services.postgres.ports[5432]}}/oban_test
-          MIX_ENV: test
         run: mix ecto.migrate -r Oban.Test.Repo
 
-      - name: Run mix ci
+      - name: Run mix test
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:${{job.services.postgres.ports[5432]}}/oban_test
-          MIX_ENV: test
-        run: mix ci
+        run: mix test
+
+      - name: Run dialyzer
+        run: mix dialyzer
+        if: ${{ matrix.lint }}

--- a/README.md
+++ b/README.md
@@ -130,17 +130,19 @@ orphaned due to crashes.
 [rdbms]: https://en.wikipedia.org/wiki/Relational_database#RDBMS
 [tele]: https://github.com/beam-telemetry/telemetry
 
-## Requirements
-
-Oban has been developed and actively tested with Elixir 1.8+, Erlang/OTP 21.1+
-and PostgreSQL 11.0+. Running Oban currently requires Elixir 1.8+, Erlang 21+,
-and PostgreSQL 9.6+.
-
 ## Oban Web+Pro
 
-A web-based user interface for managing Oban, along with an official set of
-plugins and workers are available as private packages. Learn more about Oban
-Web+Pro at [getoban.pro](https://getoban.pro).
+A web dashboard for managing Oban, along with an official set of plugins and
+workers are available as private packages.
+
+* [🧭 Web Overview](https://hexdocs.pm/oban/web_overview.html#content)
+* [🌟 Pro Overview](https://hexdocs.pm/oban/pro_overview.html#content)
+
+Learn more about licensing Oban Web+Pro at [getoban.pro](https://getoban.pro).
+
+## Requirements
+
+Running Oban requires Elixir 1.9+, Erlang 21+, and PostgreSQL 9.6+.
 
 ## Installation
 

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Oban.MixProject do
     [
       app: :oban,
       version: @version,
-      elixir: "~> 1.8",
+      elixir: "~> 1.9",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Oban.MixProject do
       aliases: aliases(),
       preferred_cli_env: [
         bench: :test,
-        ci: :test,
+        "test.ci": :test,
         "test.setup": :test
       ],
 
@@ -169,7 +169,7 @@ defmodule Oban.MixProject do
     [
       bench: "run bench/bench_helper.exs",
       "test.setup": ["ecto.create", "ecto.migrate"],
-      ci: [
+      "test.ci": [
         "format --check-formatted",
         "deps.unlock --check-unused",
         "credo --strict",

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,7 @@
-Code.put_compiler_option(:warnings_as_errors, true)
+if function_exported?(Code, :put_compiler_option, 2) do
+  Code.put_compiler_option(:warnings_as_errors, true)
+end
+
 Logger.configure(level: :warn)
 
 ExUnit.start()


### PR DESCRIPTION
This bumps the minimum Elixir version and augments the CI flow to check the oldest and newest supported elixir/otp/postgres combinations.

Closes #437
