### PR TITLE
Add Core.Repo.aggregate

### DIFF
--- a/lib/oban/repo.ex
+++ b/lib/oban/repo.ex
@@ -13,6 +13,7 @@ defmodule Oban.Repo do
   @doc "Wraps `c:Ecto.Repo.aggregate/3` and `c:Ecto.Repo.aggregate/4`."
   @spec aggregate(Config.t(), Ecto.Queryable.t(), :count, opts :: Keyword.t()) :: term | nil
   @spec aggregate(
+          Config.t(),
           Ecto.Queryable.t(),
           :avg | :count | :max | :min | :sum,
           field :: atom,

--- a/lib/oban/repo.ex
+++ b/lib/oban/repo.ex
@@ -10,6 +10,41 @@ defmodule Oban.Repo do
   alias Ecto.{Changeset, Multi, Query, Queryable, Schema}
   alias Oban.Config
 
+  @doc "Wraps `c:Ecto.Repo.aggregate/3` and `c:Ecto.Repo.aggregate/4`."
+  @spec aggregate(Config.t(), Ecto.Queryable.t(), :count, opts :: Keyword.t()) :: term | nil
+  @spec aggregate(
+          Ecto.Queryable.t(),
+          :avg | :count | :max | :min | :sum,
+          field :: atom,
+          opts :: Keyword.t()
+        ) :: term | nil
+  @aggregates [:count, :avg, :max, :min, :sum]
+  def aggregate(conf, queryable, aggregate, opts \\ [])
+
+  def aggregate(conf, queryable, aggregate, opts)
+      when aggregate in [:count] and is_list(opts) do
+    with_dynamic_repo(
+      conf,
+      fn -> conf.repo.aggregate(queryable, aggregate, query_opts(conf, opts)) end
+    )
+  end
+
+  def aggregate(conf, queryable, aggregate, field)
+      when aggregate in @aggregates and is_atom(field) do
+    with_dynamic_repo(
+      conf,
+      fn -> conf.repo.aggregate(queryable, aggregate, field, query_opts(conf, [])) end
+    )
+  end
+
+  def aggregate(conf, queryable, aggregate, field, opts)
+      when aggregate in @aggregates and is_atom(field) and is_list(opts) do
+    with_dynamic_repo(
+      conf,
+      fn -> conf.repo.aggregate(queryable, aggregate, field, query_opts(conf, opts)) end
+    )
+  end
+
   @doc "Wraps `c:Ecto.Repo.all/2`."
   @doc since: "2.2.0"
   @spec all(Config.t(), Queryable.t(), Keyword.t()) :: [Schema.t()]


### PR DESCRIPTION
We have a use case where we want to constrain queue size and feed our queues incrementally, as we have a large backlog of pending jobs, very slow external services, and small available concurrency on those services. We've estimated that it will take over a year to process all jobs. The prioritization of pending jobs will change on the fly.

We initially used `select: count(job.id)` with some state filters to find unprocessed jobs, but that makes our dialyzer unhappy... the query would return `[integer]`, but the spec on any of the available `Oban.Repo` functions is a map.

This function works as intended and also allows us to run dialyzer.