### PR TITLE
Add insert_all clause to match empty changesets list

### DIFF
--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -304,7 +304,7 @@ defmodule Oban do
   @spec insert_all(name(), changesets_or_wrapper()) :: [Job.t()]
   def insert_all(name \\ __MODULE__, changesets_or_wrapper)
 
-  def insert_all(name, %{changesets: [_ | _] = changesets}) do
+  def insert_all(name, %{changesets: changesets}) when is_list(changesets) do
     insert_all(name, changesets)
   end
 
@@ -336,7 +336,7 @@ defmodule Oban do
         ) :: Multi.t()
   def insert_all(name \\ __MODULE__, multi, multi_name, changesets_or_wrapper)
 
-  def insert_all(name, multi, multi_name, %{changesets: [_ | _] = changesets}) do
+  def insert_all(name, multi, multi_name, %{changesets: changesets}) when is_list(changesets) do
     insert_all(name, multi, multi_name, changesets)
   end
 

--- a/test/integration/inserting_test.exs
+++ b/test/integration/inserting_test.exs
@@ -46,9 +46,8 @@ defmodule Oban.Integration.InsertingTest do
 
   test "handling empty changesets list from wrapper with insert_all/2" do
     name = start_supervised_oban!(queues: false)
-    wrap = %{changesets: []}
 
-    assert [] = Oban.insert_all(name, wrap)
+    assert [] = Oban.insert_all(name, %{changesets: []})
   end
 
   test "inserting multiple jobs within a multi using insert_all/4" do

--- a/test/integration/inserting_test.exs
+++ b/test/integration/inserting_test.exs
@@ -98,11 +98,10 @@ defmodule Oban.Integration.InsertingTest do
 
   test "handling empty changesets list from wrapper using insert_all/4" do
     name = start_supervised_oban!(queues: false)
-    wrap = %{changesets: []}
 
-    assert {:ok, %{}} =
+    assert {:ok, %{jobs: []}} =
              name
-             |> Oban.insert_all(Ecto.Multi.new(), "jobs", wrap)
+             |> Oban.insert_all(Ecto.Multi.new(), :jobs, %{changesets: []})
              |> Repo.transaction()
   end
 end

--- a/test/integration/inserting_test.exs
+++ b/test/integration/inserting_test.exs
@@ -44,6 +44,13 @@ defmodule Oban.Integration.InsertingTest do
     [_job_1, _job_2] = Oban.insert_all(name, wrap)
   end
 
+  test "handling empty changesets list from wrapper with insert_all/2" do
+    name = start_supervised_oban!(queues: false)
+    wrap = %{changesets: []}
+
+    assert [] = Oban.insert_all(name, wrap)
+  end
+
   test "inserting multiple jobs within a multi using insert_all/4" do
     name = start_supervised_oban!(queues: false)
 
@@ -88,5 +95,15 @@ defmodule Oban.Integration.InsertingTest do
       name
       |> Oban.insert_all(Ecto.Multi.new(), "jobs", wrap)
       |> Repo.transaction()
+  end
+
+  test "handling empty changesets list from wrapper using insert_all/4" do
+    name = start_supervised_oban!(queues: false)
+    wrap = %{changesets: []}
+
+    assert {:ok, %{}} =
+             name
+             |> Oban.insert_all(Ecto.Multi.new(), "jobs", wrap)
+             |> Repo.transaction()
   end
 end


### PR DESCRIPTION
Currently `Oban.insert_all` does not handle when a wrapper is given with an empty list of changesets. This can be reproduced passing a wrapper like `Workflow` that has no changesets:
```elixir
** (FunctionClauseError) no function clause matching in Oban.insert_all/2    
    
    The following arguments were given to Oban.insert_all/2:
    
        # 1
        Oban
    
        # 2
        %Oban.Pro.Workers.Workflow{
          changesets: [],
          id: "2a464755-77dd-496c-ae68-d03ced6084bf",
          names: #MapSet<[]>,
          opts: %{}
        }
    
    Attempted function clauses (showing 2 out of 2):
    
        def insert_all(name, %{changesets: [_ | _] = changesets})
        def insert_all(name, changesets) when is_list(changesets)
    
    (oban 2.8.0) lib/oban.ex:302: Oban.insert_all/2
```

This PR adds new `insert_all/2` and `insert_all/4` functions clauses that handle empty changeset lists.