### PR TITLE
Inline testing mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,9 @@ config :my_app, Oban,
   plugins: [Oban.Plugins.Pruner],
   queues: [default: 10, events: 50, media: 20]
 
+# confg/test.exs
+config :my_app, Oban, testing: :inline
+
 # lib/my_app/application.ex
 defmodule MyApp.Application do
   @moduledoc false
@@ -257,14 +260,6 @@ defmodule MyApp.Application do
     Application.fetch_env!(:my_app, Oban)
   end
 end
-```
-
-If you are running tests (which you should be) you'll want to enable `testing`
-mode to disable plugins, and job dispatching altogether when testing:
-
-```elixir
-# config/test.exs
-config :my_app, Oban, testing: true
 ```
 
 See the installation instructions in the README or on the Hexdocs guide for details

--- a/guides/testing/testing.md
+++ b/guides/testing/testing.md
@@ -6,21 +6,37 @@ testing Oban is highly recommended.
 
 ## Setup Application Config
 
-Ensure your app is configured for testing before you start running any tests.
-Chances are, you already did this as part of the initial setup. To be sure,
-set `testing: true` to disable running queues and plugins within `test.exs`:
+Ensure your app is configured for testing before you begin running tests.
+
+There are two testing modes available:
+
+* `:inline`—jobs execute immediately within the calling process and without
+  touching the database. This mode is simple and may not be suitable for apps
+  with complex jobs.
+* `:manual`—jobs are inserted into the database where they can be verified and
+  executed when desired. This mode is more advanced and trades simplicity for
+  flexibility.
+
+If you're just starting out, `:inline` mode is recommended:
 
 ```elixir
-config :my_app, Oban, testing: true
+config :my_app, Oban, testing: :inline
 ```
 
-Disabling testing prevents Oban from running any database queries in the
+For more complex applications, or if you'd like complete control over when jobs
+run, then use `:manual` mode instead:
+
+```elixir
+config :my_app, Oban, testing: :manual
+```
+
+Both testing modes prevent Oban from running any database queries in the
 background. This simultaneously prevents Sandbox errors from plugin queries and
-gives you complete control over when jobs run.
+prevents queues from executing jobs unexpectedly.
 
 ## Setup Testing Helpers
 
-Oban provides helpers to facilitate testing. These helpers handle the
+Oban provides helpers to facilitate manual testing. These helpers handle the
 boilerplate of making assertions on which jobs are enqueued.
 
 The most convenient way to use the helpers is to `use` the module within your

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -49,7 +49,7 @@ defmodule Oban do
           | {:queues, false | [{queue_name(), pos_integer() | Keyword.t()}]}
           | {:repo, module()}
           | {:shutdown_grace_period, timeout()}
-          | {:testing, boolean()}
+          | {:testing, :disabled | :inline | :manual}
 
   @type drain_option ::
           {:queue, queue_name()}
@@ -130,8 +130,9 @@ defmodule Oban do
     Queues accept additional override options to customize their behavior, e.g. by setting
     `paused` or `dispatch_cooldown` for a specific queue.
 
-  * `:testing` — a boolean that controls whether an instance is configured for testing. When set
-    to `true`, queues, peer, and plugins are automatically disabled. Defaults to `false`.
+  * `:testing` — a mode that controls how an instance is configured for testing. When set to
+    `:inline` or `:manual` queues, peers, and plugins are automatically disabled. Defaults to
+    `:disabled`, no test mode.
 
   ### Twiddly Options
 

--- a/lib/oban/config.ex
+++ b/lib/oban/config.ex
@@ -24,7 +24,7 @@ defmodule Oban.Config do
           queues: false | [{atom() | binary(), pos_integer() | Keyword.t()}],
           repo: module(),
           shutdown_grace_period: timeout(),
-          testing: :manual | :inline | :disabled
+          testing: :disabled | :inline | :manual
         }
 
   @enforce_keys [:node, :repo]
@@ -241,7 +241,7 @@ defmodule Oban.Config do
     if testing in @testing_modes do
       :ok
     else
-      {:error, "expected :testing to be a boolean, got: #{inspect(testing)}"}
+      {:error, "expected :testing to be a known mode, got: #{inspect(testing)}"}
     end
   end
 

--- a/lib/oban/config.ex
+++ b/lib/oban/config.ex
@@ -319,7 +319,6 @@ defmodule Oban.Config do
     |> Keyword.put_new(:node, node_name())
     |> Keyword.update(:plugins, [], &(&1 || []))
     |> Keyword.update(:queues, [], &(&1 || []))
-    |> Keyword.update(:testing, :disabled, &normalize_testing/1)
     |> Keyword.delete(:circuit_backoff)
     |> Enum.reject(&(&1 == {:notifier, Oban.PostgresNotifier}))
   end
@@ -364,10 +363,6 @@ defmodule Oban.Config do
       opts
     end
   end
-
-  defp normalize_testing(true), do: :manual
-  defp normalize_testing(false), do: :disabled
-  defp normalize_testing(mode), do: mode
 
   defp normalize_queues(queues) do
     for {name, value} <- queues do

--- a/lib/oban/queue/drainer.ex
+++ b/lib/oban/queue/drainer.ex
@@ -39,8 +39,7 @@ defmodule Oban.Queue.Drainer do
       |> Enum.reduce(old_acc, fn job, acc ->
         result =
           conf
-          |> Executor.new(job)
-          |> Executor.put(:safe, args.with_safety)
+          |> Executor.new(job, safe: args.with_safety)
           |> Executor.call()
           |> case do
             %{state: :exhausted} -> :discard

--- a/lib/oban/queue/executor.ex
+++ b/lib/oban/queue/executor.ex
@@ -28,6 +28,8 @@ defmodule Oban.Queue.Executor do
           worker: Worker.t()
         }
 
+  @type option :: {:safe, boolean()}
+
   @enforce_keys [:conf, :job]
   defstruct [
     :conf,
@@ -49,20 +51,16 @@ defmodule Oban.Queue.Executor do
     state: :unset
   ]
 
-  @spec new(Config.t(), Job.t()) :: t()
-  def new(%Config{} = conf, %Job{} = job) do
+  @spec new(Config.t(), Job.t(), [option()]) :: t()
+  def new(%Config{} = conf, %Job{} = job, opts \\ []) do
     struct!(__MODULE__,
       conf: conf,
       job: %{job | conf: conf},
       meta: event_metadata(conf, job),
+      safe: Keyword.get(opts, :safe, true),
       start_mono: System.monotonic_time(),
       start_time: System.system_time()
     )
-  end
-
-  @spec put(t(), :safe, boolean()) :: t()
-  def put(%__MODULE__{} = exec, :safe, value) when is_boolean(value) do
-    %{exec | safe: value}
   end
 
   @spec call(t()) :: t()

--- a/lib/oban/queue/inline_engine.ex
+++ b/lib/oban/queue/inline_engine.ex
@@ -109,10 +109,8 @@ defmodule Oban.Queue.InlineEngine do
     case Changeset.apply_action(changeset, :insert) do
       {:ok, job} ->
         conf
-        |> Executor.new(job)
-        |> Executor.put(:safe, false)
+        |> Executor.new(job, safe: false)
         |> Executor.call()
-        |> tap(&IO.inspect(&1.state))
         |> complete_job()
 
       {:error, changeset} ->

--- a/lib/oban/queue/inline_engine.ex
+++ b/lib/oban/queue/inline_engine.ex
@@ -1,0 +1,136 @@
+defmodule Oban.Queue.InlineEngine do
+  @moduledoc false
+
+  @behaviour Oban.Queue.Engine
+
+  import DateTime, only: [utc_now: 0]
+
+  alias Ecto.{Changeset, Multi}
+  alias Oban.{Config, Job}
+  alias Oban.Queue.{BasicEngine, Engine, Executor}
+
+  @impl Engine
+  defdelegate init(conf, opts), to: BasicEngine
+
+  @impl Engine
+  def put_meta(_conf, meta, key, value), do: Map.put(meta, key, value)
+
+  @impl Engine
+  def check_meta(_conf, meta, _running), do: meta
+
+  @impl Engine
+  def refresh(_conf, meta), do: meta
+
+  @impl Engine
+  def insert_job(%Config{} = conf, %Changeset{} = changeset) do
+    {:ok, execute_job(conf, changeset)}
+  end
+
+  @impl Engine
+  def insert_job(%Config{} = conf, %Multi{} = multi, name, fun) when is_function(fun, 1) do
+    Multi.run(multi, name, fn repo, changes ->
+      {:ok, execute_job(%{conf | repo: repo}, fun.(changes))}
+    end)
+  end
+
+  @impl Engine
+  def insert_job(%Config{} = conf, %Multi{} = multi, name, %Changeset{} = changeset) do
+    Multi.run(multi, name, fn repo, _changes ->
+      {:ok, execute_job(%{conf | repo: repo}, changeset)}
+    end)
+  end
+
+  @impl Engine
+  def insert_all_jobs(%Config{} = conf, changesets) do
+    changesets
+    |> expand()
+    |> Enum.map(&execute_job(conf, &1))
+  end
+
+  @impl Engine
+  def insert_all_jobs(%Config{} = conf, %Multi{} = multi, name, wrapper) do
+    Multi.run(multi, name, fn repo, changes ->
+      conf = %{conf | repo: repo}
+
+      jobs =
+        wrapper
+        |> expand(changes)
+        |> Enum.map(&execute_job(conf, &1))
+
+      {:ok, jobs}
+    end)
+  end
+
+  @impl Engine
+  def fetch_jobs(_conf, meta, _running), do: {:ok, {meta, []}}
+
+  @impl Engine
+  def complete_job(_conf, _job), do: :ok
+
+  @impl Engine
+  def discard_job(_conf, _job), do: :ok
+
+  @impl Engine
+  def error_job(_conf, _job, seconds) when is_integer(seconds), do: :ok
+
+  @impl Engine
+  def snooze_job(_conf, _job, seconds) when is_integer(seconds), do: :ok
+
+  @impl Engine
+  def cancel_job(_conf, _job), do: :ok
+
+  @impl Engine
+  def cancel_all_jobs(_conf, _queryable), do: {:ok, {0, []}}
+
+  @impl Engine
+  def retry_job(_conf, _job), do: :ok
+
+  @impl Engine
+  def retry_all_jobs(_conf, _queryable), do: {:ok, 0}
+
+  # Changeset Helpers
+
+  defp expand(value), do: expand(value, %{})
+  defp expand(fun, changes) when is_function(fun, 1), do: expand(fun.(changes), changes)
+  defp expand(%{changesets: changesets}, _), do: expand(changesets, %{})
+  defp expand(changesets, _) when is_list(changesets), do: changesets
+
+  # Execution Helpers
+
+  defp execute_job(conf, changeset) do
+    changeset =
+      changeset
+      |> Changeset.put_change(:attempted_by, [conf.node])
+      |> Changeset.put_change(:attempted_at, utc_now())
+      |> Changeset.put_change(:scheduled_at, utc_now())
+      |> Changeset.update_change(:args, &json_encode_decode/1)
+      |> Changeset.update_change(:meta, &json_encode_decode/1)
+
+    case Changeset.apply_action(changeset, :insert) do
+      {:ok, job} ->
+        conf
+        |> Executor.new(job)
+        |> Executor.put(:safe, false)
+        |> Executor.call()
+        |> tap(&IO.inspect(&1.state))
+        |> complete_job()
+
+      {:error, changeset} ->
+        raise Ecto.InvalidChangesetError, action: :insert, changeset: changeset
+    end
+  end
+
+  defp json_encode_decode(map) do
+    map
+    |> Jason.encode!()
+    |> Jason.decode!()
+  end
+
+  defp complete_job(%{job: job, state: :success}) do
+    %Job{job | state: "completed", completed_at: utc_now()}
+  end
+
+  defp complete_job(%{job: job, result: {:snooze, snooze}, state: :snoozed}) do
+    %Job{job | state: "scheduled", scheduled_at: DateTime.add(utc_now(), snooze, :second)}
+  end
+end

--- a/lib/oban/testing.ex
+++ b/lib/oban/testing.ex
@@ -229,17 +229,10 @@ defmodule Oban.Testing do
 
     result =
       conf_opts
+      |> Keyword.put(:testing, :inline)
       |> Config.new()
-      |> Executor.new(create_job(changeset))
-      |> Executor.put(:safe, false)
-      |> Executor.record_started()
-      |> Executor.resolve_worker()
-      |> Executor.start_timeout()
-      |> Executor.perform()
-      |> Executor.cancel_timeout()
-      |> Executor.record_finished()
-      |> Executor.emit_event()
-      |> Executor.reraise_unsafe()
+      |> Executor.new(create_job(changeset), safe: false)
+      |> Executor.call()
       |> Map.fetch!(:result)
 
     assert_valid_result(result)

--- a/lib/oban/testing.ex
+++ b/lib/oban/testing.ex
@@ -1,6 +1,7 @@
 defmodule Oban.Testing do
   @moduledoc """
-  This module simplifies testing workers and making assertions about enqueued jobs.
+  This module simplifies testing workers and making assertions about enqueued jobs when testing in
+  `:manual` mode.
 
   Assertions may be made on any property of a job, but you'll typically want to check by `args`,
   `queue` or `worker`. If you're using namespacing through PostgreSQL schemas, also called

--- a/test/integration/testing_mode_test.exs
+++ b/test/integration/testing_mode_test.exs
@@ -10,13 +10,16 @@ defmodule Oban.Integration.TestingModeTest do
       name = start_supervised_oban!(testing: :inline)
 
       assert {:ok, job_1} = Oban.insert(name, Worker.new(%{ref: 1, action: "OK"}))
-      assert {:ok, job_2} = Oban.insert(name, Worker.new(%{ref: 2, action: "SNOOZE"}))
+      assert {:ok, job_2} = Oban.insert(name, Worker.new(%{ref: 2, action: "ERROR"}))
+      assert {:ok, job_3} = Oban.insert(name, Worker.new(%{ref: 3, action: "SNOOZE"}))
 
       assert %{completed_at: %_{}, state: "completed"} = job_1
-      assert %{scheduled_at: %_{}, state: "scheduled"} = job_2
+      assert %{scheduled_at: %_{}, errors: [_], state: "retryable"} = job_2
+      assert %{scheduled_at: %_{}, state: "scheduled"} = job_3
 
       assert_receive {:ok, 1}
-      assert_receive {:snooze, 2}
+      assert_receive {:error, 2}
+      assert_receive {:snooze, 3}
     end
 
     test "executing a job with errors raises" do

--- a/test/integration/testing_mode_test.exs
+++ b/test/integration/testing_mode_test.exs
@@ -1,0 +1,79 @@
+defmodule Oban.Integration.TestingModeTest do
+  use Oban.Case
+
+  alias Ecto.Multi
+
+  @moduletag :integration
+
+  describe ":inline mode" do
+    test "executing a single inserted job inline" do
+      name = start_supervised_oban!(testing: :inline)
+
+      assert {:ok, job_1} = Oban.insert(name, Worker.new(%{ref: 1, action: "OK"}))
+      assert {:ok, job_2} = Oban.insert(name, Worker.new(%{ref: 2, action: "SNOOZE"}))
+
+      assert %{completed_at: %_{}, state: "completed"} = job_1
+      assert %{scheduled_at: %_{}, state: "scheduled"} = job_2
+
+      assert_receive {:ok, 1}
+      assert_receive {:snooze, 2}
+    end
+
+    test "executing a job with errors raises" do
+      name = start_supervised_oban!(testing: :inline)
+
+      assert_raise RuntimeError, fn ->
+        Oban.insert(name, Worker.new(%{ref: 1, action: "FAIL"}))
+      end
+
+      assert_raise Oban.CrashError, fn ->
+        Oban.insert(name, Worker.new(%{ref: 1, action: "EXIT"}))
+      end
+    end
+
+    test "executing single jobs inserted within a multi" do
+      name = start_supervised_oban!(testing: :inline)
+
+      multi = Multi.new()
+      multi = Oban.insert(name, multi, :job_1, Worker.new(%{ref: 1, action: "OK"}))
+      multi = Oban.insert(name, multi, :job_2, fn _ -> Worker.new(%{ref: 2, action: "OK"}) end)
+
+      assert {:ok, %{job_1: _, job_2: _}} = Repo.transaction(multi)
+
+      assert_receive {:ok, 1}
+      assert_receive {:ok, 2}
+    end
+
+    test "executing multiple jobs inserted inline" do
+      name = start_supervised_oban!(testing: :inline)
+
+      jobs_1 = for ref <- 1..2, do: Worker.new(%{ref: ref, action: "OK"})
+      jobs_2 = for ref <- 3..4, do: Worker.new(%{ref: ref, action: "OK"})
+
+      assert [%Job{}, %Job{}] = Oban.insert_all(name, jobs_1)
+      assert [%Job{}, %Job{}] = Oban.insert_all(name, %{changesets: jobs_2})
+
+      assert_receive {:ok, 2}
+      assert_receive {:ok, 4}
+    end
+
+    test "executing multiple jobs inserted within a multi" do
+      name = start_supervised_oban!(testing: :inline)
+
+      jobs_1 = for ref <- 1..2, do: Worker.new(%{ref: ref, action: "OK"})
+      jobs_2 = for ref <- 3..4, do: Worker.new(%{ref: ref, action: "OK"})
+      jobs_3 = for ref <- 5..6, do: Worker.new(%{ref: ref, action: "OK"})
+
+      multi = Multi.new()
+      multi = Oban.insert_all(name, multi, :jobs_1, jobs_1)
+      multi = Oban.insert_all(name, multi, :jobs_2, %{changesets: jobs_2})
+      multi = Oban.insert_all(name, multi, :jobs_3, fn _ -> jobs_3 end)
+
+      assert {:ok, %{jobs_1: _, jobs_2: _, jobs_3: _}} = Repo.transaction(multi)
+
+      assert_receive {:ok, 2}
+      assert_receive {:ok, 4}
+      assert_receive {:ok, 6}
+    end
+  end
+end

--- a/test/integration/testing_mode_test.exs
+++ b/test/integration/testing_mode_test.exs
@@ -1,5 +1,5 @@
 defmodule Oban.Integration.TestingModeTest do
-  use Oban.Case
+  use Oban.Case, async: true
 
   alias Ecto.Multi
 

--- a/test/oban/config_test.exs
+++ b/test/oban/config_test.exs
@@ -109,6 +109,8 @@ defmodule Oban.ConfigTest do
 
       assert_valid(testing: true)
       assert_valid(testing: false)
+      assert_valid(testing: :inline)
+      assert_valid(testing: :manual)
     end
   end
 
@@ -121,7 +123,12 @@ defmodule Oban.ConfigTest do
       assert %Config{queues: []} = conf(queues: false)
     end
 
-    test ":testing disables queues, peer, and plugins" do
+    test ":testing with a boolean convert to :manual or :disabled" do
+      assert %Config{testing: :manual} = conf(testing: true)
+      assert %Config{testing: :disabled} = conf(testing: false)
+    end
+
+    test ":testing in :manual mode disables queues, peer, and plugins" do
       assert %Config{queues: [], plugins: [], peer: false} =
                conf(queues: [alpha: 1], plugins: [Pruner], testing: true)
     end

--- a/test/oban/config_test.exs
+++ b/test/oban/config_test.exs
@@ -106,11 +106,11 @@ defmodule Oban.ConfigTest do
 
     test ":testing is validated as a boolean" do
       refute_valid(testing: :ok)
+      refute_valid(testing: true)
 
-      assert_valid(testing: true)
-      assert_valid(testing: false)
       assert_valid(testing: :inline)
       assert_valid(testing: :manual)
+      assert_valid(testing: :disabled)
     end
   end
 
@@ -123,14 +123,9 @@ defmodule Oban.ConfigTest do
       assert %Config{queues: []} = conf(queues: false)
     end
 
-    test ":testing with a boolean convert to :manual or :disabled" do
-      assert %Config{testing: :manual} = conf(testing: true)
-      assert %Config{testing: :disabled} = conf(testing: false)
-    end
-
     test ":testing in :manual mode disables queues, peer, and plugins" do
       assert %Config{queues: [], plugins: [], peer: false} =
-               conf(queues: [alpha: 1], plugins: [Pruner], testing: true)
+               conf(queues: [alpha: 1], plugins: [Pruner], testing: :manual)
     end
 
     test "translating deprecated crontab/timezone config into plugin usage" do


### PR DESCRIPTION
Inline testing immediately executes jobs as they are inserted within the current process and without ever touching the database. It's an alternative to the standard insert/verify/execute flow for testing.

This includes `Executor` cleanup to facilitate error handling within engines.

/cc @sorenone 