### PR TITLE
Add note about uniqueness and Oban.insert_all/2

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,6 +567,10 @@ with {:ok, %Job{conflict?: true}} <- Oban.insert(changeset) do
 end
 ```
 
+Note that conflicts are only detected for jobs enqueued through `Oban.insert/2,3`.
+Jobs enqueued through `Oban.insert_all/2` _do not_ use per-job unique
+configuration.
+
 #### Replacing Values
 
 In addition to detecting unique conflicts, passing options to `replace` can


### PR DESCRIPTION
Hey folks! 

README already has multiple mentions about `insert_all/2` not supporting uniqueness configuration, but there is no mention of that in the `Unique Jobs` section.

This PR adds one more note about it - this time at the `Unique Jobs` section. 

I hope it saves some debug time from people! 😄  
