### PR TITLE
Use `drop_if_exists` in 2.6 upgrade doc

### DIFF
--- a/guides/upgrading/v2.6.md
+++ b/guides/upgrading/v2.6.md
@@ -132,8 +132,8 @@ Within the generated migration module:
 use Ecto.Migration
 
 def up do
-  drop table("oban_beats")
-  drop table("oban_beats", prefix: "private") # If you have any prefixes:
+  drop_if_exists table("oban_beats")
+  drop_if_exists table("oban_beats", prefix: "private") # If you have any prefixes:
 end
 
 def down do


### PR DESCRIPTION
This prevents errors if somebody runs `mix ecto.migrate` and then tries to run a test suite.