### PR TITLE
Soft replace discard with cancel return value

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ orphaned due to crashes.
 
 - **Job Canceling** — Jobs can be canceled in the middle of execution regardless
   of which node they are running on. This stops the job at once and flags it as
-  `discarded`.
+  `cancelled`.
 
 - **Triggered Execution** — Database triggers ensure that jobs are dispatched as
   soon as they are inserted into the database.
@@ -217,7 +217,7 @@ end
 
 Successful jobs should return `:ok` or an `{:ok, value}` tuple. The value
 returned from `perform/1` is used to control whether the job is treated as a
-success, a failure, discarded completely or deferred until later.
+success, a failure, cancelled or deferred for retrying later.
 
 See the `Oban.Worker` docs for more details on failure conditions and
 `Oban.Telemetry` for details on job reporting.

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -59,6 +59,7 @@ defmodule Oban do
           | {:with_scheduled, boolean() | DateTime.t()}
 
   @type drain_result :: %{
+          cancelled: non_neg_integer(),
           discard: non_neg_integer(),
           failure: non_neg_integer(),
           snoozed: non_neg_integer(),

--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -22,12 +22,12 @@ defmodule Oban.Job do
 
   @type unique_state :: [
           :available
-          | :scheduled
-          | :executing
-          | :retryable
+          | :cancelled
           | :completed
           | :discarded
-          | :cancelled
+          | :executing
+          | :retryable
+          | :scheduled
         ]
 
   @type unique_option ::

--- a/lib/oban/queue/drainer.ex
+++ b/lib/oban/queue/drainer.ex
@@ -18,7 +18,7 @@ defmodule Oban.Queue.Drainer do
       |> Map.put_new(:with_scheduled, false)
       |> Map.update!(:queue, &to_string/1)
 
-    drain(conf, %{discard: 0, failure: 0, snoozed: 0, success: 0}, args)
+    drain(conf, %{cancelled: 0, discard: 0, failure: 0, snoozed: 0, success: 0}, args)
   end
 
   defp stage_scheduled(conf, queue, with_scheduled) do

--- a/lib/oban/worker.ex
+++ b/lib/oban/worker.ex
@@ -27,7 +27,7 @@ defmodule Oban.Worker do
         end
       end
 
-  The following example defines a complex worker module to process jobs in the `events` queue. 
+  The following example defines a complex worker module to process jobs in the `events` queue.
   It then dials down the priority from 0 to 1, limits retrying on failures to 10 attempts, adds
   a "business" tag, and ensures that duplicate jobs aren't enqueued within a 30 second period:
 
@@ -56,9 +56,12 @@ defmodule Oban.Worker do
   The value returned from `c:perform/1` can control whether the job is a success or a failure:
 
   * `:ok` or `{:ok, value}` — the job is successful; for success tuples the `value` is ignored
-  * `:discard` or `{:discard, reason}` — discard the job and prevent it from being retried again.
-    An error is recorded using the optional reason, though the job is still successful
+
+  * `{:cancel, reason}` — cancel executing the job and stop retrying it. An error is recorded
+    using the optional `reason`, though the job is still successful.
+
   * `{:error, error}` — the job failed, record the error and schedule a retry if possible
+
   * `{:snooze, seconds}` — mark the job as `snoozed` and schedule it to run again `seconds` in the
     future. See [Snoozing](#module-snoozing-jobs) for more details.
 
@@ -241,6 +244,7 @@ defmodule Oban.Worker do
   @type result ::
           :ok
           | :discard
+          | {:cancel, reason :: term()}
           | {:discard, reason :: term()}
           | {:ok, ignored :: term()}
           | {:error, reason :: term()}

--- a/test/integration/draining_test.exs
+++ b/test/integration/draining_test.exs
@@ -10,15 +10,17 @@ defmodule Oban.Integration.DrainingTest do
     insert!(ref: 2, action: "FAIL")
     insert!(ref: 3, action: "OK")
     insert!(ref: 4, action: "SNOOZE")
-    insert!(ref: 5, action: "DISCARD")
-    insert!(%{ref: 6, action: "FAIL"}, max_attempts: 1)
+    insert!(ref: 5, action: "CANCEL")
+    insert!(ref: 6, action: "DISCARD")
+    insert!(%{ref: 7, action: "FAIL"}, max_attempts: 1)
 
-    assert %{discard: 2, failure: 1, snoozed: 1, success: 2} ==
+    assert %{cancelled: 1, discard: 2, failure: 1, snoozed: 1, success: 2} ==
              Oban.drain_queue(name, queue: :alpha)
 
-    assert_received {:ok, 3}
-    assert_received {:fail, 2}
     assert_received {:ok, 1}
+    assert_received {:fail, 2}
+    assert_received {:ok, 3}
+    assert_received {:cancel, 5}
   end
 
   describe ":with_scheduled" do

--- a/test/support/worker.ex
+++ b/test/support/worker.ex
@@ -24,6 +24,11 @@ defmodule Oban.Integration.Worker do
 
         :ok
 
+      "CANCEL" ->
+        send(pid, {:cancel, ref})
+
+        {:cancel, :because}
+
       "DISCARD" ->
         send(pid, {:discard, ref})
 


### PR DESCRIPTION
Discard was originally intended to mean "a job exhausted all retries." Later, it was added as a return type and it came to mean either "stop retrying" or "exhausted retries" ambiguously, with no clear way to differentiate. Even later, we introduced `cancel` with a `cancelled` state as way to stop jobs at runtime. At a semantic level, it's better to keep discarding and cancelling distinct.

This introduces a `{:cancel, reason}` return type and soft deprecates the use of `discard` from `perform/1` entirely. The meaning of each action/state is now:

* `cancel`—this job was purposefully stopped from retrying, either from a return value or the cancel command
* `discard`—this job has exhausted all retries

Closes #703

/cc @jc00ke @igorffs @patmaddox