### PR TITLE
Change backoff example to use Job struct

### DIFF
--- a/guides/recipes/expected-failures.md
+++ b/guides/recipes/expected-failures.md
@@ -107,8 +107,8 @@ strategy is too fast. By defining a custom `backoff` function on the
 # inside of MyApp.Workers.FlakyWorker
 
 @impl true
-def backoff(attempt, base_amount \\ 60) do
-  attempt * base_amount
+def backoff(%Job{attempt: attempt}) do
+  attempt * 60
 end
 ```
 


### PR DESCRIPTION
The backoff example implies that it takes an `attempt` and `base_amount` but elsewhere in the docs the function takes a `Job` struct. This updates the example.