### PR TITLE
Fix tiny typo in Notifier example

### DIFF
--- a/lib/oban/notifier.ex
+++ b/lib/oban/notifier.ex
@@ -42,7 +42,7 @@ defmodule Oban.Notifier do
   Listening for job complete events from another process:
 
       def insert_and_listen(args) do
-        :ok = Oban.Notifier.listen([:gosip])
+        :ok = Oban.Notifier.listen([:gossip])
 
         {:ok, job} =
           args


### PR DESCRIPTION
Noticed a missing `s` so I added it.