### PR TITLE
fix md MyApp.ErrorReporter.maybe_get_worker_struct/1 that uses Oban.W…

### DIFF
--- a/guides/recipes/expected-failures.md
+++ b/guides/recipes/expected-failures.md
@@ -80,6 +80,7 @@ defmodule MyApp.ErrorReporter do
     try do
       worker
       |> Oban.Worker.from_string()
+      |> elem(1)
       |> struct()
     rescue
       UndefinedFunctionError -> worker


### PR DESCRIPTION
…orker.from_string() expecting to get a module name instead of {:ok, module_name}