### PR TITLE
Remove outdated mention of producer circuit breakers

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,6 @@ orphaned due to crashes.
   independently at runtime locally or across _all_ running nodes (even in
   environments like Heroku, without distributed Erlang).
 
-- **Resilient Queues** — Failing queries won't crash the entire supervision tree,
-  instead they trip a circuit breaker and will be retried again in the future.
-
 - **Job Canceling** — Jobs can be canceled in the middle of execution regardless
   of which node they are running on. This stops the job at once and flags it as
   `discarded`.


### PR DESCRIPTION
Circuit breakers were removed in 4c17c8d1bebdffb61dafde1bd8d62055e6e6da7d but the reference to them is still in the Readme.