### PR TITLE
Update README, add umbrella configuration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
   - [Unique Jobs](#unique-jobs)
   - [Periodic Jobs](#periodic-jobs)
   - [Prioritizing Jobs](#prioritizing-jobs)
+  - [Umbrella Apps](#umbrella-apps)
 - [Testing](#testing)
 - [Error Handling](#error-handling)
 - [Instrumentation and Logging](#instrumentation-and-logging)
@@ -735,53 +736,39 @@ a job by assigning a numerical `priority`.
   priority. Within a particular priority jobs are executed in their scheduled
   order.
 
-### Oban usage in an umbrella app
+### Umbrella Apps
 
 If you need to run Oban from an umbrella application where more than one of
 the child apps need to interact with Oban, you may need to set the :name for
-each child application.
+each child application that configures Oban.
 
 #### For example
 
-If `MyAppA` is just responsible for ObanWeb
+`MyAppA` may be the app responsible for inserting Oban Jobs, but never
+processing those jobs.
 
 Configure Oban in `MyAppA`
   ```elixir
   config :my_app_a, Oban,
     name: MyAppA.Oban,
     repo: MyApp.Repo,
-    plugins: [Oban.Web.Plugins.Stats],
+    plugins: [],
     queues: []
   ```
 
-When mounting the `ObanWeb` dashboard reference the named oban.
-
-  `oban_dashboard("/oban", oban_name: MyAppA.Oban)`
-
-`MyAppB` may only be responsible for inserting Oban Jobs, but never processing
-those jobs.
+`MyAppB` may be the app resonsible for processing Oban jobs.
 
 Configure Oban in `MyAppB`
   ```elixir
   config :my_app_b, Oban,
     name: MyAppB.Oban,
     repo: MyApp.Repo,
-    plugins: [],
-    queues: []
-  ```
-
-`MyAppC` may be the app resonsible for processing Oban jobs.
-
-Configure Oban in `MyAppC`
-  ```elixir
-  config :my_app_c, Oban,
-    name: MyAppC.Oban,
-    repo: MyApp.Repo,
-    plugins: [Oban.Web.Plugins.Stats, {Oban.Plugins.Gossip, interval: :timer.seconds(5)}],
+    plugins: [...],
     queues: [:default, :queue_two, :etc]
   ```
 
-Then when scheduling a job use the configured name to reference the named Oban process.
+Then when scheduling a job use the configured name to reference the named
+Oban process.
 
 See:
   - `insert/2`
@@ -792,8 +779,8 @@ See:
 
   ```elixir
   Oban.insert!(MyAppA.Oban, %Oban.Job{})
-  Oban.insert(MyAppB.Oban, %Oban.Job{})
-  Oban.insert_all(MyAppC.Oban, multi, :multiname, [%Oban.Job{}])
+  Oban.insert(MyAppA.Oban, %Oban.Job{})
+  Oban.insert_all(MyAppB.Oban, multi, :multiname, [%Oban.Job{}])
   ```
 
 For testing the named Oban process, use `drain_queue/2`


### PR DESCRIPTION
I just went through this config for our umbrella app and the existing documentation doesn't have much about using the name argument. 

The best I could find was [issue-426](https://github.com/sorentwo/oban/issues/), which only makes reference to a slack thread. Hopefully this makes it clearer. But I'm happy to move this around or make changes. 

