### PR TITLE
Public config validation functions

### DIFF
--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -207,7 +207,7 @@ defmodule Oban do
 
   ## Example
 
-  Retreive the default `Oban` instance config:
+  Retrieve the default `Oban` instance config:
 
       %Oban.Config{} = Oban.config()
 

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -203,7 +203,17 @@ defmodule Oban do
   end
 
   @doc """
-  Retrieve the config struct for a named Oban supervision tree.
+  Retrieve the `Oban.Config` struct for a named Oban supervision tree.
+
+  ## Example
+
+  Retreive the default `Oban` instance config:
+
+      %Oban.Config{} = Oban.config()
+
+  Retrieve the config for an instance started with a custom name:
+
+      %Oban.Config{} = Oban.config(MyCustomOban)
   """
   @doc since: "0.2.0"
   @spec config(name()) :: Config.t()

--- a/lib/oban/config.ex
+++ b/lib/oban/config.ex
@@ -41,6 +41,9 @@ defmodule Oban.Config do
             log: false,
             get_dynamic_repo: nil
 
+  @cron_keys [:crontab, :timezone]
+  @log_levels ~w(false emergency alert critical error warning warn notice info debug)a
+
   @doc """
   Generate a Config struct after normalizing and verifying Oban options.
 
@@ -209,8 +212,6 @@ defmodule Oban.Config do
     Validation.validate_integer(:shutdown_grace_period, period)
   end
 
-  @log_levels ~w(false emergency alert critical error warning warn notice info debug)a
-
   defp validate_opt({:log, log}) do
     if log in @log_levels do
       :ok
@@ -278,8 +279,6 @@ defmodule Oban.Config do
     |> Keyword.delete(:circuit_backoff)
     |> Enum.reject(&(&1 == {:notifier, Oban.PostgresNotifier}))
   end
-
-  @cron_keys [:crontab, :timezone]
 
   defp crontab_to_plugin(opts) do
     case {opts[:plugins], opts[:crontab]} do

--- a/lib/oban/config.ex
+++ b/lib/oban/config.ex
@@ -177,11 +177,7 @@ defmodule Oban.Config do
   end
 
   defp validate_opt({:plugins, plugins}) do
-    if is_list(plugins) do
-      Validation.validate(plugins, &validate_plugin/1)
-    else
-      {:error, "expected :plugins to be a list, got: #{inspect(plugins)}"}
-    end
+    Validation.validate(:plugins, plugins, &validate_plugin/1)
   end
 
   defp validate_opt({:prefix, prefix}) do
@@ -236,21 +232,23 @@ defmodule Oban.Config do
   defp validate_plugin(plugin) when not is_tuple(plugin), do: validate_plugin({plugin, []})
 
   defp validate_plugin({plugin, opts}) do
+    name = inspect(plugin)
+
     cond do
       not is_atom(plugin) ->
-        {:error, "plugin #{inspect(plugin)} is not a valid module"}
+        {:error, "plugin #{name} is not a valid module"}
 
       not Code.ensure_loaded?(plugin) ->
-        {:error, "plugin #{plugin} could not be loaded"}
+        {:error, "plugin #{name} could not be loaded"}
 
       not function_exported?(plugin, :validate, 1) ->
-        {:error, "plugin #{plugin} is invalid because it's missing a `validate/1` function"}
+        {:error, "plugin #{name} is invalid because it's missing a `validate/1` function"}
 
       not function_exported?(plugin, :init, 1) ->
-        {:error, "plugin #{plugin} is invalid because it's missing an `init/1` function"}
+        {:error, "plugin #{name} is invalid because it's missing an `init/1` function"}
 
       not Keyword.keyword?(opts) ->
-        {:error, "expected options to be a keyword, got: #{inspect(opts)}"}
+        {:error, "expected #{name} options to be a keyword list, got: #{inspect(opts)}"}
 
       true ->
         plugin.validate(opts)

--- a/lib/oban/config.ex
+++ b/lib/oban/config.ex
@@ -6,6 +6,8 @@ defmodule Oban.Config do
   modules and plugins are always passed the config with a `:conf` key.
   """
 
+  alias Oban.Validation
+
   @type t :: %__MODULE__{
           dispatch_cooldown: pos_integer(),
           engine: module(),
@@ -37,29 +39,57 @@ defmodule Oban.Config do
             log: false,
             get_dynamic_repo: nil
 
-  defguardp is_pos_integer(interval) when is_integer(interval) and interval > 0
-
   @doc false
   @spec new([Oban.option()]) :: t()
   def new(opts) when is_list(opts) do
-    opts =
-      opts
-      |> crontab_to_plugin()
-      |> poll_interval_to_plugin()
-      |> Keyword.put_new(:node, node_name())
-      |> Keyword.update(:plugins, [], &(&1 || []))
-      |> Keyword.update(:queues, [], &(&1 || []))
-      |> Keyword.delete(:circuit_backoff)
-      |> Enum.reject(&(&1 == {:notifier, Oban.PostgresNotifier}))
+    opts = normalize(opts)
 
-    Enum.each(opts, &validate_opt!/1)
+    Validation.validate!(opts, &validate_option/1)
 
     opts =
       opts
-      |> Keyword.update!(:queues, &parse_queues/1)
+      |> Keyword.update!(:queues, &normalize_queues/1)
       |> Keyword.update!(:plugins, &normalize_plugins/1)
 
     struct!(__MODULE__, opts)
+  end
+
+  @doc """
+  Utility for verifying configuration options.
+
+  This helper is used by `new/1`, and therefore by `Oban.init/1`, to verify configuration options
+  when an Oban supervisor starts. It is provided publicly to aid in configuration testing, as
+  `test` config may differ from `prod` config.
+
+  # Example
+
+  Validating top level options:
+
+      iex> Oban.Config.validate(name: Oban)
+      :ok
+
+      iex> Oban.Config.validate(name: Oban, log: false)
+      :ok
+
+      iex> Oban.Config.validate(node: {:not, :binary})
+      {:error, "expected :node to be a non-empty binary, got: {:not, :binary}"}
+
+      iex> Oban.Config.validate(plugins: true)
+      {:error, "expected :plugins to be a list, got: true"}
+
+  Validating plugin options:
+
+      iex> Oban.Config.validate(plugins: [{Oban.Plugins.Pruner, max_age: 60}])
+      :ok
+
+      iex> Oban.Config.validate(plugins: [{Oban.Plugins.Pruner, max_age: 0}])
+      {:error, "expected :max_age to be a positive integer, got: 0"}
+  """
+  @spec validate([Oban.option()]) :: :ok | {:error, String.t()}
+  def validate(opts) when is_list(opts) do
+    opts
+    |> normalize()
+    |> Validation.validate(&validate_option/1)
   end
 
   @doc false
@@ -91,7 +121,162 @@ defmodule Oban.Config do
     to_ident(conf) == ident
   end
 
-  # Helpers
+  # Validation
+
+  defp is_pos_integer(interval), do: is_integer(interval) and interval > 0
+
+  defp validate_option({:dispatch_cooldown, cooldown}) do
+    if is_pos_integer(cooldown) do
+      :ok
+    else
+      {:error, "expected :dispatch_cooldown to be a positive integer, got: #{inspect(cooldown)}"}
+    end
+  end
+
+  defp validate_option({:engine, engine}) do
+    if Code.ensure_loaded?(engine) and function_exported?(engine, :init, 2) do
+      :ok
+    else
+      {:error, "expected :engine to be an Oban.Queue.Engine, got: #{inspect(engine)}"}
+    end
+  end
+
+  defp validate_option({:notifier, notifier}) do
+    if Code.ensure_loaded?(notifier) and function_exported?(notifier, :listen, 2) do
+      :ok
+    else
+      {:error, "expected :notifier to be an Oban.Notifier, got: #{inspect(notifier)}"}
+    end
+  end
+
+  defp validate_option({:name, _}), do: :ok
+
+  defp validate_option({:node, node}) do
+    if is_binary(node) and String.trim(node) != "" do
+      :ok
+    else
+      {:error, "expected :node to be a non-empty binary, got: #{inspect(node)}"}
+    end
+  end
+
+  defp validate_option({:peer, peer}) do
+    if peer == false or Code.ensure_loaded?(peer) do
+      :ok
+    else
+      {:error, "expected :peer to be false or an Oban.Peer, got: #{inspect(peer)}"}
+    end
+  end
+
+  defp validate_option({:plugins, plugins}) do
+    if is_list(plugins) do
+      Validation.validate(plugins, &validate_plugin/1)
+    else
+      {:error, "expected :plugins to be a list, got: #{inspect(plugins)}"}
+    end
+  end
+
+  defp validate_option({:prefix, prefix}) do
+    if is_binary(prefix) and Regex.match?(~r/^[a-z0-9_]+$/i, prefix) do
+      :ok
+    else
+      {:error, "expected :prefix to be an alphanumeric string, got: #{inspect(prefix)}"}
+    end
+  end
+
+  defp validate_option({:queues, queues}) do
+    if Keyword.keyword?(queues) do
+      Validation.validate(queues, &validate_queue/1)
+    else
+      {:error, "expected :queues to be a keyword list, got: #{inspect(queues)}"}
+    end
+  end
+
+  defp validate_option({:repo, repo}) do
+    if Code.ensure_loaded?(repo) and function_exported?(repo, :config, 0) do
+      :ok
+    else
+      {:error, "expected :repo to be an Ecto.Repo, got: #{inspect(repo)}"}
+    end
+  end
+
+  defp validate_option({:shutdown_grace_period, period}) do
+    if is_pos_integer(period) do
+      :ok
+    else
+      {:error,
+       "expected :shutdown_grace_period to be a positive integer, got: #{inspect(period)}"}
+    end
+  end
+
+  @log_levels ~w(false emergency alert critical error warning warn notice info debug)a
+
+  defp validate_option({:log, log}) do
+    if log in @log_levels do
+      :ok
+    else
+      {:error, "expected :log to be one of #{inspect(@log_levels)}, got: #{inspect(log)}"}
+    end
+  end
+
+  defp validate_option({:get_dynamic_repo, fun}) do
+    if is_nil(fun) or is_function(fun, 0) do
+      :ok
+    else
+      {:error,
+       "expected :get_dynamic_repo to be nil or a zero arity function, got: #{inspect(fun)}"}
+    end
+  end
+
+  defp validate_option(option) do
+    {:error, "unknown option provided #{inspect(option)}"}
+  end
+
+  defp validate_plugin(plugin) when not is_tuple(plugin), do: validate_plugin({plugin, []})
+
+  defp validate_plugin({plugin, opts}) do
+    cond do
+      not is_atom(plugin) ->
+        {:error, "plugin #{inspect(plugin)} is not a valid module"}
+
+      not Code.ensure_loaded?(plugin) ->
+        {:error, "plugin #{plugin} could not be loaded"}
+
+      not function_exported?(plugin, :validate, 1) ->
+        {:error, "plugin #{plugin} is invalid because it's missing a `validate/1` function"}
+
+      not function_exported?(plugin, :init, 1) ->
+        {:error, "plugin #{plugin} is invalid because it's missing an `init/1` function"}
+
+      not Keyword.keyword?(opts) ->
+        {:error, "expected options to be a keyword, got: #{inspect(opts)}"}
+
+      true ->
+        plugin.validate(opts)
+    end
+  end
+
+  defp validate_queue({name, opts}) do
+    if is_pos_integer(opts) or Keyword.keyword?(opts) do
+      :ok
+    else
+      {:error,
+       "expected queue #{inspect(name)} opts to be a positive integer limit or a " <>
+         "keyword list, got: #{inspect(opts)}"}
+    end
+  end
+
+  # Normalization
+
+  defp normalize(opts) do
+    opts
+    |> crontab_to_plugin()
+    |> poll_interval_to_plugin()
+    |> Keyword.put_new(:node, node_name())
+    |> Keyword.update(:plugins, [], &(&1 || []))
+    |> Keyword.update(:queues, [], &(&1 || []))
+    |> Keyword.delete(:circuit_backoff)
+    |> Enum.reject(&(&1 == {:notifier, Oban.PostgresNotifier}))
+  end
 
   @cron_keys [:crontab, :timezone]
 
@@ -128,131 +313,7 @@ defmodule Oban.Config do
     end
   end
 
-  defp validate_opt!({:dispatch_cooldown, cooldown}) do
-    unless is_pos_integer(cooldown) do
-      raise ArgumentError,
-            "expected :dispatch_cooldown to be a positive integer, got: #{inspect(cooldown)}"
-    end
-  end
-
-  defp validate_opt!({:engine, engine}) do
-    unless Code.ensure_loaded?(engine) and function_exported?(engine, :init, 2) do
-      raise ArgumentError,
-            "expected :engine to be an Oban.Queue.Engine, got: #{inspect(engine)}"
-    end
-  end
-
-  defp validate_opt!({:notifier, notifier}) do
-    unless Code.ensure_loaded?(notifier) and function_exported?(notifier, :listen, 2) do
-      raise ArgumentError,
-            "expected :notifier to be an Oban.Notifier, got: #{inspect(notifier)}"
-    end
-  end
-
-  defp validate_opt!({:name, _}), do: :ok
-
-  defp validate_opt!({:node, node}) do
-    unless is_binary(node) and String.trim(node) != "" do
-      raise ArgumentError,
-            "expected :node to be a non-empty binary, got: #{inspect(node)}"
-    end
-  end
-
-  defp validate_opt!({:peer, peer}) do
-    unless peer == false or Code.ensure_loaded?(peer) do
-      raise ArgumentError,
-            "expected :peer to be false or Oban.Peer, got: #{inspect(peer)}"
-    end
-  end
-
-  defp validate_opt!({:plugins, plugins}) do
-    unless is_list(plugins) do
-      raise ArgumentError, "expected :plugins to be a list, got #{inspect(plugins)}"
-    end
-
-    Enum.each(plugins, &validate_plugin/1)
-  end
-
-  defp validate_opt!({:prefix, prefix}) do
-    unless is_binary(prefix) and Regex.match?(~r/^[a-z0-9_]+$/i, prefix) do
-      raise ArgumentError,
-            "expected :prefix to be a binary with alphanumeric characters, got: #{inspect(prefix)}"
-    end
-  end
-
-  defp validate_opt!({:queues, queues}) do
-    unless Keyword.keyword?(queues) and Enum.all?(queues, &valid_queue?/1) do
-      raise ArgumentError,
-            "expected :queues to be a keyword list of {atom, integer} pairs or " <>
-              "a list of {atom, keyword} pairs, got: #{inspect(queues)}"
-    end
-  end
-
-  defp validate_opt!({:repo, repo}) do
-    unless Code.ensure_loaded?(repo) and function_exported?(repo, :config, 0) do
-      raise ArgumentError,
-            "expected :repo to be an Ecto.Repo, got: #{inspect(repo)}"
-    end
-  end
-
-  defp validate_opt!({:shutdown_grace_period, period}) do
-    unless is_pos_integer(period) do
-      raise ArgumentError,
-            "expected :shutdown_grace_period to be a positive integer, got: #{inspect(period)}"
-    end
-  end
-
-  @log_levels ~w(false emergency alert critical error warning warn notice info debug)a
-
-  defp validate_opt!({:log, log}) do
-    unless log in @log_levels do
-      raise ArgumentError,
-            "expected :log to be one of #{inspect(@log_levels)}, got: #{inspect(log)}"
-    end
-  end
-
-  defp validate_opt!({:get_dynamic_repo, fun}) do
-    unless is_nil(fun) or is_function(fun, 0) do
-      raise ArgumentError,
-            "expected :get_dynamic_repo to be nil or a zero arity function, got: #{inspect(fun)}"
-    end
-  end
-
-  defp validate_opt!(option) do
-    raise ArgumentError, "unknown option provided #{inspect(option)}"
-  end
-
-  defp valid_queue?({_name, opts}) do
-    is_pos_integer(opts) or Keyword.keyword?(opts)
-  end
-
-  defp validate_plugin(plugin) when not is_tuple(plugin), do: validate_plugin({plugin, []})
-
-  defp validate_plugin({plugin, opts}) do
-    unless is_atom(plugin) do
-      raise ArgumentError, "plugin #{inspect(plugin)} is not a valid module"
-    end
-
-    unless Code.ensure_loaded?(plugin) do
-      raise ArgumentError, "plugin #{plugin} could not be found"
-    end
-
-    unless function_exported?(plugin, :validate, 1) do
-      raise ArgumentError,
-            "plugin #{plugin} is invalid because it's missing a `validate/1` function"
-    end
-
-    unless function_exported?(plugin, :init, 1) do
-      raise ArgumentError,
-            "plugin #{plugin} is invalid because it's missing an `init/1` function"
-    end
-
-    unless Keyword.keyword?(opts) do
-      raise ArgumentError, "expected options to be a keyword, got #{inspect(opts)}"
-    end
-  end
-
-  defp parse_queues(queues) do
+  defp normalize_queues(queues) do
     for {name, value} <- queues do
       opts = if is_integer(value), do: [limit: value], else: value
 

--- a/lib/oban/config.ex
+++ b/lib/oban/config.ex
@@ -2,8 +2,10 @@ defmodule Oban.Config do
   @moduledoc """
   The Config struct validates and encapsulates Oban instance state.
 
-  Options passed to `Oban.start_link/1` are validated and stored in a config struct. Internal
-  modules and plugins are always passed the config with a `:conf` key.
+  Typically, you won't use the Config module directly. Oban automatically creates a Config struct
+  on initialization and passes it through to all supervised children with the `:conf` key.
+
+  To fetch a running Oban supervisor's config, see `Oban.config/1`.
   """
 
   alias Oban.Validation
@@ -39,7 +41,17 @@ defmodule Oban.Config do
             log: false,
             get_dynamic_repo: nil
 
-  @doc false
+  @doc """
+  Generate a Config struct after normalizing and verifying Oban options.
+
+  See `Oban.start_link/1` for a comprehensive description of available options.
+
+  ## Example
+
+  Generate a minimal config with only a `:repo`:
+
+      iex> Oban.Config.new(repo: Oban.Test.Repo)
+  """
   @spec new([Oban.option()]) :: t()
   def new(opts) when is_list(opts) do
     opts = normalize(opts)
@@ -55,11 +67,11 @@ defmodule Oban.Config do
   end
 
   @doc """
-  Utility for verifying configuration options.
+  Verify configuration options.
 
-  This helper is used by `new/1`, and therefore by `Oban.init/1`, to verify configuration options
-  when an Oban supervisor starts. It is provided publicly to aid in configuration testing, as
-  `test` config may differ from `prod` config.
+  This helper is used by `new/1`, and therefore by `Oban.start_link/1`, to verify configuration
+  options when an Oban supervisor starts. It is provided publicly to aid in configuration testing,
+  as `test` config may differ from `prod` config.
 
   # Example
 

--- a/lib/oban/plugin.ex
+++ b/lib/oban/plugin.ex
@@ -7,7 +7,7 @@ defmodule Oban.Plugin do
 
   ## Example
 
-  Defining a basic plugin that satisfies the minimum:
+  Defining a basic plugin that satisfies the minimum behaviour:
 
       defmodule MyPlugin do
         @behaviour Oban.Plugin

--- a/lib/oban/plugin.ex
+++ b/lib/oban/plugin.ex
@@ -41,7 +41,6 @@ defmodule Oban.Plugin do
   alias Oban.Config
 
   @type option :: {:conf, Config.t()} | {:name, GenServer.name()} | {atom(), term()}
-  @type validator :: (option() -> :ok | {:error, term()})
 
   @doc """
   Starts a Plugin process linked to the current process.
@@ -54,34 +53,5 @@ defmodule Oban.Plugin do
   @doc """
   Validate the structure, presence, or values of keyword options.
   """
-  @callback validate([option()]) :: :ok | {:error, term()}
-
-  @doc """
-  A utility to help validate options without resorting to `throw` or `raise` for control flow.
-
-  ## Example
-
-  Ensure all keys are known and the correct type:
-
-      validate(opts, fn
-        {:conf, conf} when is_struct(conf) -> :ok
-        {:name, name} when is_atom(name) -> :ok
-        opt -> {:error, "unknown option: " <> inspect(opt)}
-      end)
-  """
-  @spec validate([option()], validator()) :: :ok | {:error, term()}
-  def validate(opts, validator) do
-    Enum.reduce_while(opts, :ok, fn opt, acc ->
-      case validator.(opt) do
-        :ok -> {:cont, acc}
-        {:error, _reason} = error -> {:halt, error}
-      end
-    end)
-  end
-
-  @doc false
-  @spec validate!([option()], ([option()] -> :ok | {:error, term()})) :: :ok
-  def validate!(opts, validate) do
-    with {:error, reason} <- validate.(opts), do: raise(ArgumentError, reason)
-  end
+  @callback validate([option()]) :: :ok | {:error, String.t()}
 end

--- a/lib/oban/plugins/cron.ex
+++ b/lib/oban/plugins/cron.ex
@@ -84,7 +84,7 @@ defmodule Oban.Plugins.Cron do
   def validate(opts) when is_list(opts) do
     Validation.validate(opts, fn
       {:conf, _} -> :ok
-      {:crontab, crontab} -> Validation.validate(crontab, &validate_crontab/1)
+      {:crontab, crontab} -> Validation.validate(:crontab, crontab, &validate_crontab/1)
       {:name, _} -> :ok
       {:timezone, timezone} -> Validation.validate_timezone(:timezone, timezone)
       option -> {:error, "unknown option provided: #{inspect(option)}"}

--- a/lib/oban/plugins/gossip.ex
+++ b/lib/oban/plugins/gossip.ex
@@ -39,7 +39,7 @@ defmodule Oban.Plugins.Gossip do
 
   use GenServer
 
-  alias Oban.{Notifier, Plugin}
+  alias Oban.{Notifier, Plugin, Validation}
 
   @type option :: Plugin.option() | {:interval, pos_integer()}
 
@@ -57,17 +57,17 @@ defmodule Oban.Plugins.Gossip do
 
   @impl Plugin
   def validate(opts) do
-    Plugin.validate(opts, fn
+    Validation.validate(opts, fn
       {:conf, _} -> :ok
       {:name, _} -> :ok
-      {:interval, interval} -> validate_integer(:interval, interval)
+      {:interval, interval} -> Validation.validate_integer(:interval, interval)
       option -> {:error, "unknown option provided: #{inspect(option)}"}
     end)
   end
 
   @impl GenServer
   def init(opts) do
-    Plugin.validate!(opts, &validate/1)
+    Validation.validate!(opts, &validate/1)
 
     Process.flag(:trap_exit, true)
 
@@ -110,16 +110,6 @@ defmodule Oban.Plugins.Gossip do
 
   def handle_info(_message, state) do
     {:noreply, state}
-  end
-
-  # Validation
-
-  defp validate_integer(key, value) do
-    if is_integer(value) and value > 0 do
-      :ok
-    else
-      {:error, "expected #{inspect(key)} to be a positive integer, got: #{inspect(value)}"}
-    end
   end
 
   # Scheduling

--- a/lib/oban/plugins/lifeline.ex
+++ b/lib/oban/plugins/lifeline.ex
@@ -82,7 +82,7 @@ defmodule Oban.Plugins.Lifeline do
     Validation.validate(opts, fn
       {:conf, _} -> :ok
       {:name, _} -> :ok
-      {:interval, interval} -> Validation.validate_timeout(:interval, interval)
+      {:interval, interval} -> Validation.validate_integer(:interval, interval)
       {:rescue_after, interval} -> Validation.validate_integer(:rescue_after, interval)
       option -> {:error, "unknown option provided: #{inspect(option)}"}
     end)

--- a/lib/oban/plugins/lifeline.ex
+++ b/lib/oban/plugins/lifeline.ex
@@ -33,6 +33,7 @@ defmodule Oban.Plugins.Lifeline do
   ## Options
 
   * `:interval` — the number of milliseconds between rescue attempts. The default is `60_000ms`.
+
   * `:rescue_after` — the maximum amount of time, in milliseconds, that a job may execute before
   being rescued. 60 minutes by default, and rescuing is performed once a minute.
 
@@ -82,7 +83,7 @@ defmodule Oban.Plugins.Lifeline do
       {:conf, _} -> :ok
       {:name, _} -> :ok
       {:interval, interval} -> Validation.validate_timeout(:interval, interval)
-      {:rescue_after, interval} -> Validation.validate_timeout(:rescue_after, interval)
+      {:rescue_after, interval} -> Validation.validate_integer(:rescue_after, interval)
       option -> {:error, "unknown option provided: #{inspect(option)}"}
     end)
   end

--- a/lib/oban/plugins/pruner.ex
+++ b/lib/oban/plugins/pruner.ex
@@ -44,7 +44,7 @@ defmodule Oban.Plugins.Pruner do
 
   import Ecto.Query, only: [join: 5, limit: 2, or_where: 3, select: 2]
 
-  alias Oban.{Job, Peer, Plugin, Repo}
+  alias Oban.{Job, Peer, Plugin, Repo, Validation}
 
   @type option ::
           Plugin.option()
@@ -72,19 +72,19 @@ defmodule Oban.Plugins.Pruner do
 
   @impl Plugin
   def validate(opts) do
-    Plugin.validate(opts, fn
+    Validation.validate(opts, fn
       {:conf, _} -> :ok
       {:name, _} -> :ok
-      {:interval, interval} -> validate_integer(:interval, interval)
-      {:limit, limit} -> validate_integer(:limit, limit)
-      {:max_age, max_age} -> validate_integer(:max_age, max_age)
+      {:interval, interval} -> Validation.validate_integer(:interval, interval)
+      {:limit, limit} -> Validation.validate_integer(:limit, limit)
+      {:max_age, max_age} -> Validation.validate_integer(:max_age, max_age)
       option -> {:error, "unknown option provided: #{inspect(option)}"}
     end)
   end
 
   @impl GenServer
   def init(opts) do
-    Plugin.validate!(opts, &validate/1)
+    Validation.validate!(opts, &validate/1)
 
     Process.flag(:trap_exit, true)
 
@@ -118,16 +118,6 @@ defmodule Oban.Plugins.Pruner do
     end)
 
     {:noreply, schedule_prune(state)}
-  end
-
-  # Validation
-
-  defp validate_integer(key, value) do
-    if is_integer(value) and value > 0 do
-      :ok
-    else
-      {:error, "expected #{inspect(key)} to be a positive integer, got: #{inspect(value)}"}
-    end
   end
 
   # Scheduling

--- a/lib/oban/plugins/repeater.ex
+++ b/lib/oban/plugins/repeater.ex
@@ -38,7 +38,7 @@ defmodule Oban.Plugins.Repeater do
 
   use GenServer
 
-  alias Oban.Plugin
+  alias Oban.{Plugin, Validation}
 
   @type option :: Plugin.option() | {:interval, pos_integer()}
 
@@ -56,17 +56,17 @@ defmodule Oban.Plugins.Repeater do
 
   @impl Plugin
   def validate(opts) do
-    Plugin.validate(opts, fn
+    Validation.validate(opts, fn
       {:conf, _} -> :ok
       {:name, _} -> :ok
-      {:interval, interval} -> validate_integer(:interval, interval)
+      {:interval, interval} -> Validation.validate_integer(:interval, interval)
       option -> {:error, "unknown option provided: #{inspect(option)}"}
     end)
   end
 
   @impl GenServer
   def init(opts) do
-    Plugin.validate!(opts, &validate/1)
+    Validation.validate!(opts, &validate/1)
 
     Process.flag(:trap_exit, true)
 
@@ -96,16 +96,6 @@ defmodule Oban.Plugins.Repeater do
     end)
 
     {:noreply, schedule_notify(state)}
-  end
-
-  # Validation
-
-  defp validate_integer(key, value) do
-    if is_integer(value) and value > 0 do
-      :ok
-    else
-      {:error, "expected #{inspect(key)} to be a positive integer, got: #{inspect(value)}"}
-    end
   end
 
   # Scheduling

--- a/lib/oban/validation.ex
+++ b/lib/oban/validation.ex
@@ -18,7 +18,7 @@ defmodule Oban.Validation do
       :ok
   """
   @spec validate(Keyword.t(), validator()) :: :ok | {:error, String.t()}
-  def validate(opts, validator) do
+  def validate(opts, validator) when is_list(opts) and is_function(validator, 1) do
     Enum.reduce_while(opts, :ok, fn opt, acc ->
       case validator.(opt) do
         :ok -> {:cont, acc}

--- a/lib/oban/validation.ex
+++ b/lib/oban/validation.ex
@@ -10,12 +10,11 @@ defmodule Oban.Validation do
 
   Ensure all keys are known and the correct type:
 
-      iex> validate(opts, fn
+      iex> Oban.Validation.validate(name: Oban, fn
       ...>   {:conf, conf} when is_struct(conf) -> :ok
       ...>   {:name, name} when is_atom(name) -> :ok
       ...>   opt -> {:error, "unknown option: " <> inspect(opt)}
       ...> end)
-      ...> Oban.Validation.validate(name: Oban)
       :ok
   """
   @spec validate(Keyword.t(), validator()) :: :ok | {:error, String.t()}

--- a/lib/oban/validation.ex
+++ b/lib/oban/validation.ex
@@ -60,14 +60,4 @@ defmodule Oban.Validation do
       {:error, "expected #{inspect(key)} to be a known timezone, got: #{inspect(value)}"}
     end
   end
-
-  @doc false
-  def validate_timeout(key, value) do
-    if (is_integer(value) and value > 0) or value == :infinity do
-      :ok
-    else
-      {:error,
-       "expected #{inspect(key)} to be a positive integer or :infinity, got: #{inspect(value)}"}
-    end
-  end
 end

--- a/lib/oban/validation.ex
+++ b/lib/oban/validation.ex
@@ -17,14 +17,20 @@ defmodule Oban.Validation do
       ...> end)
       :ok
   """
-  @spec validate(Keyword.t(), validator()) :: :ok | {:error, String.t()}
-  def validate(opts, validator) when is_list(opts) and is_function(validator, 1) do
+  @spec validate(atom(), Keyword.t(), validator()) :: :ok | {:error, String.t()}
+  def validate(parent_key \\ nil, opts, validator)
+
+  def validate(_parent_key, opts, validator) when is_list(opts) and is_function(validator, 1) do
     Enum.reduce_while(opts, :ok, fn opt, acc ->
       case validator.(opt) do
         :ok -> {:cont, acc}
         {:error, _reason} = error -> {:halt, error}
       end
     end)
+  end
+
+  def validate(parent_key, opts, _validator) do
+    {:error, "expected #{inspect(parent_key)} to be a list, got: #{inspect(opts)}"}
   end
 
   @doc """

--- a/lib/oban/validation.ex
+++ b/lib/oban/validation.ex
@@ -1,0 +1,34 @@
+defmodule Oban.Validation do
+  @moduledoc false
+
+  @type validator :: ({atom(), term()} -> :ok | {:error, term()})
+
+  @doc """
+  A utility to help validate options without resorting to `throw` or `raise` for control flow.
+
+  ## Example
+
+  Ensure all keys are known and the correct type:
+
+      validate(opts, fn
+        {:conf, conf} when is_struct(conf) -> :ok
+        {:name, name} when is_atom(name) -> :ok
+        opt -> {:error, "unknown option: " <> inspect(opt)}
+      end)
+  """
+  @spec validate(Keyword.t(), validator()) :: :ok | {:error, String.t()}
+  def validate(opts, validator) do
+    Enum.reduce_while(opts, :ok, fn opt, acc ->
+      case validator.(opt) do
+        :ok -> {:cont, acc}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  @doc false
+  @spec validate!(opts :: Keyword.t(), validator()) :: :ok
+  def validate!(opts, validator) do
+    with {:error, reason} <- validate(opts, validator), do: raise(ArgumentError, reason)
+  end
+end

--- a/test/oban/plugins/cron_test.exs
+++ b/test/oban/plugins/cron_test.exs
@@ -11,6 +11,10 @@ defmodule Oban.Plugins.CronTest do
   end
 
   describe "validate/1" do
+    test ":crontab is validated as a list" do
+      refute_valid("expected :crontab to be", crontab: %{})
+    end
+
     test ":crontab job format is validated" do
       refute_valid("expected crontab entry to be", crontab: ["* * * * *"])
       assert_valid(crontab: [{"* * * * *", Worker}])

--- a/test/oban/plugins/cron_test.exs
+++ b/test/oban/plugins/cron_test.exs
@@ -11,33 +11,29 @@ defmodule Oban.Plugins.CronTest do
   end
 
   describe "validate/1" do
-    test ":crontab is validated as a list of cron job expressions" do
-      refute_valid("expected :crontab to be a list", crontab: %{worker1: "foo"})
-    end
-
-    test "job format is validated" do
+    test ":crontab job format is validated" do
       refute_valid("expected crontab entry to be", crontab: ["* * * * *"])
       assert_valid(crontab: [{"* * * * *", Worker}])
       assert_valid(crontab: [{"* * * * *", Worker, queue: "special"}])
     end
 
-    test "worker existence is validated" do
+    test ":crontab worker existence is validated" do
       refute_valid("Fake not found", crontab: [{"* * * * *", Worker}, {"* * * * *", Fake}])
     end
 
-    test "worker perform/1 callback is validated" do
+    test ":crontab worker perform/1 callback is validated" do
       refute_valid("WorkerWithoutPerform does not implement `perform/1`",
         crontab: [{"* * * * *", WorkerWithoutPerform}]
       )
     end
 
-    test "worker options format is validated" do
+    test ":crontab worker options format is validated" do
       refute_valid("options must be a keyword list",
         crontab: [{"* * * * *", Worker, %{foo: "bar"}}]
       )
     end
 
-    test "worker options are validated" do
+    test ":crontab worker options are validated" do
       refute_valid("expected valid job options", crontab: [{"* * * * *", Worker, priority: -1}])
       refute_valid("expected valid job options", crontab: [{"* * * * *", Worker, unique: []}])
     end

--- a/test/oban/plugins/lifeline_test.exs
+++ b/test/oban/plugins/lifeline_test.exs
@@ -8,8 +8,10 @@ defmodule Oban.Plugins.LifelineTest do
     test "validating interval options" do
       assert {:error, _} = Lifeline.validate(interval: 0)
       assert {:error, _} = Lifeline.validate(rescue_after: 0)
+      assert {:error, _} = Lifeline.validate(rescue_after: :infinity)
 
       assert :ok = Lifeline.validate(interval: :timer.seconds(30))
+      assert :ok = Lifeline.validate(interval: :infinity)
       assert :ok = Lifeline.validate(rescue_after: :timer.minutes(30))
     end
   end

--- a/test/oban/plugins/lifeline_test.exs
+++ b/test/oban/plugins/lifeline_test.exs
@@ -8,10 +8,8 @@ defmodule Oban.Plugins.LifelineTest do
     test "validating interval options" do
       assert {:error, _} = Lifeline.validate(interval: 0)
       assert {:error, _} = Lifeline.validate(rescue_after: 0)
-      assert {:error, _} = Lifeline.validate(rescue_after: :infinity)
 
       assert :ok = Lifeline.validate(interval: :timer.seconds(30))
-      assert :ok = Lifeline.validate(interval: :infinity)
       assert :ok = Lifeline.validate(rescue_after: :timer.minutes(30))
     end
   end


### PR DESCRIPTION
Another step in exposing Oban's internal validation functions. Last time it was plugins, and this time it is the shared config!

Some items to note:

* Add a public `Config.validate/1` to aid in testing complete Oban configuration
* Validate plugin options during `Config.new/1` or `Config.validate/1`, before starting plugins at all
* Extract common validations into a new `Oban.Validation` module
* Move `validate/2` and `validate!/2` functions from `Plugin` into `Validation`
* Display the exact queue name and opts that failed
* Be more consistent with the structure of validation error messages

---

It's now possible to run this test using public functions, and without `assert_raise`:

```elixir
base_env = Config.Reader.read!("config/config.exs", env: :prod)
prod_env = Config.Reader.read!("config/prod.exs", env: :prod)

assert :ok =
         base_env
         |> Config.Reader.merge(prod_env)
         |> get_in([:my_app, Oban])
         |> Oban.Config.validate()

```

/cc @milmazz 