### PR TITLE
adds listen to the documentation

### DIFF
--- a/lib/oban/notifier.ex
+++ b/lib/oban/notifier.ex
@@ -41,6 +41,8 @@ defmodule Oban.Notifier do
   Listening for job complete events from another process:
 
       def insert_and_listen(args) do
+        :ok = Oban.Notifier.listen([:gosip])
+        
         {:ok, job} =
           args
           |> MyApp.Worker.new()


### PR DESCRIPTION
The documentation `insert_and_listen/1` doesn't work as it stands alone.
To make it work out of the box, it needs to call `listen/2`. Since the
function is `insert_and_listen`, I thought this was an acceptable solution.

Co-authored-by: Chad Fennel <chad@binarynoggin.com>