### PR TITLE
Documentation updated to reflect latest Honeybadger API

### DIFF
--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -191,7 +191,7 @@ defmodule Oban.Telemetry do
       if attempt >= 3 do
         context = Map.take(meta, [:id, :args, :queue, :worker])
 
-        Honeybadger.notify(meta.reason, context, meta.stacktrace)
+        Honeybadger.notify(meta.reason, metadata: context, stacktrace: meta.stacktrace)
       end
     end
   end


### PR DESCRIPTION
The Honeybadger package deprecated `notify/3` with its 0.15 release and prints a deprecation notice whenever the function is called ([docs here](https://hexdocs.pm/honeybadger/0.18.1/Honeybadger.html#notify/3)).

This change updates the Honeybadger Telemetry integration example to use the currently recommended API.