### PR TITLE
Improve validation and support all opts for queue functions

### DIFF
--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -443,7 +443,7 @@ defmodule Oban do
       :ok
   """
   @doc since: "0.12.0"
-  @spec start_queue(name(), opts :: [{atom(), term()}]) :: :ok
+  @spec start_queue(name(), opts :: Keyword.t()) :: :ok
   def start_queue(name \\ __MODULE__, [_ | _] = opts) do
     conf = config(name)
 

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -436,6 +436,11 @@ defmodule Oban do
 
       Oban.start_queue(queue: :media, limit: 5, local_only: true)
       :ok
+
+  Start the `:media` queue in a `paused` state.
+
+      Oban.start_queue(queue: :media, limit: 5, paused: true)
+      :ok
   """
   @doc since: "0.12.0"
   @spec start_queue(name(), opts :: [{atom(), term()}]) :: :ok
@@ -525,8 +530,10 @@ defmodule Oban do
   ## Options
 
   * `:queue` - a string or atom specifying the queue to scale, required
-  * `:limit` — the new concurrency limit
+  * `:limit` — the new concurrency limit, required
   * `:local_only` — whether the queue will be scaled only on the local node, default: `false`
+
+  In addition, all engine-specific queue options are passed along after validation.
 
   ## Example
 
@@ -553,12 +560,11 @@ defmodule Oban do
     validate_queue_opts!(opts, [:queue, :local_only])
     validate_engine_meta!(conf, opts)
 
-    data = %{
-      action: :scale,
-      queue: opts[:queue],
-      limit: opts[:limit],
-      ident: scope_signal(conf, opts)
-    }
+    data =
+      opts
+      |> Map.new()
+      |> Map.put(:action, :scale)
+      |> Map.put(:ident, scope_signal(conf, opts))
 
     Notifier.notify(conf, :signal, data)
   end

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -419,8 +419,11 @@ defmodule Oban do
   ## Options
 
   * `:queue` - a string or atom specifying the queue to start, required
-  * `:limit` - set the concurrency limit, required
   * `:local_only` - whether the queue will be started only on the local node, default: `false`
+  * `:limit` - set the concurrency limit, required
+  * `:paused` — set whether the queue starts in the "paused" state, optional
+
+  In addition, all engine-specific queue options are passed along after validation.
 
   ## Example
 
@@ -442,12 +445,11 @@ defmodule Oban do
     validate_queue_opts!(opts, [:queue, :local_only])
     validate_engine_meta!(conf, opts)
 
-    data = %{
-      action: :start,
-      queue: opts[:queue],
-      limit: opts[:limit],
-      ident: scope_signal(conf, opts)
-    }
+    data =
+      opts
+      |> Map.new()
+      |> Map.put(:action, :start)
+      |> Map.put(:ident, scope_signal(conf, opts))
 
     Notifier.notify(conf, :signal, data)
   end

--- a/lib/oban/queue/basic_engine.ex
+++ b/lib/oban/queue/basic_engine.ex
@@ -12,12 +12,12 @@ defmodule Oban.Queue.BasicEngine do
   def init(%Config{} = conf, opts) do
     meta =
       opts
-      |> Keyword.put_new(:paused, false)
-      |> Keyword.put(:name, conf.name)
-      |> Keyword.put(:node, conf.node)
-      |> Keyword.put(:started_at, utc_now())
-      |> Keyword.put(:updated_at, utc_now())
       |> Map.new()
+      |> Map.put_new(:paused, false)
+      |> Map.put(:name, conf.name)
+      |> Map.put(:node, conf.node)
+      |> Map.put(:started_at, utc_now())
+      |> Map.put(:updated_at, utc_now())
 
     {:ok, meta}
   end

--- a/lib/oban/queue/drainer.ex
+++ b/lib/oban/queue/drainer.ex
@@ -13,11 +13,11 @@ defmodule Oban.Queue.Drainer do
 
     args =
       opts
-      |> Keyword.put_new(:with_recursion, false)
-      |> Keyword.put_new(:with_safety, true)
-      |> Keyword.put_new(:with_scheduled, false)
-      |> Keyword.update!(:queue, &to_string/1)
       |> Map.new()
+      |> Map.put_new(:with_recursion, false)
+      |> Map.put_new(:with_safety, true)
+      |> Map.put_new(:with_scheduled, false)
+      |> Map.update!(:queue, &to_string/1)
 
     drain(conf, %{failure: 0, success: 0}, args)
   end

--- a/lib/oban/queue/engine.ex
+++ b/lib/oban/queue/engine.ex
@@ -33,6 +33,11 @@ defmodule Oban.Queue.Engine do
   @callback check_meta(conf(), meta(), running()) :: map()
 
   @doc """
+  Validate metadata options for a queue engine.
+  """
+  @callback validate_meta(conf(), opts()) :: :ok | {:error, Exception.t()}
+
+  @doc """
   Fetch available jobs for the given queue, up to configured limits.
   """
   @callback fetch_jobs(conf(), meta(), running()) :: {:ok, {meta(), [Job.t()]}} | {:error, term()}
@@ -94,6 +99,11 @@ defmodule Oban.Queue.Engine do
   @doc false
   def check_meta(%Config{} = conf, %{} = meta, %{} = running) do
     conf.engine.check_meta(conf, meta, running)
+  end
+
+  @doc false
+  def validate_meta(%Config{} = conf, [_ | _] = opts) do
+    conf.engine.validate_meta(conf, opts)
   end
 
   @doc false

--- a/lib/oban/queue/producer.ex
+++ b/lib/oban/queue/producer.ex
@@ -17,7 +17,6 @@ defmodule Oban.Queue.Producer do
       :dispatch_timer,
       :refresh_timer,
       dispatch_cooldown: 5,
-      refresh_interval: :timer.seconds(30),
       running: %{}
     ]
   end
@@ -205,7 +204,7 @@ defmodule Oban.Queue.Producer do
   end
 
   defp schedule_refresh(%State{} = state) do
-    cooldown = Breaker.jitter(state.refresh_interval, mode: :dec, mult: 0.5)
+    cooldown = Breaker.jitter(state.meta.refresh_interval, mode: :dec, mult: 0.5)
     timer = Process.send_after(self(), :refresh, cooldown)
 
     %{state | refresh_timer: timer}

--- a/lib/oban/queue/producer.ex
+++ b/lib/oban/queue/producer.ex
@@ -132,8 +132,12 @@ defmodule Oban.Queue.Producer do
         %{"action" => "resume", "queue" => ^queue} ->
           Engine.put_meta(state.conf, state.meta, :paused, false)
 
-        %{"action" => "scale", "queue" => ^queue, "limit" => limit} ->
-          Engine.put_meta(state.conf, state.meta, :limit, limit)
+        %{"action" => "scale", "queue" => ^queue} ->
+          payload
+          |> Map.drop(["action", "queue"])
+          |> Enum.reduce(state.meta, fn {key, val}, meta ->
+            Engine.put_meta(state.conf, meta, String.to_existing_atom(key), val)
+          end)
 
         %{"action" => "pkill", "job_id" => jid} ->
           for {ref, {pid, exec}} <- state.running, exec.job.id == jid do

--- a/test/integration/checking_test.exs
+++ b/test/integration/checking_test.exs
@@ -20,4 +20,11 @@ defmodule Oban.Integration.CheckingTest do
     assert %{limit: 2, queue: "gamma", running: [_]} = Oban.check_queue(name, queue: :gamma)
     assert %{paused: true, queue: "delta", running: []} = Oban.check_queue(name, queue: :delta)
   end
+
+  test "checking an unknown or invalid queue" do
+    name = start_supervised_oban!(queues: [])
+
+    assert_raise ArgumentError, fn -> Oban.check_queue(name, wrong: nil) end
+    assert_raise ArgumentError, fn -> Oban.check_queue(name, queue: nil) end
+  end
 end

--- a/test/integration/controlling_test.exs
+++ b/test/integration/controlling_test.exs
@@ -170,6 +170,20 @@ defmodule Oban.Integration.ControllingTest do
       end)
     end
 
+    test "forwarding scaling options for alternative engines" do
+      # This is an abuse of `scale` because other engines support other options and passing
+      # `paused` verifies that other options are supported.
+      name = start_supervised_oban!(queues: [alpha: 1])
+
+      wait_for_notifier(name)
+
+      assert :ok = Oban.scale_queue(name, queue: :alpha, limit: 5, paused: true)
+
+      with_backoff(fn ->
+        assert %{limit: 5, paused: true} = Oban.check_queue(name, queue: :alpha)
+      end)
+    end
+
     test "scaling queues only on the local node" do
       name1 = start_supervised_oban!(queues: [alpha: 2])
       name2 = start_supervised_oban!(queues: [alpha: 2])

--- a/test/integration/controlling_test.exs
+++ b/test/integration/controlling_test.exs
@@ -7,10 +7,13 @@ defmodule Oban.Integration.ControllingTest do
 
   describe "start_queue/2" do
     test "validating options" do
-      assert_invalid_opts(:start_queue, queue: nil)
-      assert_invalid_opts(:start_queue, limit: -1)
-      assert_invalid_opts(:start_queue, local_only: -1)
-      assert_invalid_opts(:start_queue, wat: -1)
+      name = start_supervised_oban!(queues: [])
+
+      assert_invalid_opts(name, :start_queue, [])
+      assert_invalid_opts(name, :start_queue, queue: nil)
+      assert_invalid_opts(name, :start_queue, limit: -1)
+      assert_invalid_opts(name, :start_queue, local_only: -1)
+      assert_invalid_opts(name, :start_queue, wat: -1)
     end
 
     test "starting individual queues dynamically" do
@@ -44,8 +47,10 @@ defmodule Oban.Integration.ControllingTest do
 
   describe "stop_queue/2" do
     test "validating options" do
-      assert_invalid_opts(:start_queue, queue: nil)
-      assert_invalid_opts(:start_queue, local_only: -1)
+      name = start_supervised_oban!(queues: [])
+
+      assert_invalid_opts(name, :start_queue, queue: nil)
+      assert_invalid_opts(name, :start_queue, local_only: -1)
     end
 
     test "stopping individual queues" do
@@ -81,11 +86,13 @@ defmodule Oban.Integration.ControllingTest do
 
   describe "pause_queue/2 and resume_queue/2" do
     test "validating options" do
-      assert_invalid_opts(:pause_queue, queue: nil)
-      assert_invalid_opts(:pause_queue, local_only: -1)
+      name = start_supervised_oban!(queues: [])
 
-      assert_invalid_opts(:resume_queue, queue: nil)
-      assert_invalid_opts(:resume_queue, local_only: -1)
+      assert_invalid_opts(name, :pause_queue, queue: nil)
+      assert_invalid_opts(name, :pause_queue, local_only: -1)
+
+      assert_invalid_opts(name, :resume_queue, queue: nil)
+      assert_invalid_opts(name, :resume_queue, local_only: -1)
     end
 
     test "pausing and resuming individual queues" do
@@ -145,9 +152,12 @@ defmodule Oban.Integration.ControllingTest do
 
   describe "scale_queue/2" do
     test "validating options" do
-      assert_invalid_opts(:scale_queue, queue: nil)
-      assert_invalid_opts(:scale_queue, limit: -1)
-      assert_invalid_opts(:scale_queue, local_only: -1)
+      name = start_supervised_oban!(queues: [])
+
+      assert_invalid_opts(name, :scale_queue, [])
+      assert_invalid_opts(name, :scale_queue, queue: nil)
+      assert_invalid_opts(name, :scale_queue, limit: -1)
+      assert_invalid_opts(name, :scale_queue, local_only: -1)
     end
 
     test "scaling queues up" do
@@ -309,7 +319,7 @@ defmodule Oban.Integration.ControllingTest do
     end)
   end
 
-  defp assert_invalid_opts(function_name, opts) do
-    assert_raise ArgumentError, fn -> apply(Oban, function_name, [opts]) end
+  defp assert_invalid_opts(oban_name, function_name, opts) do
+    assert_raise ArgumentError, fn -> apply(oban_name, function_name, [opts]) end
   end
 end

--- a/test/integration/controlling_test.exs
+++ b/test/integration/controlling_test.exs
@@ -19,13 +19,13 @@ defmodule Oban.Integration.ControllingTest do
     test "starting individual queues dynamically" do
       name = start_supervised_oban!(queues: [alpha: 9])
 
-      assert :ok = Oban.start_queue(name, queue: :gamma, limit: 5)
+      assert :ok = Oban.start_queue(name, queue: :gamma, limit: 5, refresh_interval: 10)
       assert :ok = Oban.start_queue(name, queue: :delta, limit: 6, paused: true)
       assert :ok = Oban.start_queue(name, queue: :alpha, limit: 5)
 
       with_backoff(fn ->
         assert %{limit: 9} = Oban.check_queue(name, queue: :alpha)
-        assert %{limit: 5} = Oban.check_queue(name, queue: :gamma)
+        assert %{limit: 5, refresh_interval: 10} = Oban.check_queue(name, queue: :gamma)
         assert %{limit: 6, paused: true} = Oban.check_queue(name, queue: :delta)
       end)
     end

--- a/test/integration/controlling_test.exs
+++ b/test/integration/controlling_test.exs
@@ -20,21 +20,19 @@ defmodule Oban.Integration.ControllingTest do
       name = start_supervised_oban!(queues: [alpha: 9])
 
       assert :ok = Oban.start_queue(name, queue: :gamma, limit: 5)
-      assert :ok = Oban.start_queue(name, queue: :delta, limit: 6)
+      assert :ok = Oban.start_queue(name, queue: :delta, limit: 6, paused: true)
       assert :ok = Oban.start_queue(name, queue: :alpha, limit: 5)
 
       with_backoff(fn ->
         assert %{limit: 9} = Oban.check_queue(name, queue: :alpha)
         assert %{limit: 5} = Oban.check_queue(name, queue: :gamma)
-        assert %{limit: 6} = Oban.check_queue(name, queue: :delta)
+        assert %{limit: 6, paused: true} = Oban.check_queue(name, queue: :delta)
       end)
     end
 
     test "starting individual queues only on the local node" do
       name1 = start_supervised_oban!(queues: [])
       name2 = start_supervised_oban!(queues: [])
-
-      wait_for_notifier(name1)
 
       assert :ok = Oban.start_queue(name1, queue: :alpha, limit: 1, local_only: true)
 

--- a/test/oban/notifier_test.exs
+++ b/test/oban/notifier_test.exs
@@ -1,0 +1,26 @@
+defmodule Oban.NotifierTest do
+  use Oban.Case
+
+  alias Oban.Notifier
+
+  describe "listen/notify" do
+    test "notifying with complex types" do
+      name = start_supervised_oban!(queues: [])
+
+      Notifier.listen(name, [:signal])
+
+      Notifier.notify(name, :signal, %{
+        date: ~D[2021-08-09],
+        keyword: [a: 1, b: 1],
+        map: %{tuple: {1, :second}},
+        tuple: {1, :second}
+      })
+
+      assert_receive {:notification, :signal, notice}
+      assert %{"date" => "2021-08-09", "keyword" => [["a", 1], ["b", 1]]} = notice
+      assert %{"map" => %{"tuple" => [1, "second"]}, "tuple" => [1, "second"]} = notice
+
+      stop_supervised(Oban)
+    end
+  end
+end


### PR DESCRIPTION
This will allow calling a function like `Oban.scale_queue(queue: :special, global_limit: 10)`. It still requires some tweaks on serialization to make `rate_limit` work as well.

Closes #503