### PR TITLE
Handle cancelled jobs in inline engine

### DIFF
--- a/lib/oban/engines/inline.ex
+++ b/lib/oban/engines/inline.ex
@@ -134,6 +134,12 @@ defmodule Oban.Engines.Inline do
     %Job{job | errors: [error], state: "retryable", scheduled_at: utc_now()}
   end
 
+  defp complete_job(%{job: job, state: :cancelled}) do
+    error = %{attempt: job.attempt, at: utc_now(), error: format_blamed(job.unsaved_error)}
+
+    %Job{job | errors: [error], state: "cancelled", cancelled_at: utc_now()}
+  end
+
   defp complete_job(%{job: job, state: state}) when state in [:discard, :exhausted] do
     error = %{attempt: job.attempt, at: utc_now(), error: format_blamed(job.unsaved_error)}
 

--- a/test/integration/inline_mode_test.exs
+++ b/test/integration/inline_mode_test.exs
@@ -11,16 +11,19 @@ defmodule Oban.Integration.InlineModeTest do
       assert {:ok, job_2} = Oban.insert(name, Worker.new(%{ref: 2, action: "ERROR"}))
       assert {:ok, job_3} = Oban.insert(name, Worker.new(%{ref: 3, action: "SNOOZE"}))
       assert {:ok, job_4} = Oban.insert(name, Worker.new(%{ref: 4, action: "DISCARD"}))
+      assert {:ok, job_5} = Oban.insert(name, Worker.new(%{ref: 5, action: "CANCEL"}))
 
       assert %{attempt: 1, completed_at: %_{}, state: "completed"} = job_1
       assert %{attempt: 1, scheduled_at: %_{}, errors: [_], state: "retryable"} = job_2
       assert %{attempt: 1, scheduled_at: %_{}, state: "scheduled"} = job_3
       assert %{attempt: 1, discarded_at: %_{}, state: "discarded"} = job_4
+      assert %{attempt: 1, cancelled_at: %_{}, state: "cancelled"} = job_5
 
       assert_receive {:ok, 1}
       assert_receive {:error, 2}
       assert_receive {:snooze, 3}
       assert_receive {:discard, 4}
+      assert_receive {:cancel, 5}
     end
 
     test "executing a job with errors raises" do


### PR DESCRIPTION
Currently when a job is cancelled with the inline mode we get the following error:
```elixir
     ** (FunctionClauseError) no function clause matching in Oban.Engines.Inline.complete_job/1

     The following arguments were given to Oban.Engines.Inline.complete_job/1:

         # 1
         %Oban.Queue.Executor{result: {:cancel, :reason}, state: :cancelled, ...} # Rest of executor omitted for readability reasons

     Attempted function clauses (showing 4 out of 4):

         defp complete_job(%{job: job, state: :failure})
         defp complete_job(%{job: job, state: state}) when state === :discard or state === :exhausted
         defp complete_job(%{job: job, state: :success})
         defp complete_job(%{job: job, result: {:snooze, snooze}, state: :snoozed})

     stacktrace:
       (oban 2.13.4) lib/oban/engines/inline.ex:135: Oban.Engines.Inline.complete_job/1
       (oban 2.13.4) lib/oban/engines/inline.ex:29: Oban.Engines.Inline.insert_job/3
       (oban 2.13.4) lib/oban/engine.ex:280: anonymous fn/3 in Oban.Engine.with_span/4
```

With the changes made in this PR, cancelled jobs are correctly handled, receiving the correct state and having `cancelled_at` filled accordingly.