### PR TITLE
Check when inserted unique job previously existed

### DIFF
--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -112,6 +112,7 @@ defmodule Oban.Job do
     field :conf, :map, virtual: true
     field :replace, {:array, :any}, virtual: true
     field :unique, :map, virtual: true
+    field :conflict?, :boolean, virtual: true, default: false
     field :unsaved_error, :map, virtual: true
   end
 

--- a/test/integration/uniqueness_test.exs
+++ b/test/integration/uniqueness_test.exs
@@ -97,6 +97,11 @@ defmodule Oban.Integration.UniquenessTest do
     assert count_jobs() == 5
   end
 
+  test "conflict? is true when job already exists", %{name: name} do
+    assert %Job{id: id, conflict?: false} = unique_insert!(name, %{id: 1})
+    assert %Job{id: ^id, conflict?: true} = unique_insert!(name, %{id: 1})
+  end
+
   test "replace allows replacing the args for the same job id", context do
     assert %Job{id: id_1} = unique_insert!(context.name, %{id: 1, url: "https://a.co"})
 


### PR DESCRIPTION
Adds the `duplicate?` virtual field, which is true when an inserted job already existed in the database.

I don't think that this is a good name, as I wouldn't say that the `:replace` upsert scenario is a dupe.

Related to #483, but doesn't use a tuple as this would be weird with the bang variant of `Oban.insert`