### PR TITLE
Change docs to reference newest notifier

### DIFF
--- a/lib/oban/notifiers/pg.ex
+++ b/lib/oban/notifiers/pg.ex
@@ -15,7 +15,7 @@ defmodule Oban.Notifiers.PG do
 
   ```elixir
   config :my_app, Oban,
-    notifier: Oban.Pro.Notifiers.PG,
+    notifier: Oban.Notifiers.PG,
     ...
   ```
 


### PR DESCRIPTION
Based on the docs [here](https://hexdocs.pm/oban/2.11.3/changelog.html#alternative-pg-process-groups-notifier) I believe this should be updated