### PR TITLE
fix cron reboot with timezone not working properly

### DIFF
--- a/lib/oban/cron/expression.ex
+++ b/lib/oban/cron/expression.ex
@@ -64,6 +64,7 @@ defmodule Oban.Cron.Expression do
 
   The parser can handle common expressions that use minutes, hours, days, months and weekdays,
   along with ranges and steps. It also supports common extensions, also called nicknames.
+  The second argument, now is only used for @reboot common expression.
 
   Raises an `ArgumentError` if the expression cannot be parsed.
 
@@ -89,24 +90,24 @@ defmodule Oban.Cron.Expression do
       iex> parse!("60 * * * *")
       ** (ArgumentError)
   """
-  @spec parse!(input :: binary()) :: t()
-  def parse!("@annually"), do: parse!("0 0 1 1 *")
-  def parse!("@yearly"), do: parse!("0 0 1 1 *")
-  def parse!("@monthly"), do: parse!("0 0 1 * *")
-  def parse!("@weekly"), do: parse!("0 0 * * 0")
-  def parse!("@midnight"), do: parse!("0 0 * * *")
-  def parse!("@daily"), do: parse!("0 0 * * *")
-  def parse!("@hourly"), do: parse!("0 * * * *")
+  @spec parse!(input :: binary(), DateTime.t()) :: t()
+  def parse!(expression, now \\ DateTime.utc_now())
 
-  def parse!("@reboot") do
-    now = DateTime.utc_now()
+  def parse!("@annually", _now), do: parse!("0 0 1 1 *")
+  def parse!("@yearly", _now), do: parse!("0 0 1 1 *")
+  def parse!("@monthly", _now), do: parse!("0 0 1 * *")
+  def parse!("@weekly", _now), do: parse!("0 0 * * 0")
+  def parse!("@midnight", _now), do: parse!("0 0 * * *")
+  def parse!("@daily", _now), do: parse!("0 0 * * *")
+  def parse!("@hourly", _now), do: parse!("0 * * * *")
 
+  def parse!("@reboot", now) do
     [now.minute, now.hour, now.day, now.month, day_of_week(now)]
     |> Enum.join(" ")
     |> parse!()
   end
 
-  def parse!(input) when is_binary(input) do
+  def parse!(input, _now) when is_binary(input) do
     [mip, hrp, dap, mop, wdp] =
       input
       |> String.trim()

--- a/lib/oban/plugins/cron.ex
+++ b/lib/oban/plugins/cron.ex
@@ -143,11 +143,13 @@ defmodule Oban.Plugins.Cron do
 
   # Parsing & Validation Helpers
 
-  defp parse_crontab(%State{crontab: crontab} = state) do
+  defp parse_crontab(%State{crontab: crontab, timezone: timezone} = state) do
+    now = DateTime.shift_zone!(DateTime.utc_now(), timezone)
+
     parsed =
       Enum.map(crontab, fn
-        {expression, worker} -> {Expression.parse!(expression), worker, []}
-        {expression, worker, opts} -> {Expression.parse!(expression), worker, opts}
+        {expression, worker} -> {Expression.parse!(expression, now), worker, []}
+        {expression, worker, opts} -> {Expression.parse!(expression, now), worker, opts}
       end)
 
     %{state | crontab: parsed}

--- a/test/oban/plugins/cron_test.exs
+++ b/test/oban/plugins/cron_test.exs
@@ -142,6 +142,15 @@ defmodule Oban.Plugins.CronTest do
     assert inserted_refs() == [1]
   end
 
+  test "reboot jobs with specified timezone are also enqueued on startup" do
+    run_with_opts(
+      crontab: [{"@reboot", Worker, args: worker_args(1)}],
+      timezone: "America/Chicago"
+    )
+
+    assert inserted_refs() == [1]
+  end
+
   test "translating deprecated crontab/timezone config into plugin usage" do
     assert [timezone: "America/Chicago", crontab: [{"* * * * *", Worker}]]
            |> start_supervised_oban!()


### PR DESCRIPTION
Hello. Thank you very much for this amazing library.

I recently found an issue where reboot crontab will not create job immediately if timezone is set(The timezone is set for other crontab). Related issue is reported here https://github.com/sorentwo/oban/issues/597

This PR is an attempt to fix this. I tried to keep minimal change but I guess the biggest change is to move timezone from `Cron.State` to `Cron.Expression`. One of the reason I do this is to allow another future PR to allow user set individual crontab expression timezone which provide greater flexibility.

I apologize in advance if the change in this PR is not good. But I am willing to update this PR upon any good feedback.