### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ config :my_app, Oban,
   plugins: [Oban.Plugins.Pruner],
   queues: [default: 10, events: 50, media: 20]
 
-# confg/test.exs
+# config/test.exs
 config :my_app, Oban, testing: :inline
 
 # lib/my_app/application.ex


### PR DESCRIPTION
While I was reading the docs I encountered a small typo in the path in the usage section. instead of `config/test.exs` it was using the path `confg/test.exs`. This PR fixes this typo.