### PR TITLE
bugfix: keep transaction behavior using dynamic repo

### DIFF
--- a/lib/oban/repo.ex
+++ b/lib/oban/repo.ex
@@ -191,6 +191,17 @@ defmodule Oban.Repo do
   end
 
   defp in_transaction?(conf, instance) when is_pid(instance), do: conf.repo.in_transaction?()
+
+  defp in_transaction?(conf, instance) when is_atom(instance) do
+    case GenServer.whereis(instance) do
+      pid when is_pid(pid) ->
+        in_transaction?(conf, pid)
+
+      _ ->
+        false
+    end
+  end
+
   defp in_transaction?(_, _), do: false
 
   defp query_opts(opts, conf) do

--- a/test/integration/dynamic_repo_test.exs
+++ b/test/integration/dynamic_repo_test.exs
@@ -30,10 +30,10 @@ defmodule Oban.Integration.DynamicRepoTest do
   test "rollback job insertion after transaction failure", context do
     name = start_oban!(context.repo_pid, queues: [alpha: 1])
 
-    {:ok, app_repo_pid} =
+    {:ok, _app_repo_pid} =
       start_supervised(%{DynamicRepo.child_spec(name: :app_repo) | id: :app_repo})
 
-    DynamicRepo.put_dynamic_repo(app_repo_pid)
+    DynamicRepo.put_dynamic_repo(:app_repo)
 
     ref = System.unique_integer([:positive, :monotonic])
 


### PR DESCRIPTION
One of the fundamental advantages of using Oban is that it runs on top
of PostgreSQL, this setup allow us to enqueue jobs along with multiple
repo operations, ensuring that everything is committed or rolled back
atomically using transactions.

The previous behavior fails when you set a dynamic repo as part of the
Oban configuration via the `get_dynamic_repo` setting. The Oban dynamic
repo always takes precedence even when the caller is running a
transaction.

This PR is an attempt to fix the previous issue.

Fixes: #442