### PR TITLE
Document default value for uniqueness period

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,8 +502,9 @@ duplicate jobs.  Uniqueness is based on a combination of `args`, `queue`,
 level using the following options:
 
 * `:period` — The number of seconds until a job is no longer considered
-  duplicate. You should always specify a period. `:infinity` can be used to
-  indicate the job be considered a duplicate as long as jobs are retained.
+  duplicate. You should always specify a period, otherwise Oban will default to 
+  60 seconds. `:infinity` can be used to indicate the job be considered a
+  duplicate as long as jobs are retained.
 
 * `:fields` — The fields to compare when evaluating uniqueness. The available
   fields are `:args`, `:queue` and `:worker`, by default all three are used.


### PR DESCRIPTION
If we don't specify a uniqueness period, Oban will check [60 seconds by default](https://github.com/sorentwo/oban/blob/a0018f11954a898dfe6cd8260a3a8a085f4f0921/lib/oban/job.ex#L261).

The documentation says that "you should always specify a period" but does not mention the default value. This is a small pull request to fix that part of the documentation.