### PR TITLE
Update v2.11 migration docs: add disable_migration_lock setting

### DIFF
--- a/guides/upgrading/v2.11.md
+++ b/guides/upgrading/v2.11.md
@@ -83,6 +83,7 @@ Within the generated migration module:
 
 ```elixir
 @disable_ddl_transaction true
+@disable_migration_lock true
 
 def change do
   create_if_not_exists index(


### PR DESCRIPTION
As per the docs (https://hexdocs.pm/ecto_sql/Ecto.Migration.html#index/3-adding-dropping-indexes-concurrently), it's necessary to set both `disable_ddl_transaction` **and** `disable_migration_lock` to enable adding/dropping indexes concurrently. The latter was missing in the docs.