### PR TITLE
feat: allow to specify query timeouts on Reindexer plugin

### DIFF
--- a/lib/oban/plugins/reindexer.ex
+++ b/lib/oban/plugins/reindexer.ex
@@ -164,12 +164,18 @@ defmodule Oban.Plugins.Reindexer do
 
       if Expression.now?(state.schedule, datetime) do
         prefix = inspect(state.conf.prefix)
+        params = []
         query_opts = [timeout: state.timeout]
 
-        Repo.query(state.conf, deindex_query(state), query_opts)
+        Repo.query(state.conf, deindex_query(state), params, query_opts)
 
         for index <- state.indexes do
-          Repo.query(state.conf, "REINDEX INDEX CONCURRENTLY #{prefix}.#{index}", query_opts)
+          Repo.query(
+            state.conf,
+            "REINDEX INDEX CONCURRENTLY #{prefix}.#{index}",
+            params,
+            query_opts
+          )
         end
       end
     else

--- a/lib/oban/plugins/reindexer.ex
+++ b/lib/oban/plugins/reindexer.ex
@@ -33,7 +33,7 @@ defmodule Oban.Plugins.Reindexer do
 
     * `:schedule` — a cron expression that controls when to reindex. Defaults to `"@midnight"`.
 
-    * `:timeout` - time in milliseconds to wait for each query call to finish.
+    * `:timeout` - time in milliseconds to wait for each query call to finish. Defaults to 15 seconds.
 
     * `:timezone` — which timezone to use when evaluating the schedule. To use a timezone other than
       the default of "Etc/UTC" you *must* have a timezone database like [tzdata][tzdata] installed
@@ -60,9 +60,9 @@ defmodule Oban.Plugins.Reindexer do
       :name,
       :schedule,
       :timer,
-      :timeout,
       indexes: ~w(oban_jobs_args_index oban_jobs_meta_index),
-      timezone: "Etc/UTC"
+      timezone: "Etc/UTC",
+      timeout: 15_000
     ]
   end
 
@@ -164,7 +164,7 @@ defmodule Oban.Plugins.Reindexer do
 
       if Expression.now?(state.schedule, datetime) do
         prefix = inspect(state.conf.prefix)
-        query_opts = query_opts(state)
+        query_opts = [timeout: state.timeout]
 
         Repo.query(state.conf, deindex_query(state), query_opts)
 
@@ -195,11 +195,5 @@ defmodule Oban.Plugins.Reindexer do
       END LOOP;
     END $$
     """
-  end
-
-  defp query_opts(state) do
-    timeout = state.timeout
-
-    if timeout, do: [timeout: timeout], else: []
   end
 end

--- a/lib/oban/plugins/reindexer.ex
+++ b/lib/oban/plugins/reindexer.ex
@@ -62,7 +62,7 @@ defmodule Oban.Plugins.Reindexer do
       :timer,
       indexes: ~w(oban_jobs_args_index oban_jobs_meta_index),
       timezone: "Etc/UTC",
-      timeout: 15_000
+      timeout: :timer.seconds(15)
     ]
   end
 

--- a/test/oban/plugins/reindexer_test.exs
+++ b/test/oban/plugins/reindexer_test.exs
@@ -29,6 +29,13 @@ defmodule Oban.Plugins.ReindexerTest do
       assert :ok = Reindexer.validate(timezone: "Europe/Copenhagen")
       assert :ok = Reindexer.validate(timezone: "America/Chicago")
     end
+
+    test "validating that :timeout is a positive integer" do
+      assert {:error, _} = Reindexer.validate(timeout: "")
+      assert {:error, _} = Reindexer.validate(timeout: 0)
+
+      assert :ok = Reindexer.validate(timeout: :timer.minutes(1))
+    end
   end
 
   @tag :reindex


### PR DESCRIPTION
In some cases, applying `REINDEX INDEX CONCURRENTLY` on the indexes `oban_jobs_args_index`, and `oban_jobs_meta_index` takes more than the default value (15 seconds). This new option will allow clients to specify other values than the default.