### PR TITLE
Allow meta as a unique field with keys support

### DIFF
--- a/test/integration/uniqueness_test.exs
+++ b/test/integration/uniqueness_test.exs
@@ -39,6 +39,7 @@ defmodule Oban.Integration.UniquenessTest do
   test "scoping uniqueness to particular fields", context do
     assert %Job{id: id_1} = unique_insert!(context.name, %{id: 1}, queue: "default")
     assert %Job{id: id_2} = unique_insert!(context.name, %{id: 2}, queue: "delta")
+
     assert %Job{id: ^id_2} = unique_insert!(context.name, %{id: 1}, unique: [fields: [:worker]])
 
     assert %Job{id: ^id_1} =
@@ -67,6 +68,18 @@ defmodule Oban.Integration.UniquenessTest do
              unique_insert!(context.name, %{id: 2, url: "https://a.co"}, unique: [keys: [:id]])
 
     assert %Job{id: ^id_2} = unique_insert!(context.name, %{"id" => 2}, unique: [keys: [:id]])
+
+    assert count_jobs() == 2
+  end
+
+  test "scoping uniqueness by specific meta keys", %{name: name} do
+    unique = [fields: [:meta], keys: [:slug]]
+
+    assert %Job{id: id_1} = unique_insert!(name, %{}, meta: %{slug: "abc123"}, unique: unique)
+    assert %Job{id: id_2} = unique_insert!(name, %{}, meta: %{slug: "def456"}, unique: unique)
+
+    assert %Job{id: ^id_1} = unique_insert!(name, %{}, meta: %{slug: "abc123"}, unique: unique)
+    assert %Job{id: ^id_2} = unique_insert!(name, %{}, meta: %{slug: "def456"}, unique: unique)
 
     assert count_jobs() == 2
   end

--- a/test/oban/job_test.exs
+++ b/test/oban/job_test.exs
@@ -58,10 +58,11 @@ defmodule Oban.JobTest do
     end
 
     test "overriding unique defaults" do
-      changeset = Job.new(%{}, worker: Fake, unique: [fields: [:worker], states: [:available]])
+      changeset =
+        Job.new(%{}, worker: Fake, unique: [fields: [:meta, :worker], states: [:available]])
 
       assert changeset.changes[:unique] == %{
-               fields: [:worker],
+               fields: [:meta, :worker],
                keys: [],
                period: 60,
                states: [:available]


### PR DESCRIPTION
This adds support for `meta` as an available unique field, though not included by default. The eventual goal is to eliminate the `args` index and rely on a single computed value in `meta`, which is a much smaller column in most cases.