### PR TITLE
Make the Engine module and behaviour public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ config :my_app, Oban,
 
 ### Bug Fixes
 
-- [BasicEngine] Never fetch jobs that have reached max attempts
+- [Engine] Never fetch jobs that have reached max attempts
 
   This adds a safeguard to the `fetch_jobs` function to prevent ever hitting the
   `attempt <= max_attempts` check constraint. Hitting the constraint causes the
@@ -89,7 +89,7 @@ config :my_app, Oban,
 - [Repo] Set `query_opts` in `Repo.transaction` options to prevent logging
   `begin` and `commit` events in development loggers.
 
-- [BasicEngine] Remove the `ORDER BY` clause from unique queries
+- [Engine] Remove the `ORDER BY` clause from unique queries
 
   The previous `ORDER BY id DESC` significantly hurts unique query performance
   when there are a _lot_ of potential jobs to check. The ordering was originally

--- a/guides/upgrading/v2.6.md
+++ b/guides/upgrading/v2.6.md
@@ -62,7 +62,7 @@ config :my_app, Oban,
 ```
 
 If you have multiple Oban instances you need to configure each one to use the
-`SmartEngine`, otherwise they'll default to the `BasicEngine`.
+`SmartEngine`, otherwise they'll default to the `Basic` engine.
 
 ## Start Gossiping
 

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -11,8 +11,8 @@ defmodule Oban do
   use Supervisor
 
   alias Ecto.{Changeset, Multi}
-  alias Oban.{Config, Job, Midwife, Notifier, Peer, Registry, Telemetry}
-  alias Oban.Queue.{Drainer, Engine, Producer}
+  alias Oban.{Config, Engine, Job, Midwife, Notifier, Peer, Registry, Telemetry}
+  alias Oban.Queue.{Drainer, Producer}
   alias Oban.Queue.Supervisor, as: QueueSupervisor
 
   @type name :: term()

--- a/lib/oban/config.ex
+++ b/lib/oban/config.ex
@@ -29,7 +29,7 @@ defmodule Oban.Config do
 
   @enforce_keys [:node, :repo]
   defstruct dispatch_cooldown: 5,
-            engine: Oban.Queue.BasicEngine,
+            engine: Oban.Engines.Basic,
             get_dynamic_repo: nil,
             log: false,
             name: Oban,
@@ -214,7 +214,7 @@ defmodule Oban.Config do
       conf_opts =
         opts
         |> Keyword.take([:engine, :name, :node, :repo])
-        |> Keyword.put_new(:engine, Oban.Queue.BasicEngine)
+        |> Keyword.put_new(:engine, Oban.Engines.Basic)
         |> Keyword.put_new(:repo, None)
 
       conf = struct!(__MODULE__, conf_opts)
@@ -320,7 +320,9 @@ defmodule Oban.Config do
     |> Keyword.update(:plugins, [], &(&1 || []))
     |> Keyword.update(:queues, [], &(&1 || []))
     |> Keyword.delete(:circuit_backoff)
-    |> Enum.reject(&(&1 == {:notifier, Oban.PostgresNotifier}))
+    |> Enum.reject(
+      &(&1 in [{:engine, Oban.Queue.BasicEngine}, {:notifier, Oban.PostgresNotifier}])
+    )
   end
 
   defp crontab_to_plugin(opts) do
@@ -358,7 +360,7 @@ defmodule Oban.Config do
 
   defp testing_to_engine(opts) do
     if opts[:testing] == :inline do
-      Keyword.put(opts, :engine, Oban.Queue.InlineEngine)
+      Keyword.put(opts, :engine, Oban.Engines.Inline)
     else
       opts
     end

--- a/lib/oban/engine.ex
+++ b/lib/oban/engine.ex
@@ -1,5 +1,22 @@
-defmodule Oban.Queue.Engine do
-  @moduledoc false
+defmodule Oban.Engine do
+  @moduledoc """
+  Defines an Engine.
+
+  Engines are responsible for all non-plugin database interaction, from inserting through
+  executing jobs.
+
+  Oban ships with two Engine implementations:
+
+    1. `Basic` — The default engine for development, production, and manual testing mode.
+    2. `Inline` — Designed specifically for testing, it executes jobs immediately,
+       in-memory, as they are inserted.
+
+  > #### 🌟 SmartEngine {: .info}
+  >
+  > The Basic engine lacks advanced functionality such as global limits, rate limits, and
+  > unique bulk insert. For those features and more, see the [`SmartEngine` in Oban
+  > Pro](https://getoban.pro/docs/pro/smart_engine.html).
+  """
 
   alias Ecto.{Changeset, Multi}
   alias Oban.{Config, Job}

--- a/lib/oban/engines/basic.ex
+++ b/lib/oban/engines/basic.ex
@@ -1,14 +1,13 @@
-defmodule Oban.Queue.BasicEngine do
+defmodule Oban.Engines.Basic do
   @moduledoc false
 
-  @behaviour Oban.Queue.Engine
+  @behaviour Oban.Engine
 
   import Ecto.Query
   import DateTime, only: [utc_now: 0]
 
   alias Ecto.{Changeset, Multi}
-  alias Oban.{Config, Job, Repo}
-  alias Oban.Queue.Engine
+  alias Oban.{Config, Engine, Job, Repo}
 
   @impl Engine
   def init(%Config{} = conf, opts) do

--- a/lib/oban/engines/inline.ex
+++ b/lib/oban/engines/inline.ex
@@ -1,16 +1,16 @@
-defmodule Oban.Queue.InlineEngine do
+defmodule Oban.Engines.Inline do
   @moduledoc false
 
-  @behaviour Oban.Queue.Engine
+  @behaviour Oban.Engine
 
   import DateTime, only: [utc_now: 0]
 
   alias Ecto.{Changeset, Multi}
-  alias Oban.{Config, Job}
-  alias Oban.Queue.{BasicEngine, Engine, Executor}
+  alias Oban.{Config, Engine, Job}
+  alias Oban.Queue.Executor
 
   @impl Engine
-  defdelegate init(conf, opts), to: BasicEngine
+  def init(_conf, opts), do: {:ok, Map.new(opts)}
 
   @impl Engine
   def put_meta(_conf, meta, key, value), do: Map.put(meta, key, value)

--- a/lib/oban/queue/executor.ex
+++ b/lib/oban/queue/executor.ex
@@ -1,9 +1,8 @@
 defmodule Oban.Queue.Executor do
   @moduledoc false
 
-  alias Oban.{Backoff, Config, CrashError, Job, PerformError, Telemetry, TimeoutError, Worker}
-
-  alias Oban.Queue.Engine
+  alias Oban.{Backoff, Config, CrashError, Engine, Job}
+  alias Oban.{PerformError, Telemetry, TimeoutError, Worker}
 
   require Logger
 

--- a/lib/oban/queue/producer.ex
+++ b/lib/oban/queue/producer.ex
@@ -3,8 +3,8 @@ defmodule Oban.Queue.Producer do
 
   use GenServer
 
-  alias Oban.{Backoff, Notifier, TimeoutError}
-  alias Oban.Queue.{Engine, Executor}
+  alias Oban.{Backoff, Engine, Notifier, TimeoutError}
+  alias Oban.Queue.Executor
 
   defmodule State do
     @moduledoc false

--- a/lib/oban/testing.ex
+++ b/lib/oban/testing.ex
@@ -389,8 +389,8 @@ defmodule Oban.Testing do
   def with_testing_mode(mode, fun) when mode in [:manual, :inline] and is_function(fun, 0) do
     engine =
       case mode do
-        :manual -> Oban.Queue.BasicEngine
-        :inline -> Oban.Queue.InlineEngine
+        :manual -> Oban.Engines.Basic
+        :inline -> Oban.Engines.Inline
       end
 
     Process.put(:oban_engine, engine)

--- a/mix.exs
+++ b/mix.exs
@@ -111,6 +111,7 @@ defmodule Oban.MixProject do
       ],
       Extending: [
         Oban.Config,
+        Oban.Engine,
         Oban.Notifier,
         Oban.Peer,
         Oban.Plugin,

--- a/test/oban/config_test.exs
+++ b/test/oban/config_test.exs
@@ -15,7 +15,8 @@ defmodule Oban.ConfigTest do
       refute_valid(engine: nil)
       refute_valid(engine: Repo)
 
-      assert_valid(engine: Oban.Queue.BasicEngine)
+      assert_valid(engine: Oban.Engines.Basic)
+      assert_valid(engine: Oban.Engines.Inline)
     end
 
     test ":log is validated as `false` or a valid log level" do
@@ -117,6 +118,10 @@ defmodule Oban.ConfigTest do
   describe "new/1" do
     test ":notifier translates to the correct postgres module" do
       assert %Config{notifier: Oban.Notifiers.Postgres} = conf(notifier: Oban.PostgresNotifier)
+    end
+
+    test ":engine translates to the correct basic module" do
+      assert %Config{engine: Oban.Engines.Basic} = conf(engine: Oban.Queue.BasicEngine)
     end
 
     test ":queues convert to an empty list when set to false" do


### PR DESCRIPTION
Along with documenting the `Engine`, this also flattens its name for parity with other "extension" modules. For consistency with notifiers and peers, this also renames the Basic and Inline engines.

/cc @sorenone