### PR TITLE
Raise ArgumentError if `:limit` is missing from opts

### DIFF
--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -438,6 +438,7 @@ defmodule Oban do
   @spec start_queue(name(), opts :: [queue_option()]) :: :ok
   def start_queue(name \\ __MODULE__, [_ | _] = opts) do
     Enum.each(opts, &validate_queue_opt!/1)
+    require_queue_opts(opts, [:limit])
 
     conf = config(name)
 
@@ -730,5 +731,12 @@ defmodule Oban do
 
   defp validate_queue_opt!(option) do
     raise ArgumentError, "unknown option provided #{inspect(option)}"
+  end
+
+  defp require_queue_opts(opts, required_opts) do
+    Enum.each(required_opts, fn required_opt ->
+      if !Keyword.has_key?(opts, required_opt),
+        do: raise(ArgumentError, "expected #{required_opt} to be present in opts")
+    end)
   end
 end

--- a/test/integration/controlling_test.exs
+++ b/test/integration/controlling_test.exs
@@ -7,10 +7,11 @@ defmodule Oban.Integration.ControllingTest do
 
   describe "start_queue/2" do
     test "validating options" do
-      assert_invalid_opts(:start_queue, queue: nil)
+      assert_invalid_opts(:start_queue, queue: nil, limit: 1)
+      assert_invalid_opts(:start_queue, queue: "foo")
       assert_invalid_opts(:start_queue, limit: -1)
-      assert_invalid_opts(:start_queue, local_only: -1)
-      assert_invalid_opts(:start_queue, wat: -1)
+      assert_invalid_opts(:start_queue, local_only: -1, limit: 1)
+      assert_invalid_opts(:start_queue, wat: -1, limit: 1)
     end
 
     test "starting individual queues dynamically" do


### PR DESCRIPTION
Without this check, Oban crashes the queue elsewhere with a weird error:

```[error] GenServer {Oban.Registry, {Oban, {:producer, "my_queue"}}} terminating          
** (ArithmeticError) bad argument in arithmetic expression                             
    :erlang.-(nil, 0)                                                                  
    (oban 2.7.2) lib/oban/queue/basic_engine.ex:54: Oban.Queue.BasicEngine.fetch_jobs/3
```