### PR TITLE
Fix error when a job exits with something other than a stacktrace

### DIFF
--- a/lib/oban/queue/executor.ex
+++ b/lib/oban/queue/executor.ex
@@ -170,10 +170,16 @@ defmodule Oban.Queue.Executor do
   def emit_event(%__MODULE__{state: :failure} = exec) do
     measurements = %{duration: exec.duration, queue_time: exec.queue_time}
 
+    kind =
+      case exec.kind do
+        {:EXIT, _pid} -> :exit
+        kind when kind in [:exit, :throw, :error] -> kind
+      end
+
     meta =
       Map.merge(exec.meta, %{
         job: exec.job,
-        kind: exec.kind,
+        kind: kind,
         error: exec.error,
         reason: exec.error,
         stacktrace: exec.stacktrace,

--- a/test/integration/executing_test.exs
+++ b/test/integration/executing_test.exs
@@ -71,7 +71,8 @@ defmodule Oban.Integration.ExecutingTest do
 
   defp job do
     gen all queue <- member_of(~w(alpha beta gamma delta)),
-            action <- member_of(~w(OK DISCARD ERROR EXIT FAIL KILL SNOOZE TASK_ERROR)),
+            action <-
+              member_of(~w(OK DISCARD ERROR EXIT FAIL KILL SNOOZE TASK_ERROR TASK_EXIT_ERROR)),
             ref <- integer(),
             max_attempts <- integer(1..20),
             timeout <- frequency([{3, constant(0)}, {1, constant(100)}]),

--- a/test/integration/executing_test.exs
+++ b/test/integration/executing_test.exs
@@ -71,8 +71,7 @@ defmodule Oban.Integration.ExecutingTest do
 
   defp job do
     gen all queue <- member_of(~w(alpha beta gamma delta)),
-            action <-
-              member_of(~w(OK DISCARD ERROR EXIT FAIL KILL SNOOZE TASK_ERROR TASK_EXIT_ERROR)),
+            action <- member_of(~w(OK DISCARD ERROR EXIT FAIL KILL SNOOZE TASK_ERROR TASK_EXIT),
             ref <- integer(),
             max_attempts <- integer(1..20),
             timeout <- frequency([{3, constant(0)}, {1, constant(100)}]),

--- a/test/integration/executing_test.exs
+++ b/test/integration/executing_test.exs
@@ -71,7 +71,7 @@ defmodule Oban.Integration.ExecutingTest do
 
   defp job do
     gen all queue <- member_of(~w(alpha beta gamma delta)),
-            action <- member_of(~w(OK DISCARD ERROR EXIT FAIL KILL SNOOZE TASK_ERROR TASK_EXIT),
+            action <- member_of(~w(OK DISCARD ERROR EXIT FAIL KILL SNOOZE TASK_ERROR TASK_EXIT)),
             ref <- integer(),
             max_attempts <- integer(1..20),
             timeout <- frequency([{3, constant(0)}, {1, constant(100)}]),

--- a/test/support/worker.ex
+++ b/test/support/worker.ex
@@ -63,7 +63,7 @@ defmodule Oban.Integration.Worker do
 
         :ok
 
-      "TASK_EXIT_ERROR" ->
+      "TASK_EXIT" ->
         send(pid, {:async, ref})
 
         fn -> exit({:timeout, :not_a_list}) end

--- a/test/support/worker.ex
+++ b/test/support/worker.ex
@@ -14,6 +14,7 @@ defmodule Oban.Integration.Worker do
   end
 
   @impl Worker
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   def perform(%_{args: %{"ref" => ref, "action" => action, "bin_pid" => bin_pid}}) do
     pid = bin_to_pid(bin_pid)
 
@@ -61,6 +62,13 @@ defmodule Oban.Integration.Worker do
         |> Task.await()
 
         :ok
+
+      "TASK_EXIT_ERROR" ->
+        send(pid, {:async, ref})
+
+        fn -> exit({:timeout, :not_a_list}) end
+        |> Task.async()
+        |> Task.await()
     end
   end
 


### PR DESCRIPTION
We have seen that sometimes Oban is unable to process certain `DOWN` messages. It crashes on a line calling `Exception.format` because the "stacktrace" that we save here is not always a stacktrace after all (see the added test for example).

From https://hexdocs.pm/elixir/Exception.html#format/3, if `kind` is `{:EXIT, pid}`, then it doesn't format the stacktrace.

I'm reasonably certain that this is the correct behaviour but curious what your thoughts are.