### PR TITLE
Fix migrations: allow any prefix name.

### DIFF
--- a/lib/oban/migrations.ex
+++ b/lib/oban/migrations.ex
@@ -158,13 +158,15 @@ defmodule Oban.Migrations do
 
   @doc false
   def migrated_version(repo, prefix) do
+    escaped_prefix = String.replace(prefix, "'", "\\'")
+
     query = """
     SELECT description
     FROM pg_class
     LEFT JOIN pg_description ON pg_description.objoid = pg_class.oid
     LEFT JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
     WHERE pg_class.relname = 'oban_jobs'
-    AND pg_namespace.nspname = '#{prefix}'
+    AND pg_namespace.nspname = '#{escaped_prefix}'
     """
 
     conf = Config.new(repo: repo, prefix: prefix)
@@ -193,6 +195,6 @@ defmodule Oban.Migrations do
   defp record_version(_opts, 0), do: :ok
 
   defp record_version(%{prefix: prefix}, version) do
-    execute "COMMENT ON TABLE #{prefix}.oban_jobs IS '#{version}'"
+    execute "COMMENT ON TABLE #{inspect(prefix)}.oban_jobs IS '#{version}'"
   end
 end

--- a/lib/oban/migrations/v02.ex
+++ b/lib/oban/migrations/v02.ex
@@ -4,10 +4,11 @@ defmodule Oban.Migrations.V02 do
   use Ecto.Migration
 
   def up(%{prefix: prefix}) do
+    quoted_prefix = inspect(prefix)
     # We only need the scheduled_at index for scheduled and available jobs
     drop_if_exists index(:oban_jobs, [:scheduled_at], prefix: prefix)
 
-    state = "#{prefix}.oban_job_state"
+    state = "#{quoted_prefix}.oban_job_state"
 
     create index(:oban_jobs, [:scheduled_at],
              where: "state in ('available'::#{state}, 'scheduled'::#{state})",
@@ -25,7 +26,7 @@ defmodule Oban.Migrations.V02 do
            )
 
     execute """
-    CREATE OR REPLACE FUNCTION #{prefix}.oban_wrap_id(value bigint) RETURNS int AS $$
+    CREATE OR REPLACE FUNCTION #{quoted_prefix}.oban_wrap_id(value bigint) RETURNS int AS $$
     BEGIN
       RETURN (CASE WHEN value > 2147483647 THEN mod(value, 2147483647) ELSE value END)::int;
     END;
@@ -34,12 +35,13 @@ defmodule Oban.Migrations.V02 do
   end
 
   def down(%{prefix: prefix}) do
+    quoted_prefix = inspect(prefix)
     drop_if_exists constraint(:oban_jobs, :queue_length, prefix: prefix)
     drop_if_exists constraint(:oban_jobs, :worker_length, prefix: prefix)
 
     drop_if_exists index(:oban_jobs, [:scheduled_at], prefix: prefix)
     create index(:oban_jobs, [:scheduled_at], prefix: prefix)
 
-    execute("DROP FUNCTION IF EXISTS #{prefix}.oban_wrap_id(value bigint)")
+    execute("DROP FUNCTION IF EXISTS #{quoted_prefix}.oban_wrap_id(value bigint)")
   end
 end

--- a/lib/oban/migrations/v04.ex
+++ b/lib/oban/migrations/v04.ex
@@ -4,12 +4,15 @@ defmodule Oban.Migrations.V04 do
   use Ecto.Migration
 
   def up(%{prefix: prefix}) do
-    execute("DROP FUNCTION IF EXISTS #{prefix}.oban_wrap_id(value bigint)")
+    quoted_prefix = inspect(prefix)
+    execute("DROP FUNCTION IF EXISTS #{quoted_prefix}.oban_wrap_id(value bigint)")
   end
 
   def down(%{prefix: prefix}) do
+    quoted_prefix = inspect(prefix)
+
     execute """
-    CREATE OR REPLACE FUNCTION #{prefix}.oban_wrap_id(value bigint) RETURNS int AS $$
+    CREATE OR REPLACE FUNCTION #{quoted_prefix}.oban_wrap_id(value bigint) RETURNS int AS $$
     BEGIN
       RETURN (CASE WHEN value > 2147483647 THEN mod(value, 2147483647) ELSE value END)::int;
     END;

--- a/lib/oban/migrations/v05.ex
+++ b/lib/oban/migrations/v05.ex
@@ -12,9 +12,10 @@ defmodule Oban.Migrations.V05 do
   end
 
   def down(%{prefix: prefix}) do
+    quoted_prefix = inspect(prefix)
     drop_if_exists index(:oban_jobs, [:queue, :state, :scheduled_at, :id], prefix: prefix)
 
-    state = "#{prefix}.oban_job_state"
+    state = "#{quoted_prefix}.oban_job_state"
 
     create_if_not_exists index(:oban_jobs, [:queue], prefix: prefix)
     create_if_not_exists index(:oban_jobs, [:state], prefix: prefix)

--- a/lib/oban/migrations/v09.ex
+++ b/lib/oban/migrations/v09.ex
@@ -4,6 +4,8 @@ defmodule Oban.Migrations.V09 do
   use Ecto.Migration
 
   def up(%{prefix: prefix}) do
+    quoted_prefix = inspect(prefix)
+
     alter table(:oban_jobs, prefix: prefix) do
       add_if_not_exists(:meta, :map, default: %{})
       add_if_not_exists(:cancelled_at, :utc_datetime_usec)
@@ -16,16 +18,16 @@ defmodule Oban.Migrations.V09 do
       already bool;
     BEGIN
       SELECT current_setting('server_version_num')::int INTO version;
-      SELECT '{cancelled}' <@ enum_range(NULL::#{prefix}.oban_job_state)::text[] INTO already;
+      SELECT '{cancelled}' <@ enum_range(NULL::#{quoted_prefix}.oban_job_state)::text[] INTO already;
 
       IF already THEN
         RETURN;
       ELSIF version >= 120000 THEN
-        ALTER TYPE #{prefix}.oban_job_state ADD VALUE IF NOT EXISTS 'cancelled';
+        ALTER TYPE #{quoted_prefix}.oban_job_state ADD VALUE IF NOT EXISTS 'cancelled';
       ELSE
-        ALTER TYPE #{prefix}.oban_job_state RENAME TO old_oban_job_state;
+        ALTER TYPE #{quoted_prefix}.oban_job_state RENAME TO old_oban_job_state;
 
-        CREATE TYPE #{prefix}.oban_job_state AS ENUM (
+        CREATE TYPE #{quoted_prefix}.oban_job_state AS ENUM (
           'available',
           'scheduled',
           'executing',
@@ -35,13 +37,13 @@ defmodule Oban.Migrations.V09 do
           'cancelled'
         );
 
-        ALTER TABLE #{prefix}.oban_jobs RENAME column state TO _state;
-        ALTER TABLE #{prefix}.oban_jobs ADD state #{prefix}.oban_job_state NOT NULL default 'available';
+        ALTER TABLE #{quoted_prefix}.oban_jobs RENAME column state TO _state;
+        ALTER TABLE #{quoted_prefix}.oban_jobs ADD state #{quoted_prefix}.oban_job_state NOT NULL default 'available';
 
-        UPDATE #{prefix}.oban_jobs SET state = _state::text::#{prefix}.oban_job_state;
+        UPDATE #{quoted_prefix}.oban_jobs SET state = _state::text::#{quoted_prefix}.oban_job_state;
 
-        ALTER TABLE #{prefix}.oban_jobs DROP column _state;
-        DROP TYPE #{prefix}.old_oban_job_state;
+        ALTER TABLE #{quoted_prefix}.oban_jobs DROP column _state;
+        DROP TYPE #{quoted_prefix}.old_oban_job_state;
       END IF;
     END$$;
     """
@@ -52,6 +54,8 @@ defmodule Oban.Migrations.V09 do
   end
 
   def down(%{prefix: prefix}) do
+    quoted_prefix = inspect(prefix)
+
     alter table(:oban_jobs, prefix: prefix) do
       remove_if_exists(:meta, :map)
       remove_if_exists(:cancelled_at, :utc_datetime_usec)
@@ -60,11 +64,11 @@ defmodule Oban.Migrations.V09 do
     execute """
     DO $$
     BEGIN
-      UPDATE #{prefix}.oban_jobs SET state = 'discarded' WHERE state = 'cancelled';
+      UPDATE #{quoted_prefix}.oban_jobs SET state = 'discarded' WHERE state = 'cancelled';
 
-      ALTER TYPE #{prefix}.oban_job_state RENAME TO old_oban_job_state;
+      ALTER TYPE #{quoted_prefix}.oban_job_state RENAME TO old_oban_job_state;
 
-      CREATE TYPE #{prefix}.oban_job_state AS ENUM (
+      CREATE TYPE #{quoted_prefix}.oban_job_state AS ENUM (
         'available',
         'scheduled',
         'executing',
@@ -73,15 +77,15 @@ defmodule Oban.Migrations.V09 do
         'discarded'
       );
 
-      ALTER TABLE #{prefix}.oban_jobs RENAME column state TO _state;
+      ALTER TABLE #{quoted_prefix}.oban_jobs RENAME column state TO _state;
 
-      ALTER TABLE #{prefix}.oban_jobs ADD state #{prefix}.oban_job_state NOT NULL default 'available';
+      ALTER TABLE #{quoted_prefix}.oban_jobs ADD state #{quoted_prefix}.oban_job_state NOT NULL default 'available';
 
-      UPDATE #{prefix}.oban_jobs SET state = _state::text::#{prefix}.oban_job_state;
+      UPDATE #{quoted_prefix}.oban_jobs SET state = _state::text::#{quoted_prefix}.oban_job_state;
 
-      ALTER TABLE #{prefix}.oban_jobs DROP column _state;
+      ALTER TABLE #{quoted_prefix}.oban_jobs DROP column _state;
 
-      DROP TYPE #{prefix}.old_oban_job_state;
+      DROP TYPE #{quoted_prefix}.old_oban_job_state;
     END$$;
     """
   end

--- a/lib/oban/migrations/v11.ex
+++ b/lib/oban/migrations/v11.ex
@@ -4,6 +4,8 @@ defmodule Oban.Migrations.V11 do
   use Ecto.Migration
 
   def up(%{prefix: prefix}) do
+    quoted_prefix = inspect(prefix)
+
     create_if_not_exists table(:oban_peers, primary_key: false, prefix: prefix) do
       add :name, :text, null: false, primary_key: true
       add :node, :text, null: false
@@ -11,7 +13,7 @@ defmodule Oban.Migrations.V11 do
       add :expires_at, :utc_datetime_usec, null: false
     end
 
-    execute "ALTER TABLE #{prefix}.oban_peers SET UNLOGGED"
+    execute "ALTER TABLE #{quoted_prefix}.oban_peers SET UNLOGGED"
   end
 
   def down(%{prefix: prefix}) do

--- a/lib/oban/plugins/reindexer.ex
+++ b/lib/oban/plugins/reindexer.ex
@@ -135,7 +135,7 @@ defmodule Oban.Plugins.Reindexer do
       {:ok, datetime} = DateTime.now(state.timezone)
 
       if Expression.now?(state.schedule, datetime) do
-        table = "#{state.conf.prefix}.oban_jobs"
+        table = "#{inspect(state.conf.prefix)}.oban_jobs"
 
         Repo.query(state.conf, "REINDEX TABLE CONCURRENTLY #{table}", [])
       end


### PR DESCRIPTION
Using reserved names such as `case` isn't possible,
because it results in a PSQL syntax error.

Using `inspect` will always print a double quoted string,
thereby fixing this issue.