### PR TITLE
Telemetry module capture

### DIFF
--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -329,7 +329,7 @@ defmodule Oban.Telemetry do
       telemetry_prefix ++ [:circuit, :open]
     ]
 
-    :telemetry.attach_many("oban-default-logger", events, &handle_event/4, level)
+    :telemetry.attach_many("oban-default-logger", events, &__MODULE__.handle_event/4, level)
   end
 
   @deprecated "Use the official :telemetry.span/3 instead"


### PR DESCRIPTION
## Motivation

After upgrading to telemetry 1.0 I started seeing the following warnings.

```
16:12:45.639 [info] Function passed as a handler with ID "oban-default-logger" is local function.
This mean that it is either anonymous function or capture of function without module specified. That may cause performance penalty when calling such handler. For more details see note in `telemetry:attach/4` documentation.
```


## Proposed solution

Use function captures with the module specified in the call to `:telemetry.attach/4` 

Ref https://hexdocs.pm/telemetry/telemetry.html#attach/4
