### PR TITLE
Add ability to include unit for :schedule_in

### DIFF
--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -59,9 +59,7 @@ defmodule Oban.Job do
              | :day
              | :days
              | :week
-             | :weeks
-             | :month
-             | :months}
+             | :weeks}
 
   @type option ::
           {:args, args()}
@@ -325,8 +323,6 @@ defmodule Oban.Job do
     days
     week
     weeks
-    month
-    months
   )a
 
   defguardp is_timestampable(value)
@@ -432,8 +428,6 @@ defmodule Oban.Job do
   defp to_timestamp({days, :days}), do: to_timestamp({days, :day})
   defp to_timestamp({weeks, :week}), do: to_timestamp(weeks * 7 * 24 * 60 * 60)
   defp to_timestamp({weeks, :weeks}), do: to_timestamp({weeks, :week})
-  defp to_timestamp({months, :month}), do: to_timestamp(months * 30 * 24 * 60 * 60)
-  defp to_timestamp({months, :months}), do: to_timestamp({months, :month})
 
   defp validate_unique_opts(unique) do
     Enum.reduce_while(unique, :ok, fn {key, val}, _acc ->

--- a/test/oban/job_test.exs
+++ b/test/oban/job_test.exs
@@ -13,10 +13,13 @@ defmodule Oban.JobTest do
     end
 
     property "scheduling a job for the future using a tuple" do
-      check all schedule_in <- tuple({integer(), time_unit()}) do
-        changeset = Job.new(%{}, worker: Fake, schedule_in: schedule_in)
-        assert changeset.changes[:state] == "scheduled"
-        assert changeset.changes[:scheduled_at]
+      now = DateTime.utc_now()
+
+      check all schedule_in <- tuple({positive_integer(), time_unit()}) do
+        assert %{changes: %{scheduled_at: %DateTime{} = scheduled_at, state: "scheduled"}} =
+                 Job.new(%{}, worker: Fake, schedule_in: schedule_in)
+
+        assert DateTime.compare(scheduled_at, now) == :gt
       end
     end
 
@@ -130,9 +133,7 @@ defmodule Oban.JobTest do
       :day,
       :days,
       :week,
-      :weeks,
-      :month,
-      :months
+      :weeks
     ])
   end
 end

--- a/test/oban/job_test.exs
+++ b/test/oban/job_test.exs
@@ -123,17 +123,6 @@ defmodule Oban.JobTest do
   end
 
   defp time_unit do
-    one_of([
-      :second,
-      :seconds,
-      :minute,
-      :minutes,
-      :hour,
-      :hours,
-      :day,
-      :days,
-      :week,
-      :weeks
-    ])
+    one_of([:second, :seconds, :minute, :minutes, :hour, :hours, :day, :days, :week, :weeks])
   end
 end


### PR DESCRIPTION
This adds the ability for users to specify `schedule_in` as a tuple of `{integer, unit}` when creating a job.

The time units and implementation are carried over from Oban Pro.