### PR TITLE
Allow replacing the scheduled execution time of a unique job

### DIFF
--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -36,6 +36,17 @@ defmodule Oban.Job do
           | {:period, unique_period()}
           | {:states, [unique_state()]}
 
+  @type replace_option :: [
+          :args
+          | :max_attempts
+          | :meta
+          | :priority
+          | :queue
+          | :scheduled_at
+          | :tags
+          | :worker
+        ]
+
   @type option ::
           {:args, args()}
           | {:max_attempts, pos_integer()}
@@ -44,7 +55,7 @@ defmodule Oban.Job do
           | {:queue, atom() | binary()}
           | {:schedule_in, pos_integer()}
           | {:replace_args, boolean()}
-          | {:replace_scheduled_at, boolean()}
+          | {:replace, [replace_option()]}
           | {:scheduled_at, DateTime.t()}
           | {:tags, tags()}
           | {:unique, [unique_option()]}
@@ -99,8 +110,7 @@ defmodule Oban.Job do
     field :scheduled_at, :utc_datetime_usec
 
     field :conf, :map, virtual: true
-    field :replace_args, :boolean, virtual: true
-    field :replace_scheduled_at, :boolean, virtual: true
+    field :replace, {:array, :any}, virtual: true
     field :unique, :map, virtual: true
     field :unsaved_error, :map, virtual: true
   end
@@ -120,14 +130,15 @@ defmodule Oban.Job do
     priority
     queue
     scheduled_at
-    replace_args
-    replace_scheduled_at
+    replace
     state
     tags
     worker
   )a
 
   @required_params ~w(worker args)a
+
+  @replace_options ~w(args max_attempts meta priority queue scheduled_at tags worker)a
 
   @doc """
   Construct a new job changeset ready for insertion into the database.
@@ -143,7 +154,7 @@ defmodule Oban.Job do
       of whether jobs are currently being processed for the queue.
     * `:schedule_in` - the number of seconds until the job should be executed
     * `:replace_args` - if the arguments should be replaced on a unique conflict
-    * `:replace_scheduled_at` - if the scheduled time to execute the job should be replaced on a unique conflict
+    * `:replace` - a list of keys to replace on a unique conflict
     * `:scheduled_at` - a time in the future after which the job should be executed
     * `:tags` — a list of tags to group and organize related jobs, i.e. to identify scheduled jobs
     * `:unique` — a keyword list of options specifying how uniqueness will be calculated. The
@@ -204,6 +215,8 @@ defmodule Oban.Job do
     |> validate_required(@required_params)
     |> put_scheduling(params[:schedule_in])
     |> put_uniqueness(params[:unique])
+    |> put_replace(params[:replace_args])
+    |> validate_subset(:replace, @replace_options)
     |> put_state()
     |> validate_length(:queue, min: 1, max: 128)
     |> validate_length(:worker, min: 1, max: 128)
@@ -322,6 +335,28 @@ defmodule Oban.Job do
 
       _ ->
         add_error(changeset, :unique, "invalid unique options")
+    end
+  end
+
+  defp put_replace(changeset, value) do
+    case value do
+      replace_args when is_boolean(replace_args) ->
+        replace = get_change(changeset, :replace, [])
+
+        updated =
+          if replace_args do
+            [:args | replace]
+          else
+            Enum.reject(replace, &(&1 == :args))
+          end
+
+        put_change(changeset, :replace, updated)
+
+      nil ->
+        changeset
+
+      _ ->
+        add_error(changeset, :replace_args, "invalid value")
     end
   end
 

--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -340,17 +340,12 @@ defmodule Oban.Job do
 
   defp put_replace(changeset, value) do
     case value do
-      replace_args when is_boolean(replace_args) ->
+      true ->
         replace = get_change(changeset, :replace, [])
+        put_change(changeset, :replace, [:args | replace])
 
-        updated =
-          if replace_args do
-            [:args | replace]
-          else
-            Enum.reject(replace, &(&1 == :args))
-          end
-
-        put_change(changeset, :replace, updated)
+      false ->
+        update_change(changeset, :replace, &(&1 -- [:args]))
 
       nil ->
         changeset

--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -44,6 +44,7 @@ defmodule Oban.Job do
           | {:queue, atom() | binary()}
           | {:schedule_in, pos_integer()}
           | {:replace_args, boolean()}
+          | {:replace_scheduled_at, boolean()}
           | {:scheduled_at, DateTime.t()}
           | {:tags, tags()}
           | {:unique, [unique_option()]}
@@ -99,6 +100,7 @@ defmodule Oban.Job do
 
     field :conf, :map, virtual: true
     field :replace_args, :boolean, virtual: true
+    field :replace_scheduled_at, :boolean, virtual: true
     field :unique, :map, virtual: true
     field :unsaved_error, :map, virtual: true
   end
@@ -119,6 +121,7 @@ defmodule Oban.Job do
     queue
     scheduled_at
     replace_args
+    replace_scheduled_at
     state
     tags
     worker
@@ -140,6 +143,7 @@ defmodule Oban.Job do
       of whether jobs are currently being processed for the queue.
     * `:schedule_in` - the number of seconds until the job should be executed
     * `:replace_args` - if the arguments should be replaced on a unique conflict
+    * `:replace_scheduled_at` - if the scheduled time to execute the job should be replaced on a unique conflict
     * `:scheduled_at` - a time in the future after which the job should be executed
     * `:tags` — a list of tags to group and organize related jobs, i.e. to identify scheduled jobs
     * `:unique` — a keyword list of options specifying how uniqueness will be calculated. The

--- a/lib/oban/query.ex
+++ b/lib/oban/query.ex
@@ -131,23 +131,16 @@ defmodule Oban.Query do
   end
 
   defp return_or_replace(conf, query_opts, job, changeset) do
-    replace_keys =
-      %{replace_args: :args, replace_scheduled_at: :scheduled_at}
-      |> Enum.map(fn {key, replace_key} ->
-        if Changeset.get_change(changeset, key) do
-          replace_key
-        end
-      end)
-      |> Enum.reject(&is_nil/1)
+    case Changeset.get_change(changeset, :replace, []) do
+      [] ->
+        {:ok, job}
 
-    if Enum.empty?(replace_keys) do
-      {:ok, job}
-    else
-      Repo.update(
-        conf,
-        Ecto.Changeset.change(job, Map.take(changeset.changes, replace_keys)),
-        query_opts
-      )
+      replace_keys ->
+        Repo.update(
+          conf,
+          Ecto.Changeset.change(job, Map.take(changeset.changes, replace_keys)),
+          query_opts
+        )
     end
   end
 

--- a/test/integration/uniqueness_test.exs
+++ b/test/integration/uniqueness_test.exs
@@ -109,20 +109,37 @@ defmodule Oban.Integration.UniquenessTest do
              )
   end
 
-  test "replace allows replacing the schedule for the same job id", context do
+  test "replace allows replacing job data for the same job id", context do
     now = DateTime.utc_now()
     in_one_minute = DateTime.add(now, 60, :second)
     in_two_minutes = DateTime.add(now, 120, :second)
 
-    assert %Job{id: id_1} = unique_insert!(context.name, %{id: 1}, scheduled_at: in_one_minute)
+    assert %Job{id: id_1} =
+             unique_insert!(
+               context.name,
+               %{id: 1},
+               scheduled_at: in_one_minute,
+               tags: ["a"],
+               priority: 3,
+               max_attempts: 1
+             )
 
-    assert %Job{id: ^id_1, scheduled_at: ^in_two_minutes} =
+    assert %Job{
+             id: ^id_1,
+             scheduled_at: ^in_two_minutes,
+             tags: ["b"],
+             priority: 2,
+             max_attempts: 1
+           } =
              unique_insert!(
                context.name,
                %{id: 1},
                unique: [keys: [:id]],
                scheduled_at: in_two_minutes,
-               replace_scheduled_at: true
+               tags: ["b"],
+               priority: 2,
+               max_attempts: 3,
+               replace: [:scheduled_at, :tags, :priority]
              )
   end
 

--- a/test/integration/uniqueness_test.exs
+++ b/test/integration/uniqueness_test.exs
@@ -109,6 +109,23 @@ defmodule Oban.Integration.UniquenessTest do
              )
   end
 
+  test "replace allows replacing the schedule for the same job id", context do
+    now = DateTime.utc_now()
+    in_one_minute = DateTime.add(now, 60, :second)
+    in_two_minutes = DateTime.add(now, 120, :second)
+
+    assert %Job{id: id_1} = unique_insert!(context.name, %{id: 1}, scheduled_at: in_one_minute)
+
+    assert %Job{id: ^id_1, scheduled_at: ^in_two_minutes} =
+             unique_insert!(
+               context.name,
+               %{id: 1},
+               unique: [keys: [:id]],
+               scheduled_at: in_two_minutes,
+               replace_scheduled_at: true
+             )
+  end
+
   test "scoping uniqueness by period", %{name: name} do
     now = DateTime.utc_now()
     two_minutes_ago = DateTime.add(now, -120, :second)


### PR DESCRIPTION
This commit adds the capability to update the scheduled execution time of a unique job, similar to `:replace_args`

Not sure whether this is the nicest way of going about it (if there are other fields that could be replaced in future, this API gets a bit messy) but just went with something very simple to spark discussion.

Any feedback gratefully received 😅 