### PR TITLE
Fix inserting job with extra options error

### DIFF
--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -285,6 +285,11 @@ defmodule Oban do
   end
 
   @doc false
+  def insert(%Multi{} = multi, multi_name, changeset, opts) when is_changeset_or_fun(changeset) do
+    insert(__MODULE__, multi, multi_name, changeset, opts)
+  end
+
+  @doc false
   def insert(name, multi, multi_name, changeset) when is_changeset_or_fun(changeset) do
     insert(name, multi, multi_name, changeset, [])
   end

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -402,6 +402,12 @@ defmodule Oban do
   end
 
   @doc false
+  def insert_all(%Multi{} = multi, multi_name, changesets, opts)
+      when is_list_or_wrapper(changesets) do
+    insert_all(__MODULE__, multi, multi_name, changesets, opts)
+  end
+
+  @doc false
   def insert_all(name, multi, multi_name, changesets) when is_list_or_wrapper(changesets) do
     insert_all(name, multi, multi_name, changesets, [])
   end

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -263,6 +263,12 @@ defmodule Oban do
       {:ok, job} = Oban.insert(MyApp.Worker.new(%{id: 1}), timeout: 10_000)
   """
   @doc since: "0.7.0"
+  @spec insert(Job.changeset(), Keyword.t()) ::
+          {:ok, Job.t()} | {:error, Job.changeset() | term()}
+  def insert(%Changeset{} = changeset, opts) do
+    insert(__MODULE__, changeset, opts)
+  end
+
   @spec insert(name(), Job.changeset(), Keyword.t()) ::
           {:ok, Job.t()} | {:error, Job.changeset() | term()}
   def insert(name \\ __MODULE__, changeset, opts \\ [])
@@ -315,6 +321,11 @@ defmodule Oban do
       job = Oban.insert!(MyApp.Worker.new(%{id: 1}))
   """
   @doc since: "0.7.0"
+  @spec insert!(Job.changeset(), Keyword.t()) :: Job.t()
+  def insert!(%Changeset{} = changeset, opts) do
+    insert!(__MODULE__, changeset, opts)
+  end
+
   @spec insert!(name(), Job.changeset(), opts :: Keyword.t()) :: Job.t()
   def insert!(name \\ __MODULE__, %Changeset{} = changeset, opts \\ []) do
     case insert(name, changeset, opts) do

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -326,11 +326,12 @@ defmodule Oban do
       job = Oban.insert!(MyApp.Worker.new(%{id: 1}))
   """
   @doc since: "0.7.0"
-  @spec insert!(Job.changeset(), Keyword.t()) :: Job.t()
+  @spec insert!(Job.changeset(), opts :: Keyword.t()) :: Job.t()
   def insert!(%Changeset{} = changeset, opts) do
     insert!(__MODULE__, changeset, opts)
   end
 
+  @spec insert!(name(), Job.changeset()) :: Job.t()
   @spec insert!(name(), Job.changeset(), opts :: Keyword.t()) :: Job.t()
   def insert!(name \\ __MODULE__, %Changeset{} = changeset, opts \\ []) do
     case insert(name, changeset, opts) do

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -379,6 +379,11 @@ defmodule Oban do
       |> Oban.insert_all(timeout: 10_000)
   """
   @doc since: "0.9.0"
+  @spec insert_all(changesets_or_wrapper(), Keyword.t()) :: [Job.t()]
+  def insert_all(changesets, opts) when is_list_or_wrapper(changesets) do
+    insert_all(__MODULE__, changesets, opts)
+  end
+
   @spec insert_all(
           name() | multi(),
           changesets_or_wrapper() | multi_name(),

--- a/test/integration/inserting_test.exs
+++ b/test/integration/inserting_test.exs
@@ -3,6 +3,14 @@ defmodule Oban.Integration.InsertingTest do
 
   alias Ecto.Multi
 
+  test "inserting job with insert/2" do
+    start_supervised_oban!(name: Oban, queues: false)
+    assert {:ok, %Job{}} = Oban.insert(Worker.new(%{ref: 1}), timeout: 10_000)
+
+    name = start_supervised_oban!(queues: false)
+    assert {:ok, %Job{}} = Oban.insert(name, Worker.new(%{ref: 2}))
+  end
+
   test "inserting multiple jobs within a multi using insert/3" do
     name = start_supervised_oban!(queues: false)
 
@@ -17,6 +25,14 @@ defmodule Oban.Integration.InsertingTest do
     assert job_1.id
     assert job_2.id
     assert job_3.id
+  end
+
+  test "inserting job with insert!/2" do
+    start_supervised_oban!(name: Oban, queues: false)
+    assert %Job{} = Oban.insert!(Worker.new(%{ref: 1}), timeout: 10_000)
+
+    name = start_supervised_oban!(queues: false)
+    assert %Job{} = Oban.insert!(name, Worker.new(%{ref: 2}))
   end
 
   test "inserting multiple jobs with insert_all/2" do

--- a/test/integration/inserting_test.exs
+++ b/test/integration/inserting_test.exs
@@ -3,76 +3,84 @@ defmodule Oban.Integration.InsertingTest do
 
   alias Ecto.Multi
 
-  test "inserting job with insert/2" do
+  test "inserting a job with insert/2" do
+    name = start_supervised_oban!(queues: false)
+    assert {:ok, %Job{}} = Oban.insert(name, Worker.new(%{ref: 1}))
+  end
+
+  test "inserting a job with insert/2 and use default name" do
     start_supervised_oban!(name: Oban, queues: false)
     assert {:ok, %Job{}} = Oban.insert(Worker.new(%{ref: 1}), timeout: 10_000)
-
-    name = start_supervised_oban!(queues: false)
-    assert {:ok, %Job{}} = Oban.insert(name, Worker.new(%{ref: 2}))
   end
 
   test "inserting multiple jobs within a multi using insert/4" do
     name = start_supervised_oban!(queues: false)
 
-    multi_1 = Multi.new()
-    multi_1 = Oban.insert(name, multi_1, :job_1, Worker.new(%{ref: 1}))
-    multi_1 = Oban.insert(name, multi_1, "job-2", fn _ -> Worker.new(%{ref: 2}) end)
-    multi_1 = Oban.insert(name, multi_1, {:job, 3}, Worker.new(%{ref: 3}))
-    assert {:ok, results_1} = Repo.transaction(multi_1)
+    multi = Multi.new()
+    multi = Oban.insert(name, multi, :job_1, Worker.new(%{ref: 1}))
+    multi = Oban.insert(name, multi, "job-2", fn _ -> Worker.new(%{ref: 2}) end)
+    multi = Oban.insert(name, multi, {:job, 3}, Worker.new(%{ref: 3}))
+    assert {:ok, results} = Repo.transaction(multi)
 
-    assert %{:job_1 => job_1, "job-2" => job_2, {:job, 3} => job_3} = results_1
+    assert %{:job_1 => job_1, "job-2" => job_2, {:job, 3} => job_3} = results
 
     assert job_1.id
     assert job_2.id
     assert job_3.id
-
-    start_supervised_oban!(name: Oban, queues: false)
-
-    multi_2 = Multi.new()
-    multi_2 = Oban.insert(multi_2, :job_4, Worker.new(%{ref: 4}), timeout: 10_000)
-    assert {:ok, results_2} = Repo.transaction(multi_2)
-
-    assert %{:job_4 => job_4} = results_2
-
-    assert job_4.id
   end
 
-  test "inserting job with insert!/2" do
+  test "inserting multiple jobs within a multi using insert/4 and use default name" do
+    start_supervised_oban!(name: Oban, queues: false)
+
+    multi = Multi.new()
+    multi = Oban.insert(multi, :job_1, Worker.new(%{ref: 1}), timeout: 10_000)
+    assert {:ok, results} = Repo.transaction(multi)
+
+    assert %{:job_1 => job_1} = results
+
+    assert job_1.id
+  end
+
+  test "inserting a job with insert!/2" do
+    name = start_supervised_oban!(queues: false)
+    assert %Job{} = Oban.insert!(name, Worker.new(%{ref: 1}))
+  end
+
+  test "inserting a job with insert!/2 and use default name" do
     start_supervised_oban!(name: Oban, queues: false)
     assert %Job{} = Oban.insert!(Worker.new(%{ref: 1}), timeout: 10_000)
-
-    name = start_supervised_oban!(queues: false)
-    assert %Job{} = Oban.insert!(name, Worker.new(%{ref: 2}))
   end
 
   test "inserting multiple jobs with insert_all/2" do
-    start_supervised_oban!(name: Oban, queues: false)
-
-    changesets_1 = Enum.map(0..4, &Worker.new(%{ref: &1}, queue: "special", schedule_in: 10))
-    jobs_1 = Oban.insert_all(changesets_1, timeout: 10_000)
-
-    assert is_list(jobs_1)
-    assert length(jobs_1) == 5
-
-    [%Job{queue: "special", state: "scheduled"} = job_1 | _] = jobs_1
-
-    assert job_1.id
-    assert job_1.args
-    assert job_1.scheduled_at
-
     name = start_supervised_oban!(queues: false)
 
-    changesets_2 = Enum.map(5..9, &Worker.new(%{ref: &1}, queue: "special", schedule_in: 10))
-    jobs_2 = Oban.insert_all(name, changesets_2)
+    changesets = Enum.map(0..4, &Worker.new(%{ref: &1}, queue: "special", schedule_in: 10))
+    jobs = Oban.insert_all(name, changesets)
 
-    assert is_list(jobs_2)
-    assert length(jobs_2) == 5
+    assert is_list(jobs)
+    assert length(jobs) == 5
 
-    [%Job{queue: "special", state: "scheduled"} = job_2 | _] = jobs_2
+    [%Job{queue: "special", state: "scheduled"} = job | _] = jobs
 
-    assert job_2.id
-    assert job_2.args
-    assert job_2.scheduled_at
+    assert job.id
+    assert job.args
+    assert job.scheduled_at
+  end
+
+  test "inserting multiple jobs with insert_all/2 and use default name" do
+    start_supervised_oban!(name: Oban, queues: false)
+
+    changesets = Enum.map(0..4, &Worker.new(%{ref: &1}, queue: "special", schedule_in: 10))
+    jobs = Oban.insert_all(changesets, timeout: 10_000)
+
+    assert is_list(jobs)
+    assert length(jobs) == 5
+
+    [%Job{queue: "special", state: "scheduled"} = job | _] = jobs
+
+    assert job.id
+    assert job.args
+    assert job.scheduled_at
   end
 
   test "inserting multiple jobs from a changeset wrapper with insert_all/2" do
@@ -104,29 +112,29 @@ defmodule Oban.Integration.InsertingTest do
     changesets_2 = Enum.map(3..4, &Worker.new(%{ref: &1}))
     changesets_3 = Enum.map(5..6, &Worker.new(%{ref: &1}))
 
-    multi_1 = Multi.new()
-    multi_1 = Oban.insert_all(name, multi_1, "jobs-1", changesets_1)
-    multi_1 = Oban.insert_all(name, multi_1, "jobs-2", changesets_2)
-    multi_1 = Multi.run(multi_1, "build-jobs-3", fn _, _ -> {:ok, changesets_3} end)
-    multi_1 = Oban.insert_all(name, multi_1, "jobs-3", & &1["build-jobs-3"])
-
-    {:ok, %{"jobs-1" => jobs_1, "jobs-2" => jobs_2, "jobs-3" => jobs_3}} =
-      Repo.transaction(multi_1)
+    multi = Multi.new()
+    multi = Oban.insert_all(name, multi, "jobs-1", changesets_1)
+    multi = Oban.insert_all(name, multi, "jobs-2", changesets_2)
+    multi = Multi.run(multi, "build-jobs-3", fn _, _ -> {:ok, changesets_3} end)
+    multi = Oban.insert_all(name, multi, "jobs-3", & &1["build-jobs-3"])
+    {:ok, %{"jobs-1" => jobs_1, "jobs-2" => jobs_2, "jobs-3" => jobs_3}} = Repo.transaction(multi)
 
     assert [%Job{}, %Job{}] = jobs_1
     assert [%Job{}, %Job{}] = jobs_2
     assert [%Job{}, %Job{}] = jobs_3
+  end
 
+  test "inserting multiple jobs within a multi using insert_all/4 and use default name" do
     start_supervised_oban!(name: Oban, queues: false)
 
-    changesets_4 = Enum.map(7..8, &Worker.new(%{ref: &1}))
+    changesets = Enum.map(1..2, &Worker.new(%{ref: &1}))
 
-    multi_2 = Multi.new()
-    multi_2 = Oban.insert_all(multi_2, "jobs-4", changesets_4, timeout: 10_000)
+    multi = Multi.new()
+    multi = Oban.insert_all(multi, "jobs-1", changesets, timeout: 10_000)
 
-    {:ok, %{"jobs-4" => jobs_4}} = Repo.transaction(multi_2)
+    {:ok, %{"jobs-1" => jobs_1}} = Repo.transaction(multi)
 
-    assert [%Job{}, %Job{}] = jobs_4
+    assert [%Job{}, %Job{}] = jobs_1
   end
 
   test "inserting multiple jobs from a changeset wrapper using insert_all/4" do


### PR DESCRIPTION
Some error cases:

1. `Oban.insert(MyApp.Worker.new(%{id: 1}), timeout: 10_000)`
```
** (FunctionClauseError) no function clause matching in Oban.insert/3

     The following arguments were given to Oban.insert/3:
     
         # 1
         #Ecto.Changeset<action: nil, changes: %{args: %{}, errors: [], data: #Oban.Job<>, valid?: true>
     
         # 2
         [timeout: 10000]
     
         # 3
         []
     
     Attempted function clauses (showing 2 out of 2):
     
         def insert(name, %Ecto.Changeset{} = changeset, opts)
         def insert(%Ecto.Multi{} = multi, multi_name, changeset) when is_map(changeset) and is_atom(Ecto.Changeset) or :fail and is_map_key(changeset, :__struct__) and :erlang.map_get(:__struct__, changeset) == Ecto.Changeset or is_function(changeset, 1)
```

2. `Oban.insert(Ecto.Multi.new(), "job-1", Worker.new(%{id: 1}), timeout: 10_000)`
```
** (FunctionClauseError) no function clause matching in Oban.insert/4

     The following arguments were given to Oban.insert/4:
     
         # 1
         %Ecto.Multi{names: #MapSet<[]>, operations: []}
     
         # 2
         :job_4
     
         # 3
         #Ecto.Changeset<action: nil, changes: %{args: %{}, errors: [], data: #Oban.Job<>, valid?: true>
     
         # 4
         [timeout: 10000]
     
     Attempted function clauses (showing 1 out of 1):
     
         def insert(name, multi, multi_name, changeset) when is_map(changeset) and is_atom(Ecto.Changeset) or :fail and is_map_key(changeset, :__struct__) and :erlang.map_get(:__struct__, changeset) == Ecto.Changeset or is_function(changeset, 1)
```

3. `1..100 |> Enum.map(&MyApp.Worker.new(%{id: &1})) |> Oban.insert_all(timeout: 10_000)`
```
** (RuntimeError) no config registered for [#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #Oban.Job<>, valid?: true>] instance, is the supervisor running?
```

4. `Oban.insert_all(Ecto.Multi.new(), "jobs-1", [Worker.new(%{id: 1}, Worker.new(%{id: 2}], timeout: 10_000)`
```
** (RuntimeError) no config registered for %Ecto.Multi{names: #MapSet<[]>, operations: []} instance, is the supervisor running?
```
