### PR TITLE
Validate that a queue exists when checking/controlling queues while `local_only: true` is provided

### DIFF
--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -866,7 +866,7 @@ defmodule Oban do
     queue = opts[:queue]
     local_only = opts[:local_only]
 
-    if local_only && is_nil(Registry.whereis(name, {:producer, to_string(queue)})) do
+    if local_only and is_nil(Registry.whereis(name, {:producer, to_string(queue)})) do
       raise ArgumentError, "queue #{inspect(queue)} does not exist locally"
     end
   end

--- a/lib/oban/registry.ex
+++ b/lib/oban/registry.ex
@@ -56,6 +56,10 @@ defmodule Oban.Registry do
   Get the pid for a plugin:
 
       Oban.Registry.whereis(Oban, {:plugin, MyApp.Oban.Plugin})
+
+  Get the pid for a queue's producer:
+
+      Oban.Registry.whereis(Oban, {:producer, :default})
   """
   @spec whereis(Oban.name(), role()) :: pid() | nil
   def whereis(oban_name, role \\ nil) do

--- a/test/integration/controlling_test.exs
+++ b/test/integration/controlling_test.exs
@@ -80,6 +80,16 @@ defmodule Oban.Integration.ControllingTest do
         refute supervised_queue?(name2, "alpha")
       end)
     end
+
+    test "trying to stop queues that don't exist" do
+      name = start_supervised_oban!(queues: [])
+
+      assert :ok = Oban.pause_queue(name, queue: :alpha)
+
+      assert_raise ArgumentError, "queue :alpha does not exist locally", fn ->
+        Oban.pause_queue(name, queue: :alpha, local_only: true)
+      end
+    end
   end
 
   describe "pause_queue/2 and resume_queue/2" do
@@ -146,6 +156,26 @@ defmodule Oban.Integration.ControllingTest do
         assert %{paused: true} = Oban.check_queue(name2, queue: :alpha)
       end)
     end
+
+    test "trying to resume queues that don't exist" do
+      name = start_supervised_oban!(queues: [])
+
+      assert :ok = Oban.resume_queue(name, queue: :alpha)
+
+      assert_raise ArgumentError, "queue :alpha does not exist locally", fn ->
+        Oban.resume_queue(name, queue: :alpha, local_only: true)
+      end
+    end
+
+    test "trying to pause queues that don't exist" do
+      name = start_supervised_oban!(queues: [])
+
+      assert :ok = Oban.pause_queue(name, queue: :alpha)
+
+      assert_raise ArgumentError, "queue :alpha does not exist locally", fn ->
+        Oban.pause_queue(name, queue: :alpha, local_only: true)
+      end
+    end
   end
 
   describe "scale_queue/2" do
@@ -197,6 +227,16 @@ defmodule Oban.Integration.ControllingTest do
         assert %{limit: 2} = Oban.check_queue(name1, queue: :alpha)
         assert %{limit: 1} = Oban.check_queue(name2, queue: :alpha)
       end)
+    end
+
+    test "trying to scale queues that don't exist" do
+      name = start_supervised_oban!(queues: [])
+
+      assert :ok = Oban.scale_queue(name, queue: :alpha, limit: 1)
+
+      assert_raise ArgumentError, "queue :alpha does not exist locally", fn ->
+        Oban.scale_queue(name, queue: :alpha, limit: 1, local_only: true)
+      end
     end
   end
 


### PR DESCRIPTION
Hi, this should be a ticket that resolves the issue I made [here](https://github.com/sorentwo/oban/issues/553)

Not sure if this is what you had intended 😅 I'm not too familiar with trying to contribute to OSS so I hope this is okay!

Eager to hear any feedback!