### PR TITLE
Support flexible use of perform_job with inline testing and with_testing_mode

### DIFF
--- a/lib/oban/queue/basic_engine.ex
+++ b/lib/oban/queue/basic_engine.ex
@@ -130,6 +130,10 @@ defmodule Oban.Queue.BasicEngine do
   end
 
   @impl Engine
+  def complete_job(%Config{testing: :inline}, %Job{id: nil}) do
+    {0, nil}
+  end
+
   def complete_job(%Config{} = conf, %Job{} = job) do
     Repo.update_all(
       conf,

--- a/test/oban/testing_test.exs
+++ b/test/oban/testing_test.exs
@@ -192,6 +192,11 @@ defmodule Oban.TestingTest do
     after
       :telemetry.detach("perform-job-handler")
     end
+
+    test "changing testing mode via opts" do
+      assert :ok = perform_job(Worker, %{ref: 1, action: "OK"}, testing: :inline)
+      assert :ok = perform_job(Worker, %{ref: 1, action: "OK"}, testing: :manual)
+    end
   end
 
   describe "all_enqueued/0,1" do
@@ -318,6 +323,20 @@ defmodule Oban.TestingTest do
         assert_enqueued worker: Worker
 
         refute_received {:ok, 1}
+      end)
+    end
+
+    test "with perform_job" do
+      Testing.with_testing_mode(:manual, fn ->
+        assert :ok = perform_job(Worker, %{ref: 1, action: "OK"})
+        assert :ok = perform_job(Worker, %{ref: 1, action: "OK"}, testing: :manual)
+        assert :ok = perform_job(Worker, %{ref: 1, action: "OK"}, testing: :inline)
+      end)
+
+      Testing.with_testing_mode(:inline, fn ->
+        assert :ok = perform_job(Worker, %{ref: 1, action: "OK"})
+        assert :ok = perform_job(Worker, %{ref: 1, action: "OK"}, testing: :manual)
+        assert :ok = perform_job(Worker, %{ref: 1, action: "OK"}, testing: :inline)
       end)
     end
   end


### PR DESCRIPTION
_Temporary description:_ 
Tthis branch adds a failing test case for using `perform_job` inside of a `with_testing_mode` block as a minimal reproduction of a test failure I experienced on a new project yesterday. I'm unblocked if I default project-wide to `:manual` testing to preserve the 2.11 behavior, but I thought this was worth surfacing as a relatively intuitive combination of testing techniques.

```
  1) test with_testing_mode/2 with perform_job (Oban.TestingTest)
     test/oban/testing_test.exs:324
     ** (ArgumentError) nil given for `id`. comparison with nil is forbidden as it is unsafe. Instead write a query with is_nil/1, for example: is_nil(s.id)
     code: Testing.with_testing_mode(:manual, fn ->
     stacktrace:
       (ecto 3.7.1) lib/ecto/query/builder/filter.ex:191: Ecto.Query.Builder.Filter.not_nil!/2
       (oban 2.12.0) lib/oban/queue/basic_engine.ex:136: Oban.Queue.BasicEngine.complete_job/2
       (oban 2.12.0) lib/oban/queue/engine.ex:234: anonymous fn/3 in Oban.Queue.Engine.with_span/4
       (telemetry 1.1.0) /home/shane/src/not_me/oban/deps/telemetry/src/telemetry.erl:320: :telemetry.span/3
       (oban 2.12.0) lib/oban/queue/executor.ex:203: Oban.Queue.Executor.ack_event/1
       (oban 2.12.0) lib/oban/queue/executor.ex:197: Oban.Queue.Executor.report_finished/1
       (oban 2.12.0) lib/oban/queue/executor.ex:80: anonymous fn/1 in Oban.Queue.Executor.call/1
       (oban 2.12.0) lib/oban/testing.ex:236: Oban.Testing.perform_job/3
       test/oban/testing_test.exs:326: anonymous fn/0 in Oban.TestingTest."test with_testing_mode/2 with perform_job"/1
       (oban 2.12.0) lib/oban/testing.ex:398: Oban.Testing.with_testing_mode/2
       test/oban/testing_test.exs:325: (test)
```

I'm happy to either stop here if the fix is evident to you now that the test is available, or try to pursue a fix myself. In the case of the latter I will clean up the PR description and commit history afterwards.