### PR TITLE
Validate options after all normalizations

### DIFF
--- a/lib/oban/config.ex
+++ b/lib/oban/config.ex
@@ -62,8 +62,6 @@ defmodule Oban.Config do
   def new(opts) when is_list(opts) do
     opts = normalize(opts)
 
-    Validation.validate!(opts, &validate/1)
-
     opts =
       if opts[:testing] in [:manual, :inline] do
         opts
@@ -75,6 +73,8 @@ defmodule Oban.Config do
         |> Keyword.update!(:queues, &normalize_queues/1)
         |> Keyword.update!(:plugins, &normalize_plugins/1)
       end
+
+    Validation.validate!(opts, &validate/1)
 
     struct!(__MODULE__, opts)
   end


### PR DESCRIPTION
In a project I had a config (for all envs, in config.exs) where a queue had only :global_limit specified (we're using Pro SmartEngine). In test env, when trying to use the new `:inline` mode, even though the changelog says setting the `queues` config to an empty list for tests is no longer needed, I had to do it because this queue didn't have a valid `:limit` option and wasn't passing InlineEngine's validations. This patch should make it actually work.