### PR TITLE
Doc fix: 20th retry will be ~12 days, not 24.

### DIFF
--- a/lib/oban/worker.ex
+++ b/lib/oban/worker.ex
@@ -102,7 +102,7 @@ defmodule Oban.Worker do
   When jobs fail they may be retried again in the future using a backoff algorithm. By default the
   backoff is exponential with a fixed padding of 15 seconds and a small amount of jitter. The
   jitter helps to prevent jobs that fail simultaneously from consistently retrying at the same
-  time. The default backoff is clamped to a maximum of 24 days, the equivalent of the 20th
+  time. The default backoff is clamped to a maximum of 12 days, the equivalent of the 20th
   attempt.
 
   If the default strategy is too aggressive or otherwise unsuited to your app's workload you can


### PR DESCRIPTION
@sorentwo and I looked at this when I was writing up some docs on the
Backoff. Including jitter, here are the times Parker dumped:

```
iex(1)> for attempt <- 1..20, do: {attempt, Oban.Worker.backoff(%Oban.Job{attempt: attempt})}
[
  {1, 17},
  {2, 19},
  {3, 22},
  {4, 30},
  {5, 46},
  {6, 82},
  {7, 150},
  {8, 285},
  {9, 477},
  {10, 949},
  {11, 2084},
  {12, 3751},
  {13, 7605},
  {14, 15426},
  {15, 36058},
  {16, 71194},
  {17, 139189},
  {18, 250833},
  {19, 514809},
  {20, 983433}
]
```

983433 / 60 / 60 / 24 = 11.38