### PR TITLE
README example: Blow up if can't fetch Oban config

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ defmodule MyApp.Application do
 
   # Conditionally disable queues or plugins here.
   defp oban_config do
-    Application.get_env(:my_app, Oban)
+    Application.fetch_env!(:my_app, Oban)
   end
 end
 ```


### PR DESCRIPTION
With `get_env`, if you copypasta and leave it as `:my_app`, the error is more obscure