### PR TITLE
Fix dialyzer warning related to less-specific changeset type

### DIFF
--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -200,7 +200,7 @@ defmodule Oban.Job do
       |> Oban.insert()
   """
   @doc since: "0.1.0"
-  @spec new(args(), [option]) :: Ecto.Changeset.t()
+  @spec new(args(), [option()]) :: changeset()
   def new(args, opts \\ []) when is_map(args) and is_list(opts) do
     params =
       opts


### PR DESCRIPTION
This ensures that dialyzer no longer complains about "insert_job!/2 will never return"