### PR TITLE
Add additional telemetry events

### DIFF
--- a/lib/oban/notifier.ex
+++ b/lib/oban/notifier.ex
@@ -171,11 +171,11 @@ defmodule Oban.Notifier do
     |> notify(channel, payload)
   end
 
-  defp with_span(conf, channel, payload, cb) do
+  defp with_span(conf, channel, payload, fun) do
     tele_meta = %{conf: conf, channel: channel, payload: payload}
 
     :telemetry.span([:oban, :notifier, :notify], tele_meta, fn ->
-      {cb.(), tele_meta}
+      {fun.(), tele_meta}
     end)
   end
 

--- a/lib/oban/notifier.ex
+++ b/lib/oban/notifier.ex
@@ -166,13 +166,9 @@ defmodule Oban.Notifier do
   end
 
   def notify(server, channel, payload) when is_channel(channel) do
-    conf = Oban.config(server)
-
-    with_span(conf, channel, payload, fn ->
-      conf.name
-      |> Registry.whereis(Oban.Notifier)
-      |> conf.notifier.notify(channel, normalize_payload(payload))
-    end)
+    server
+    |> Oban.config()
+    |> notify(channel, payload)
   end
 
   defp with_span(conf, channel, payload, cb) do

--- a/lib/oban/queue/engine.ex
+++ b/lib/oban/queue/engine.ex
@@ -87,7 +87,7 @@ defmodule Oban.Queue.Engine do
 
   @doc false
   def fetch_jobs(%Config{} = conf, %{} = meta, %{} = running) do
-    with_span(:fetch_jobs, conf, %{meta: meta, running: running}, fn ->
+    with_span(:fetch_jobs, conf, fn ->
       conf.engine.fetch_jobs(conf, meta, running)
     end)
   end
@@ -108,14 +108,14 @@ defmodule Oban.Queue.Engine do
 
   @doc false
   def error_job(%Config{} = conf, %Job{} = job, seconds) when is_integer(seconds) do
-    with_span(:error_job, conf, %{job: job, seconds: seconds}, fn ->
+    with_span(:error_job, conf, %{job: job}, fn ->
       conf.engine.error_job(conf, job, seconds)
     end)
   end
 
   @doc false
   def snooze_job(%Config{} = conf, %Job{} = job, seconds) when is_integer(seconds) do
-    with_span(:snooze_job, conf, %{job: job, seconds: seconds}, fn ->
+    with_span(:snooze_job, conf, %{job: job}, fn ->
       conf.engine.snooze_job(conf, job, seconds)
     end)
   end
@@ -127,7 +127,7 @@ defmodule Oban.Queue.Engine do
     end)
   end
 
-  defp with_span(event, %Config{} = conf, additional_meta, cb) do
+  defp with_span(event, %Config{} = conf, additional_meta \\ %{}, cb) do
     tele_meta =
       additional_meta
       |> Map.put(:conf, conf)

--- a/lib/oban/queue/engine.ex
+++ b/lib/oban/queue/engine.ex
@@ -67,17 +67,23 @@ defmodule Oban.Queue.Engine do
 
   @doc false
   def init(%Config{} = conf, [_ | _] = opts) do
-    conf.engine.init(conf, opts)
+    with_span(:init, conf, fn ->
+      conf.engine.init(conf, opts)
+    end)
   end
 
   @doc false
   def refresh(%Config{} = conf, %{} = meta) do
-    conf.engine.refresh(conf, meta)
+    with_span(:refresh, conf, fn ->
+      conf.engine.refresh(conf, meta)
+    end)
   end
 
   @doc false
   def put_meta(%Config{} = conf, %{} = meta, key, value) when is_atom(key) do
-    conf.engine.put_meta(conf, meta, key, value)
+    with_span(:put_meta, conf, fn ->
+      conf.engine.put_meta(conf, meta, key, value)
+    end)
   end
 
   @doc false

--- a/lib/oban/queue/engine.ex
+++ b/lib/oban/queue/engine.ex
@@ -127,14 +127,14 @@ defmodule Oban.Queue.Engine do
     end)
   end
 
-  defp with_span(event, %Config{} = conf, additional_meta \\ %{}, cb) do
+  defp with_span(event, %Config{} = conf, additional_meta \\ %{}, fun) do
     tele_meta =
       additional_meta
       |> Map.put(:conf, conf)
       |> Map.put(:engine, conf.engine)
 
     :telemetry.span([:oban, :engine, event], tele_meta, fn ->
-      {cb.(), tele_meta}
+      {fun.(), tele_meta}
     end)
   end
 end

--- a/lib/oban/queue/producer.ex
+++ b/lib/oban/queue/producer.ex
@@ -154,13 +154,7 @@ defmodule Oban.Queue.Producer do
   end
 
   def handle_info(:refresh, %State{} = state) do
-    tele_meta = tele_meta(state)
-
-    meta =
-      :telemetry.span([:oban, :engine, :refresh], tele_meta, fn ->
-        meta = Engine.refresh(state.conf, state.meta)
-        {meta, tele_meta}
-      end)
+    meta = Engine.refresh(state.conf, state.meta)
 
     {:noreply, schedule_refresh(%{state | meta: meta})}
   end
@@ -214,7 +208,7 @@ defmodule Oban.Queue.Producer do
   end
 
   defp dispatch(%State{} = state) do
-    tele_meta = tele_meta(state)
+    tele_meta = %{conf: state.conf, queue: state.meta.queue}
 
     {meta, dispatched} =
       :telemetry.span([:oban, :producer], tele_meta, fn ->
@@ -227,13 +221,7 @@ defmodule Oban.Queue.Producer do
   end
 
   defp start_jobs(%State{} = state) do
-    tele_meta = tele_meta(state)
-
-    {meta, jobs} =
-      :telemetry.span([:oban, :engine, :fetch_jobs], tele_meta, fn ->
-        {:ok, {meta, jobs}} = Engine.fetch_jobs(state.conf, state.meta, state.running)
-        {{meta, jobs}, Map.put(tele_meta, :jobs, jobs)}
-      end)
+    {:ok, {meta, jobs}} = Engine.fetch_jobs(state.conf, state.meta, state.running)
 
     dispatched =
       for job <- jobs, into: %{} do
@@ -251,6 +239,4 @@ defmodule Oban.Queue.Producer do
 
     %{state | running: Map.delete(state.running, ref)}
   end
-
-  defp tele_meta(%State{} = state), do: %{conf: state.conf, queue: state.meta.queue}
 end

--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -69,6 +69,31 @@ defmodule Oban.Telemetry do
   * `:conf` — the config of the Oban supervised producer
   * `:dispatched_count` — the number of jobs fetched and started by the producer
 
+  ### Engine Events
+
+  Oban emits the following telemetry span events for the configured Engine:
+
+  * `[:oban, :engine, :refresh, :start | :stop | :exception]` — when the engine is refreshed
+  * `[:oban, :engine, :fetch_jobs, :start | :stop | :exception]` — when new jobs are fetched
+
+  | :refresh event | measures       | metadata                |
+  | -------------- | -------------- | ----------------------- |
+  | `:start`       | `:system_time` | `:queue, :conf`         |
+  | `:stop`        | `:duration`    | `:queue, :conf`         |
+  | `:exception`   | `:duration`    | `:queue, :conf`         |
+
+  | :fetch_jobs event | measures       | metadata                |
+  | ----------------- | -------------- | ----------------------- |
+  | `:start`          | `:system_time` | `:queue, :conf`         |
+  | `:stop`           | `:duration`    | `:queue, :conf, :jobs`  |
+  | `:exception`      | `:duration`    | `:queue, :conf`         |
+
+  Metadata
+
+  * `:queue` — the name of the queue as a string, e.g. "default" or "mailers"
+  * `:conf` — the config of the Oban supervised producer
+  * `:jobs` — the jobs fetched by the engine
+
   ### Circuit Events
 
   All processes that interact with the database have circuit breakers to prevent errors from

--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -73,6 +73,30 @@ defmodule Oban.Telemetry do
 
   Oban emits telemetry span events for the following Engine operations:
 
+  * `[:oban, :engine, :init, :start | :stop | :exception]`
+
+  | event        | measures       | metadata           |
+  | ------------ | -------------- | ------------------ |
+  | `:start`     | `:system_time` | `:conf`, `engine`  |
+  | `:stop`      | `:duration`    | `:conf`, `engine`  |
+  | `:exception` | `:duration`    | `:conf`, `engine`  |
+
+  * `[:oban, :engine, :refresh, :start | :stop | :exception]`
+
+  | event        | measures       | metadata           |
+  | ------------ | -------------- | ------------------ |
+  | `:start`     | `:system_time` | `:conf`, `engine`  |
+  | `:stop`      | `:duration`    | `:conf`, `engine`  |
+  | `:exception` | `:duration`    | `:conf`, `engine`  |
+
+  * `[:oban, :engine, :put_meta, :start | :stop | :exception]`
+
+  | event        | measures       | metadata           |
+  | ------------ | -------------- | ------------------ |
+  | `:start`     | `:system_time` | `:conf`, `engine`  |
+  | `:stop`      | `:duration`    | `:conf`, `engine`  |
+  | `:exception` | `:duration`    | `:conf`, `engine`  |
+
   * `[:oban, :engine, :fetch_jobs, :start | :stop | :exception]`
 
   | event        | measures       | metadata           |

--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -69,31 +69,6 @@ defmodule Oban.Telemetry do
   * `:conf` — the config of the Oban supervised producer
   * `:dispatched_count` — the number of jobs fetched and started by the producer
 
-  ### Engine Events
-
-  Oban emits the following telemetry span events for the configured Engine:
-
-  * `[:oban, :engine, :refresh, :start | :stop | :exception]` — when the engine is refreshed
-  * `[:oban, :engine, :fetch_jobs, :start | :stop | :exception]` — when new jobs are fetched
-
-  | :refresh event | measures       | metadata                |
-  | -------------- | -------------- | ----------------------- |
-  | `:start`       | `:system_time` | `:queue, :conf`         |
-  | `:stop`        | `:duration`    | `:queue, :conf`         |
-  | `:exception`   | `:duration`    | `:queue, :conf`         |
-
-  | :fetch_jobs event | measures       | metadata                |
-  | ----------------- | -------------- | ----------------------- |
-  | `:start`          | `:system_time` | `:queue, :conf`         |
-  | `:stop`           | `:duration`    | `:queue, :conf, :jobs`  |
-  | `:exception`      | `:duration`    | `:queue, :conf`         |
-
-  Metadata
-
-  * `:queue` — the name of the queue as a string, e.g. "default" or "mailers"
-  * `:conf` — the config of the Oban supervised producer
-  * `:jobs` — the jobs fetched by the engine
-
   ### Circuit Events
 
   All processes that interact with the database have circuit breakers to prevent errors from

--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -69,6 +69,65 @@ defmodule Oban.Telemetry do
   * `:conf` — the config of the Oban supervised producer
   * `:dispatched_count` — the number of jobs fetched and started by the producer
 
+  ### Engine Events
+
+  Oban emits telemetry span events for the following Engine operations:
+
+  * `[:oban, :engine, :fetch_jobs, :start | :stop | :exception]`
+
+  | event        | measures       | metadata           |
+  | ------------ | -------------- | ------------------ |
+  | `:start`     | `:system_time` | `:conf`, `engine`  |
+  | `:stop`      | `:duration`    | `:conf`, `engine`  |
+  | `:exception` | `:duration`    | `:conf`, `engine`  |
+
+
+  * `[:oban, :engine, :complete_job, :start | :stop | :exception]` — when an engine operation is called
+
+  | event        | measures       | metadata                 |
+  | ------------ | -------------- | ------------------------ |
+  | `:start`     | `:system_time` | `:conf`, `engine`, `job` |
+  | `:stop`      | `:duration`    | `:conf`, `engine`, `job` |
+  | `:exception` | `:duration`    | `:conf`, `engine`, `job` |
+
+  * `[:oban, :engine, :discard_job, :start | :stop | :exception]`
+
+  | event        | measures       | metadata                 |
+  | ------------ | -------------- | ------------------------ |
+  | `:start`     | `:system_time` | `:conf`, `engine`, `job` |
+  | `:stop`      | `:duration`    | `:conf`, `engine`, `job` |
+  | `:exception` | `:duration`    | `:conf`, `engine`, `job` |
+
+  * `[:oban, :engine, :error_job, :start | :stop | :exception]`
+
+  | event        | measures       | metadata                 |
+  | ------------ | -------------- | ------------------------ |
+  | `:start`     | `:system_time` | `:conf`, `engine`, `job` |
+  | `:stop`      | `:duration`    | `:conf`, `engine`, `job` |
+  | `:exception` | `:duration`    | `:conf`, `engine`, `job` |
+
+  * `[:oban, :engine, :snooze_job, :start | :stop | :exception]`
+
+  | event        | measures       | metadata                 |
+  | ------------ | -------------- | ------------------------ |
+  | `:start`     | `:system_time` | `:conf`, `engine`, `job` |
+  | `:stop`      | `:duration`    | `:conf`, `engine`, `job` |
+  | `:exception` | `:duration`    | `:conf`, `engine`, `job` |
+
+  * `[:oban, :engine, :cancel_job, :start | :stop | :exception]`
+
+  | event        | measures       | metadata                 |
+  | ------------ | -------------- | ------------------------ |
+  | `:start`     | `:system_time` | `:conf`, `engine`, `job` |
+  | `:stop`      | `:duration`    | `:conf`, `engine`, `job` |
+  | `:exception` | `:duration`    | `:conf`, `engine`, `job` |
+
+  Metadata
+
+  * `:conf` — the config of the Oban supervised producer
+  * `:engine` — the module of the engine used
+  * `:job` - the `Oban.Job` in question
+
   ### Circuit Events
 
   All processes that interact with the database have circuit breakers to prevent errors from

--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -84,43 +84,43 @@ defmodule Oban.Telemetry do
 
   * `[:oban, :engine, :complete_job, :start | :stop | :exception]` — when an engine operation is called
 
-  | event        | measures       | metadata                 |
-  | ------------ | -------------- | ------------------------ |
-  | `:start`     | `:system_time` | `:conf`, `engine`, `job` |
-  | `:stop`      | `:duration`    | `:conf`, `engine`, `job` |
-  | `:exception` | `:duration`    | `:conf`, `engine`, `job` |
+  | event        | measures       | metadata                                                 |
+  | ------------ | -------------- | -------------------------------------------------------  |
+  | `:start`     | `:system_time` | `:conf`, `engine`, `job`                                 |
+  | `:stop`      | `:duration`    | `:conf`, `engine`, `job`                                 |
+  | `:exception` | `:duration`    | `:conf`, `engine`, `job`, `kind`, `reason`, `stacktrace` |
 
   * `[:oban, :engine, :discard_job, :start | :stop | :exception]`
 
-  | event        | measures       | metadata                 |
-  | ------------ | -------------- | ------------------------ |
-  | `:start`     | `:system_time` | `:conf`, `engine`, `job` |
-  | `:stop`      | `:duration`    | `:conf`, `engine`, `job` |
-  | `:exception` | `:duration`    | `:conf`, `engine`, `job` |
+  | event        | measures       | metadata                                                 |
+  | ------------ | -------------- | -------------------------------------------------------  |
+  | `:start`     | `:system_time` | `:conf`, `engine`, `job`                                 |
+  | `:stop`      | `:duration`    | `:conf`, `engine`, `job`                                 |
+  | `:exception` | `:duration`    | `:conf`, `engine`, `job`, `kind`, `reason`, `stacktrace` |
 
   * `[:oban, :engine, :error_job, :start | :stop | :exception]`
 
-  | event        | measures       | metadata                 |
-  | ------------ | -------------- | ------------------------ |
-  | `:start`     | `:system_time` | `:conf`, `engine`, `job` |
-  | `:stop`      | `:duration`    | `:conf`, `engine`, `job` |
-  | `:exception` | `:duration`    | `:conf`, `engine`, `job` |
+  | event        | measures       | metadata                                                 |
+  | ------------ | -------------- | -------------------------------------------------------  |
+  | `:start`     | `:system_time` | `:conf`, `engine`, `job`                                 |
+  | `:stop`      | `:duration`    | `:conf`, `engine`, `job`                                 |
+  | `:exception` | `:duration`    | `:conf`, `engine`, `job`, `kind`, `reason`, `stacktrace` |
 
   * `[:oban, :engine, :snooze_job, :start | :stop | :exception]`
 
-  | event        | measures       | metadata                 |
-  | ------------ | -------------- | ------------------------ |
-  | `:start`     | `:system_time` | `:conf`, `engine`, `job` |
-  | `:stop`      | `:duration`    | `:conf`, `engine`, `job` |
-  | `:exception` | `:duration`    | `:conf`, `engine`, `job` |
+  | event        | measures       | metadata                                                 |
+  | ------------ | -------------- | -------------------------------------------------------  |
+  | `:start`     | `:system_time` | `:conf`, `engine`, `job`                                 |
+  | `:stop`      | `:duration`    | `:conf`, `engine`, `job`                                 |
+  | `:exception` | `:duration`    | `:conf`, `engine`, `job`, `kind`, `reason`, `stacktrace` |
 
   * `[:oban, :engine, :cancel_job, :start | :stop | :exception]`
 
-  | event        | measures       | metadata                 |
-  | ------------ | -------------- | ------------------------ |
-  | `:start`     | `:system_time` | `:conf`, `engine`, `job` |
-  | `:stop`      | `:duration`    | `:conf`, `engine`, `job` |
-  | `:exception` | `:duration`    | `:conf`, `engine`, `job` |
+  | event        | measures       | metadata                                                 |
+  | ------------ | -------------- | -------------------------------------------------------  |
+  | `:start`     | `:system_time` | `:conf`, `engine`, `job`                                 |
+  | `:stop`      | `:duration`    | `:conf`, `engine`, `job`                                 |
+  | `:exception` | `:duration`    | `:conf`, `engine`, `job`, `kind`, `reason`, `stacktrace` |
 
   Metadata
 
@@ -134,15 +134,16 @@ defmodule Oban.Telemetry do
 
   * `[:oban, :notifier, :notify, :start | :stop | :exception]`
 
-  | event        | measures       | metadata                       |
-  | ------------ | -------------- | ------------------------------ |
-  | `:start`     | `:system_time` | `:conf`, `channel`, `payload`  |
-  | `:stop`      | `:duration`    | `:conf`, `channel`, `payload`  |
-  | `:exception` | `:duration`    | `:conf`, `channel`, `payload`  |
+  | event        | measures       | metadata                                                       |
+  | ------------ | -------------- | -------------------------------------------------------------- |
+  | `:start`     | `:system_time` | `:conf`, `channel`, `payload`                                  |
+  | `:stop`      | `:duration`    | `:conf`, `channel`, `payload`                                  |
+  | `:exception` | `:duration`    | `:conf`, `channel`, `payload`, `kind`, `reason`, `stacktrace`  |
 
   * `:conf` — the config of the Oban supervised producer
   * `:channel` — the channel on which the notification was sent
   * `:payload` - the payload that was sent
+  * `kind`, `reason`, `stacktrace`, see the explanation above.
 
   ### Circuit Events
 

--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -128,6 +128,22 @@ defmodule Oban.Telemetry do
   * `:engine` — the module of the engine used
   * `:job` - the `Oban.Job` in question
 
+  ### Notifier Events
+
+  Oban emits telemetry a span event each time the Notifier is triggered:
+
+  * `[:oban, :notifier, :notify, :start | :stop | :exception]`
+
+  | event        | measures       | metadata                       |
+  | ------------ | -------------- | ------------------------------ |
+  | `:start`     | `:system_time` | `:conf`, `channel`, `payload`  |
+  | `:stop`      | `:duration`    | `:conf`, `channel`, `payload`  |
+  | `:exception` | `:duration`    | `:conf`, `channel`, `payload`  |
+
+  * `:conf` — the config of the Oban supervised producer
+  * `:channel` — the channel on which the notification was sent
+  * `:payload` - the payload that was sent
+
   ### Circuit Events
 
   All processes that interact with the database have circuit breakers to prevent errors from

--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -106,7 +106,7 @@ defmodule Oban.Telemetry do
   | `:exception` | `:duration`    | `:conf`, `engine`  |
 
 
-  * `[:oban, :engine, :complete_job, :start | :stop | :exception]` — when an engine operation is called
+  * `[:oban, :engine, :complete_job, :start | :stop | :exception]`
 
   | event        | measures       | metadata                                                 |
   | ------------ | -------------- | -------------------------------------------------------  |


### PR DESCRIPTION
This PR adds additional telemetry events for 
- `Engine` operations that touch the database
- `Notifier` calls