### PR TITLE
 Add option to inhibit schema creation in migrations

### DIFF
--- a/lib/oban/migrations.ex
+++ b/lib/oban/migrations.ex
@@ -107,7 +107,7 @@ defmodule Oban.Migrations do
   def up(opts \\ []) when is_list(opts) do
     prefix = Keyword.get(opts, :prefix, @default_prefix)
     version = Keyword.get(opts, :version, @current_version)
-    create_schema = Keyword.get(opts, :create_schema, true)
+    create_schema = Keyword.get(opts, :create_schema, prefix != "public")
     initial = migrated_version(repo(), prefix)
 
     cond do

--- a/lib/oban/migrations/v01.ex
+++ b/lib/oban/migrations/v01.ex
@@ -3,7 +3,7 @@ defmodule Oban.Migrations.V01 do
 
   use Ecto.Migration
 
-  def up(prefix, create_schema) do
+  def up(prefix: prefix, create_schema: create_schema) do
     if create_schema, do: execute("CREATE SCHEMA IF NOT EXISTS #{prefix}")
 
     execute """
@@ -85,7 +85,7 @@ defmodule Oban.Migrations.V01 do
     """
   end
 
-  def down(prefix) do
+  def down(prefix: prefix) do
     execute "DROP TRIGGER IF EXISTS oban_notify ON #{prefix}.oban_jobs"
     execute "DROP FUNCTION IF EXISTS #{prefix}.oban_jobs_notify()"
 

--- a/lib/oban/migrations/v01.ex
+++ b/lib/oban/migrations/v01.ex
@@ -4,7 +4,7 @@ defmodule Oban.Migrations.V01 do
   use Ecto.Migration
 
   def up(prefix, create_schema) do
-    if prefix != "public" && create_schema, do: execute("CREATE SCHEMA IF NOT EXISTS #{prefix}")
+    if create_schema, do: execute("CREATE SCHEMA IF NOT EXISTS #{prefix}")
 
     execute """
     DO $$

--- a/lib/oban/migrations/v01.ex
+++ b/lib/oban/migrations/v01.ex
@@ -3,7 +3,7 @@ defmodule Oban.Migrations.V01 do
 
   use Ecto.Migration
 
-  def up(prefix: prefix, create_schema: create_schema) do
+  def up(%{prefix: prefix, create_schema: create_schema}) do
     if create_schema, do: execute("CREATE SCHEMA IF NOT EXISTS #{prefix}")
 
     execute """
@@ -85,7 +85,7 @@ defmodule Oban.Migrations.V01 do
     """
   end
 
-  def down(prefix: prefix) do
+  def down(%{prefix: prefix}) do
     execute "DROP TRIGGER IF EXISTS oban_notify ON #{prefix}.oban_jobs"
     execute "DROP FUNCTION IF EXISTS #{prefix}.oban_jobs_notify()"
 

--- a/lib/oban/migrations/v01.ex
+++ b/lib/oban/migrations/v01.ex
@@ -3,8 +3,8 @@ defmodule Oban.Migrations.V01 do
 
   use Ecto.Migration
 
-  def up(prefix) do
-    if prefix != "public", do: execute("CREATE SCHEMA IF NOT EXISTS #{prefix}")
+  def up(prefix, create_schema) do
+    if prefix != "public" && create_schema, do: execute("CREATE SCHEMA IF NOT EXISTS #{prefix}")
 
     execute """
     DO $$

--- a/lib/oban/migrations/v02.ex
+++ b/lib/oban/migrations/v02.ex
@@ -3,7 +3,7 @@ defmodule Oban.Migrations.V02 do
 
   use Ecto.Migration
 
-  def up(prefix: prefix) do
+  def up(%{prefix: prefix}) do
     # We only need the scheduled_at index for scheduled and available jobs
     drop_if_exists index(:oban_jobs, [:scheduled_at], prefix: prefix)
 
@@ -33,7 +33,7 @@ defmodule Oban.Migrations.V02 do
     """
   end
 
-  def down(prefix: prefix) do
+  def down(%{prefix: prefix}) do
     drop_if_exists constraint(:oban_jobs, :queue_length, prefix: prefix)
     drop_if_exists constraint(:oban_jobs, :worker_length, prefix: prefix)
 

--- a/lib/oban/migrations/v02.ex
+++ b/lib/oban/migrations/v02.ex
@@ -3,7 +3,7 @@ defmodule Oban.Migrations.V02 do
 
   use Ecto.Migration
 
-  def up(prefix) do
+  def up(prefix: prefix) do
     # We only need the scheduled_at index for scheduled and available jobs
     drop_if_exists index(:oban_jobs, [:scheduled_at], prefix: prefix)
 
@@ -33,7 +33,7 @@ defmodule Oban.Migrations.V02 do
     """
   end
 
-  def down(prefix) do
+  def down(prefix: prefix) do
     drop_if_exists constraint(:oban_jobs, :queue_length, prefix: prefix)
     drop_if_exists constraint(:oban_jobs, :worker_length, prefix: prefix)
 

--- a/lib/oban/migrations/v03.ex
+++ b/lib/oban/migrations/v03.ex
@@ -3,13 +3,13 @@ defmodule Oban.Migrations.V03 do
 
   use Ecto.Migration
 
-  def up(prefix) do
+  def up(prefix: prefix) do
     alter table(:oban_jobs, prefix: prefix) do
       add_if_not_exists(:attempted_by, {:array, :text})
     end
   end
 
-  def down(prefix) do
+  def down(prefix: prefix) do
     alter table(:oban_jobs, prefix: prefix) do
       remove_if_exists(:attempted_by, {:array, :text})
     end

--- a/lib/oban/migrations/v03.ex
+++ b/lib/oban/migrations/v03.ex
@@ -3,13 +3,13 @@ defmodule Oban.Migrations.V03 do
 
   use Ecto.Migration
 
-  def up(prefix: prefix) do
+  def up(%{prefix: prefix}) do
     alter table(:oban_jobs, prefix: prefix) do
       add_if_not_exists(:attempted_by, {:array, :text})
     end
   end
 
-  def down(prefix: prefix) do
+  def down(%{prefix: prefix}) do
     alter table(:oban_jobs, prefix: prefix) do
       remove_if_exists(:attempted_by, {:array, :text})
     end

--- a/lib/oban/migrations/v04.ex
+++ b/lib/oban/migrations/v04.ex
@@ -3,11 +3,11 @@ defmodule Oban.Migrations.V04 do
 
   use Ecto.Migration
 
-  def up(prefix) do
+  def up(prefix: prefix) do
     execute("DROP FUNCTION IF EXISTS #{prefix}.oban_wrap_id(value bigint)")
   end
 
-  def down(prefix) do
+  def down(prefix: prefix) do
     execute """
     CREATE OR REPLACE FUNCTION #{prefix}.oban_wrap_id(value bigint) RETURNS int AS $$
     BEGIN

--- a/lib/oban/migrations/v04.ex
+++ b/lib/oban/migrations/v04.ex
@@ -3,11 +3,11 @@ defmodule Oban.Migrations.V04 do
 
   use Ecto.Migration
 
-  def up(prefix: prefix) do
+  def up(%{prefix: prefix}) do
     execute("DROP FUNCTION IF EXISTS #{prefix}.oban_wrap_id(value bigint)")
   end
 
-  def down(prefix: prefix) do
+  def down(%{prefix: prefix}) do
     execute """
     CREATE OR REPLACE FUNCTION #{prefix}.oban_wrap_id(value bigint) RETURNS int AS $$
     BEGIN

--- a/lib/oban/migrations/v05.ex
+++ b/lib/oban/migrations/v05.ex
@@ -3,7 +3,7 @@ defmodule Oban.Migrations.V05 do
 
   use Ecto.Migration
 
-  def up(prefix) do
+  def up(prefix: prefix) do
     drop_if_exists index(:oban_jobs, [:scheduled_at], prefix: prefix)
     drop_if_exists index(:oban_jobs, [:queue], prefix: prefix)
     drop_if_exists index(:oban_jobs, [:state], prefix: prefix)
@@ -11,7 +11,7 @@ defmodule Oban.Migrations.V05 do
     create_if_not_exists index(:oban_jobs, [:queue, :state, :scheduled_at, :id], prefix: prefix)
   end
 
-  def down(prefix) do
+  def down(prefix: prefix) do
     drop_if_exists index(:oban_jobs, [:queue, :state, :scheduled_at, :id], prefix: prefix)
 
     state = "#{prefix}.oban_job_state"

--- a/lib/oban/migrations/v05.ex
+++ b/lib/oban/migrations/v05.ex
@@ -3,7 +3,7 @@ defmodule Oban.Migrations.V05 do
 
   use Ecto.Migration
 
-  def up(prefix: prefix) do
+  def up(%{prefix: prefix}) do
     drop_if_exists index(:oban_jobs, [:scheduled_at], prefix: prefix)
     drop_if_exists index(:oban_jobs, [:queue], prefix: prefix)
     drop_if_exists index(:oban_jobs, [:state], prefix: prefix)
@@ -11,7 +11,7 @@ defmodule Oban.Migrations.V05 do
     create_if_not_exists index(:oban_jobs, [:queue, :state, :scheduled_at, :id], prefix: prefix)
   end
 
-  def down(prefix: prefix) do
+  def down(%{prefix: prefix}) do
     drop_if_exists index(:oban_jobs, [:queue, :state, :scheduled_at, :id], prefix: prefix)
 
     state = "#{prefix}.oban_job_state"

--- a/lib/oban/migrations/v06.ex
+++ b/lib/oban/migrations/v06.ex
@@ -3,11 +3,11 @@ defmodule Oban.Migrations.V06 do
 
   use Ecto.Migration
 
-  def up(_prefix) do
+  def up(_opts) do
     # This used to modify oban_beats, which aren't included anymore
   end
 
-  def down(_prefix) do
+  def down(_opts) do
     # This used to modify oban_beats, which aren't included anymore
   end
 end

--- a/lib/oban/migrations/v07.ex
+++ b/lib/oban/migrations/v07.ex
@@ -3,7 +3,7 @@ defmodule Oban.Migrations.V07 do
 
   use Ecto.Migration
 
-  def up(prefix) do
+  def up(prefix: prefix) do
     create_if_not_exists index(
                            :oban_jobs,
                            ["attempted_at desc", :id],
@@ -13,7 +13,7 @@ defmodule Oban.Migrations.V07 do
                          )
   end
 
-  def down(prefix) do
+  def down(prefix: prefix) do
     drop_if_exists index(:oban_jobs, [:attempted_at, :id], prefix: prefix)
   end
 end

--- a/lib/oban/migrations/v07.ex
+++ b/lib/oban/migrations/v07.ex
@@ -3,7 +3,7 @@ defmodule Oban.Migrations.V07 do
 
   use Ecto.Migration
 
-  def up(prefix: prefix) do
+  def up(%{prefix: prefix}) do
     create_if_not_exists index(
                            :oban_jobs,
                            ["attempted_at desc", :id],
@@ -13,7 +13,7 @@ defmodule Oban.Migrations.V07 do
                          )
   end
 
-  def down(prefix: prefix) do
+  def down(%{prefix: prefix}) do
     drop_if_exists index(:oban_jobs, [:attempted_at, :id], prefix: prefix)
   end
 end

--- a/lib/oban/migrations/v08.ex
+++ b/lib/oban/migrations/v08.ex
@@ -3,7 +3,7 @@ defmodule Oban.Migrations.V08 do
 
   use Ecto.Migration
 
-  def up(prefix: prefix) do
+  def up(%{prefix: prefix}) do
     alter table(:oban_jobs, prefix: prefix) do
       add_if_not_exists(:discarded_at, :utc_datetime_usec)
       add_if_not_exists(:priority, :integer)
@@ -48,7 +48,7 @@ defmodule Oban.Migrations.V08 do
     """
   end
 
-  def down(prefix: prefix) do
+  def down(%{prefix: prefix}) do
     drop_if_exists index(:oban_jobs, [:queue, :state, :priority, :scheduled_at, :id],
                      prefix: prefix
                    )

--- a/lib/oban/migrations/v08.ex
+++ b/lib/oban/migrations/v08.ex
@@ -3,7 +3,7 @@ defmodule Oban.Migrations.V08 do
 
   use Ecto.Migration
 
-  def up(prefix) do
+  def up(prefix: prefix) do
     alter table(:oban_jobs, prefix: prefix) do
       add_if_not_exists(:discarded_at, :utc_datetime_usec)
       add_if_not_exists(:priority, :integer)
@@ -48,7 +48,7 @@ defmodule Oban.Migrations.V08 do
     """
   end
 
-  def down(prefix) do
+  def down(prefix: prefix) do
     drop_if_exists index(:oban_jobs, [:queue, :state, :priority, :scheduled_at, :id],
                      prefix: prefix
                    )

--- a/lib/oban/migrations/v09.ex
+++ b/lib/oban/migrations/v09.ex
@@ -3,7 +3,7 @@ defmodule Oban.Migrations.V09 do
 
   use Ecto.Migration
 
-  def up(prefix: prefix) do
+  def up(%{prefix: prefix}) do
     alter table(:oban_jobs, prefix: prefix) do
       add_if_not_exists(:meta, :map, default: %{})
       add_if_not_exists(:cancelled_at, :utc_datetime_usec)
@@ -51,7 +51,7 @@ defmodule Oban.Migrations.V09 do
                          )
   end
 
-  def down(prefix: prefix) do
+  def down(%{prefix: prefix}) do
     alter table(:oban_jobs, prefix: prefix) do
       remove_if_exists(:meta, :map)
       remove_if_exists(:cancelled_at, :utc_datetime_usec)

--- a/lib/oban/migrations/v09.ex
+++ b/lib/oban/migrations/v09.ex
@@ -3,7 +3,7 @@ defmodule Oban.Migrations.V09 do
 
   use Ecto.Migration
 
-  def up(prefix) do
+  def up(prefix: prefix) do
     alter table(:oban_jobs, prefix: prefix) do
       add_if_not_exists(:meta, :map, default: %{})
       add_if_not_exists(:cancelled_at, :utc_datetime_usec)
@@ -51,7 +51,7 @@ defmodule Oban.Migrations.V09 do
                          )
   end
 
-  def down(prefix) do
+  def down(prefix: prefix) do
     alter table(:oban_jobs, prefix: prefix) do
       remove_if_exists(:meta, :map)
       remove_if_exists(:cancelled_at, :utc_datetime_usec)

--- a/lib/oban/migrations/v10.ex
+++ b/lib/oban/migrations/v10.ex
@@ -3,7 +3,7 @@ defmodule Oban.Migrations.V10 do
 
   use Ecto.Migration
 
-  def up(prefix: prefix) do
+  def up(%{prefix: prefix}) do
     # These didn't have defaults out of consideration for older PG versions
     alter table(:oban_jobs, prefix: prefix) do
       modify :args, :map, default: %{}
@@ -40,7 +40,7 @@ defmodule Oban.Migrations.V10 do
     create_if_not_exists index(:oban_jobs, [:meta], using: :gin, prefix: prefix)
   end
 
-  def down(prefix: prefix) do
+  def down(%{prefix: prefix}) do
     alter table(:oban_jobs, prefix: prefix) do
       modify :args, :map, default: nil
       modify :priority, :integer, null: true

--- a/lib/oban/migrations/v10.ex
+++ b/lib/oban/migrations/v10.ex
@@ -3,7 +3,7 @@ defmodule Oban.Migrations.V10 do
 
   use Ecto.Migration
 
-  def up(prefix) do
+  def up(prefix: prefix) do
     # These didn't have defaults out of consideration for older PG versions
     alter table(:oban_jobs, prefix: prefix) do
       modify :args, :map, default: %{}
@@ -40,7 +40,7 @@ defmodule Oban.Migrations.V10 do
     create_if_not_exists index(:oban_jobs, [:meta], using: :gin, prefix: prefix)
   end
 
-  def down(prefix) do
+  def down(prefix: prefix) do
     alter table(:oban_jobs, prefix: prefix) do
       modify :args, :map, default: nil
       modify :priority, :integer, null: true


### PR DESCRIPTION
Hi @sorentwo! 👋 I don't know if you remember, but we discussed on Slack the addition of an option to inhibit the schema creation during the migration when the `prefix` option is used. Automatic schema creation can cause problems if the database user in the production database you are deploying to doesn't have permissions to create new schemas.

Here's my stab at it. My personal opinion is that `Oban.Migrations` could use some refactoring, but I tried to keep my changes to a bare minimum. Looking forward to your feedback!