### PR TITLE
Allow passing `DateTime` for the `:with_scheduled` option when draining

### DIFF
--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -421,7 +421,7 @@ defmodule Oban do
 
   Drain a queue including jobs scheduled up to a minute:
 
-      Oban.drain_queue(queue: :default, with_scheduled: DateTime.utc_now() |> DateTime.add(60, :second))
+      Oban.drain_queue(queue: :default, with_scheduled: DateTime.add(DateTime.utc_now(), 60, :second))
 
   Drain a queue and assert an error is raised:
 

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -56,7 +56,7 @@ defmodule Oban do
           | {:with_limit, pos_integer()}
           | {:with_recursion, boolean()}
           | {:with_safety, boolean()}
-          | {:with_scheduled, boolean()}
+          | {:with_scheduled, boolean() | DateTime.t()}
 
   @type drain_result :: %{
           discard: non_neg_integer(),
@@ -386,8 +386,9 @@ defmodule Oban do
   ## Scheduled Jobs
 
   By default, `drain_queue/2` will execute all currently available jobs. In order to execute
-  scheduled jobs, you may pass the `:with_scheduled` flag which will cause scheduled jobs to be
-  marked as `available` beforehand.
+  scheduled jobs, you may pass the `with_scheduled: true` which will cause all scheduled jobs to
+  be marked as `available` beforehand. To run jobs scheduled up to a specific point in time, pass
+  a `DateTime` instead.
 
   ## Options
 
@@ -402,7 +403,9 @@ defmodule Oban do
     `false`, raised exceptions or unhandled exits are reraised (unhandled exits are wrapped in
     `Oban.CrashError`).
 
-  * `:with_scheduled` — whether to include any scheduled jobs when draining, default `false`
+  * `:with_scheduled` — whether to include any scheduled jobs when draining, default `false`.
+     When `true`, drains all scheduled jobs. When a `DateTime` is provided, drains all jobs
+     scheduled up to, and including, that point in time.
 
   ## Example
 
@@ -415,6 +418,10 @@ defmodule Oban do
 
       Oban.drain_queue(queue: :default, with_scheduled: true)
       %{failure: 0, snoozed: 0, success: 1}
+
+  Drain a queue including jobs scheduled up to a minute:
+
+      Oban.drain_queue(queue: :default, with_scheduled: DateTime.utc_now() |> DateTime.add(60, :second))
 
   Drain a queue and assert an error is raised:
 

--- a/lib/oban/queue/drainer.ex
+++ b/lib/oban/queue/drainer.ex
@@ -16,7 +16,6 @@ defmodule Oban.Queue.Drainer do
       |> Map.put_new(:with_recursion, false)
       |> Map.put_new(:with_safety, true)
       |> Map.put_new(:with_scheduled, false)
-      |> Map.put_new(:with_scheduled_up_to, nil)
       |> Map.update!(:queue, &to_string/1)
 
     drain(conf, %{discard: 0, failure: 0, snoozed: 0, success: 0}, args)

--- a/test/integration/draining_test.exs
+++ b/test/integration/draining_test.exs
@@ -57,8 +57,7 @@ defmodule Oban.Integration.DrainingTest do
 
       insert!(%{ref: 1, action: "OK"}, scheduled_at: scheduled_at)
 
-      assert %{success: 1, failure: 0} =
-               Oban.drain_queue(name, queue: :alpha, with_scheduled: scheduled_at)
+      assert %{success: 1} = Oban.drain_queue(name, queue: :alpha, with_scheduled: scheduled_at)
     end
   end
 

--- a/test/integration/draining_test.exs
+++ b/test/integration/draining_test.exs
@@ -22,15 +22,43 @@ defmodule Oban.Integration.DrainingTest do
   end
 
   describe ":with_scheduled" do
-    test "scheduled jobs are executed when given the :with_scheduled flag" do
+    test "all scheduled jobs are executed when the :with_scheduled flag is true" do
       name = start_supervised_oban!(queues: false)
 
       insert!(%{ref: 1, action: "OK"}, scheduled_at: seconds_from_now(3600))
+      insert!(%{ref: 2, action: "OK"}, scheduled_at: seconds_from_now(7200))
 
       assert %{success: 0, failure: 0} = Oban.drain_queue(name, queue: :alpha)
 
-      assert %{success: 1, failure: 0} =
+      assert %{success: 2, failure: 0} =
                Oban.drain_queue(name, queue: :alpha, with_scheduled: true)
+    end
+
+    test "when a DateTime is provided, jobs scheduled up to that timestamp are executed" do
+      name = start_supervised_oban!(queues: false)
+
+      insert!(%{ref: 1, action: "OK"}, scheduled_at: seconds_from_now(3600))
+      insert!(%{ref: 2, action: "OK"}, scheduled_at: seconds_from_now(7200))
+
+      assert %{success: 0, failure: 0} =
+               Oban.drain_queue(name, queue: :alpha, with_scheduled: seconds_from_now(1))
+
+      assert %{success: 1, failure: 0} =
+               Oban.drain_queue(name, queue: :alpha, with_scheduled: seconds_from_now(5000))
+
+      assert %{success: 1, failure: 0} =
+               Oban.drain_queue(name, queue: :alpha, with_scheduled: seconds_from_now(9000))
+    end
+
+    test "DateTime range is inclusive" do
+      name = start_supervised_oban!(queues: false)
+
+      scheduled_at = seconds_from_now(3600)
+
+      insert!(%{ref: 1, action: "OK"}, scheduled_at: scheduled_at)
+
+      assert %{success: 1, failure: 0} =
+               Oban.drain_queue(name, queue: :alpha, with_scheduled: scheduled_at)
     end
   end
 


### PR DESCRIPTION
Follow-up to the discussion on Elixir Slack.

In integration tests it's useful to check the side effects of running background jobs, for example verify that an email was sent. In my particular case, I'm checking for outgoing emails that are scheduled for future. The new `:with_scheduled_up_to` option allows for better control, basically giving the option to move the time forward.

In terms of the implementation, I went with the suggestion from the original discussion on Slack, but maybe there's a better way to handle `:with_scheduled` vs `:with_scheduled_up_to` (Raise when both are set? Use `with_scheduled: <timestamp>` instead?)