### PR TITLE
Dedicated testing option

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,12 +259,12 @@ defmodule MyApp.Application do
 end
 ```
 
-If you are running tests (which you should be) you'll want to disable plugins,
-enqueueing scheduled jobs and job dispatching altogether when testing:
+If you are running tests (which you should be) you'll want to enable `testing`
+mode to disable plugins, and job dispatching altogether when testing:
 
 ```elixir
 # config/test.exs
-config :my_app, Oban, queues: false, plugins: false
+config :my_app, Oban, testing: true
 ```
 
 See the installation instructions in the README or on the Hexdocs guide for details

--- a/guides/testing/testing.md
+++ b/guides/testing/testing.md
@@ -8,18 +8,15 @@ testing Oban is highly recommended.
 
 Ensure your app is configured for testing before you start running any tests.
 Chances are, you already did this as part of the initial setup. To be sure,
-disable running queues and plugins within `test.exs`:
+set `testing: true` to disable running queues and plugins within `test.exs`:
 
 ```elixir
-config :my_app, Oban, queues: false, plugins: false
+config :my_app, Oban, testing: true
 ```
 
-Disabling with `false` prevents Oban from running any queries in the background.
-This simultaneously prevents Sandbox errors (`DBConnection.OnwershipError`) from
-plugin queries and gives you complete control over when jobs run.
-
-Note that you must use `false` because configuration is deep-merged and using an
-empty list like `queues: []` won't have any effect.
+Disabling testing prevents Oban from running any database queries in the
+background. This simultaneously prevents Sandbox errors from plugin queries and
+gives you complete control over when jobs run.
 
 ## Setup Testing Helpers
 

--- a/guides/testing/testing_config.md
+++ b/guides/testing/testing_config.md
@@ -1,23 +1,22 @@
 # Testing Config
 
-An Oban instance's config is statically defined during initialization and it
-determines the supervision tree that Oban builds. The instance config is
-encapsulated by an `Oban.Config` struct, which is then referenced by plugins,
-queues, and most public functions.
+An Oban instance's config is built from options passed to `Oban.start_link`
+during initialization and it determines the supervision tree that Oban builds.
+The instance config is encapsulated by an `Oban.Config` struct, which is then
+referenced by plugins, queues, and most public functions.
 
-Your app's Oban config is extremely important and it deserves testing!
+## Testing Dynamic Config
 
-## Testing Production Config
-
-Within the test environment, apps typically disable queues and plugins for more
-control and to prevent sandbox interference. That means only a subset of the
-full Oban config is verified when your application boots for testing.
+Oban automatically normalizes and validates config options on initialization.
+That covers any static configuration, but it won't help when config is generated
+dynamically, at runtime.
 
 The `Oban.Config.validate/1` helper is used internally when the config
 initializes. Along with each top level option, like the `:engine` or `:repo`, it
 recursively verifies all queue and plugin options.
 
-You can use `validate/1` to verify the full production config:
+You can use `validate/1` to verify dynamic configuration, e.g. options specified
+in `runtime.exs`:
 
 ```elixir
 test "production oban config is valid" do
@@ -37,16 +36,12 @@ you'll see the test fail with an error like this:
 {:error, "expected :engine to be an Oban.Queue.Engine, got: MyApp.Repo"}
 ```
 
-## Testing Plugin Config
+## Testing Dynamic Plugin Config
 
 Validation is especially helpful for plugins that have complex configuration,
 e.g. `Cron` or the `Dynamic*` plugins from Oban Pro. As of Oban v2.12.0 all
 plugins implement the `c:Oban.Plugin.validate/1` callback and we can test them
 in isolation as well as through the top level config.
-
-If your plugins are statically defined, then validating them through
-`Oban.Config` is easy and recommended. If your config is dynamic, then
-you can test the plugin config directly.
 
 Suppose you have a helper function that returns a crontab config at runtime:
 

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -49,6 +49,7 @@ defmodule Oban do
           | {:queues, false | [{queue_name(), pos_integer() | Keyword.t()}]}
           | {:repo, module()}
           | {:shutdown_grace_period, timeout()}
+          | {:testing, boolean()}
 
   @type drain_option ::
           {:queue, queue_name()}
@@ -128,6 +129,9 @@ defmodule Oban do
 
     Queues accept additional override options to customize their behavior, e.g. by setting
     `paused` or `dispatch_cooldown` for a specific queue.
+
+  * `:testing` — a boolean that controls whether an instance is configured for testing. When set
+    to `true`, queues, peer, and plugins are automatically disabled. Defaults to `false`.
 
   ### Twiddly Options
 

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -81,12 +81,18 @@ defmodule Oban do
 
   These options are required; without them the supervisor won't start
 
-  * `:name` — used for supervisor registration, defaults to `Oban`
   * `:repo` — specifies the Ecto repo used to insert and retrieve jobs
 
   ### Primary Options
 
   These options determine what the system does at a high level, i.e. which queues to run.
+
+  * `:log` — either `false` to disable logging or a standard log level (`:error`, `:warn`,
+    `:info`, `:debug`). This determines whether queries are logged or not; overriding the repo's
+    configured log level. Defaults to `false`, where no queries are logged.
+
+  * `:name` — used for supervisor registration, it must be unique across an entire VM instance.
+    Defaults to `Oban`
 
   * `:node` — used to identify the node that the supervision tree is running in. If no value is
     provided it will use the `node` name in a distributed system, or the `hostname` in an isolated
@@ -122,13 +128,6 @@ defmodule Oban do
 
     Queues accept additional override options to customize their behavior, e.g. by setting
     `paused` or `dispatch_cooldown` for a specific queue.
-
-    For testing purposes `:queues` may be set to `false` or `nil`, which effectively disables all
-    job dispatching.
-
-  * `:log` — either `false` to disable logging or a standard log level (`:error`, `:warn`,
-    `:info`, `:debug`). This determines whether queries are logged or not; overriding the repo's
-    configured log level. Defaults to `false`, where no queries are logged.
 
   ### Twiddly Options
 

--- a/test/oban/config_test.exs
+++ b/test/oban/config_test.exs
@@ -89,7 +89,6 @@ defmodule Oban.ConfigTest do
 
       assert_valid(queues: [default: 1])
       assert_valid(queues: [default: [limit: 1]])
-
     end
 
     test ":shutdown_grace_period is validated as an integer" do
@@ -100,6 +99,13 @@ defmodule Oban.ConfigTest do
       assert_valid(shutdown_grace_period: 0)
       assert_valid(shutdown_grace_period: 10)
     end
+
+    test ":testing is validated as a boolean" do
+      refute_valid(testing: :ok)
+
+      assert_valid(testing: true)
+      assert_valid(testing: false)
+    end
   end
 
   describe "new/1" do
@@ -109,6 +115,11 @@ defmodule Oban.ConfigTest do
 
     test ":queues convert to an empty list when set to false" do
       assert %Config{queues: []} = conf(queues: false)
+    end
+
+    test ":testing disables queues, peer, and plugins" do
+      assert %Config{queues: [], plugins: [], peer: false} =
+               conf(queues: [alpha: 1], plugins: [Pruner], testing: true)
     end
   end
 

--- a/test/oban/config_test.exs
+++ b/test/oban/config_test.exs
@@ -81,14 +81,18 @@ defmodule Oban.ConfigTest do
       assert_valid(prefix: "private")
     end
 
-    test ":queues are validated as atom, integer pairs or atom, keyword pairs" do
+    test ":queues are validated as an initializable keyword list" do
       refute_valid(queues: %{default: 25})
       refute_valid(queues: [{"default", 25}])
       refute_valid(queues: [default: 0])
       refute_valid(queues: [default: 3.5])
+      refute_valid(queues: [default: [lim: 1]])
+      refute_valid(queues: [default: [limit: 1, paused: :yes]])
 
       assert_valid(queues: [default: 1])
       assert_valid(queues: [default: [limit: 1]])
+      assert_valid(queues: [default: [limit: 1, paused: true]])
+      assert_valid(queues: [default: [limit: 1, dispatch_cooldown: 10]])
     end
 
     test ":shutdown_grace_period is validated as an integer" do

--- a/test/oban/plugins/cron_test.exs
+++ b/test/oban/plugins/cron_test.exs
@@ -147,28 +147,6 @@ defmodule Oban.Plugins.CronTest do
     assert inserted_refs() == [1]
   end
 
-  test "translating deprecated crontab/timezone config into plugin usage" do
-    assert [timezone: "America/Chicago", crontab: [{"* * * * *", Worker}]]
-           |> start_supervised_oban!()
-           |> Registry.whereis({:plugin, Cron})
-
-    assert [crontab: [{"* * * * *", Worker}]]
-           |> start_supervised_oban!()
-           |> Registry.whereis({:plugin, Cron})
-
-    assert [plugins: [Oban.Plugins.Pruner], crontab: [{"* * * * *", Worker}]]
-           |> start_supervised_oban!()
-           |> Registry.whereis({:plugin, Cron})
-
-    refute [plugins: false, crontab: [{"* * * * *", Worker}]]
-           |> start_supervised_oban!()
-           |> Registry.whereis({:plugin, Cron})
-
-    refute [timezone: "America/Chicago"]
-           |> start_supervised_oban!()
-           |> Registry.whereis({:plugin, Cron})
-  end
-
   defp assert_valid(opts) do
     assert :ok = Cron.validate(opts)
   end

--- a/test/oban/plugins/stager_test.exs
+++ b/test/oban/plugins/stager_test.exs
@@ -57,20 +57,6 @@ defmodule Oban.Plugins.StagerTest do
         assert %{state: "scheduled"} = Repo.reload(job_3)
       end)
     end
-
-    test "translating poll_interval config into plugin usage" do
-      assert []
-             |> start_supervised_oban!()
-             |> Registry.whereis({:plugin, Stager})
-
-      assert [poll_interval: 2000]
-             |> start_supervised_oban!()
-             |> Registry.whereis({:plugin, Stager})
-
-      refute [plugins: false, poll_interval: 2000]
-             |> start_supervised_oban!()
-             |> Registry.whereis({:plugin, Stager})
-    end
   end
 
   defp stage(name) do


### PR DESCRIPTION
This adds a `:testing` option to `Oban.start_link` to simplify test setup and minimize prod/test mismatches. There are a few miscellaneous config cleanups included, too.

Closes #680 