### PR TITLE
Rewrite Oban.Repo to auto-wrap all functions

### DIFF
--- a/lib/oban/exceptions.ex
+++ b/lib/oban/exceptions.ex
@@ -15,7 +15,8 @@ end
 
 defmodule Oban.PerformError do
   @moduledoc """
-  Wraps the reason returned by `{:error, reason}`, `{:discard, reason}` in a proper exception.
+  Wraps the reason returned by `{:error, reason}`, `{:cancel, reason}`, or `{:discard, reason}` in
+  a proper exception.
 
   The original return tuple is available in the `:reason` key.
   """

--- a/lib/oban/repo.ex
+++ b/lib/oban/repo.ex
@@ -1,247 +1,162 @@
 defmodule Oban.Repo do
   @moduledoc """
-  Wrappers around `Ecto.Repo` callbacks.
+  Wrappers around `Ecto.Repo` and `Ecto.Adapters.SQL` callbacks.
 
-  These functions should be used when working with an Ecto repo inside a plugin. These functions
-  will resolve the correct repo instance, and set the schema prefix and the log level, according
-  to the Oban configuration.
+  Each function resolves the correct repo instance and sets options such as `prefix` and `log`
+  according to `Oban.Config`.
+
+  > #### Meant for Extending Oban {: .warning}
+  >
+  > These functions should only be used when working with a repo inside engines, plugins, or other
+  > extensions for Oban. Favor using your application's repo directly when querying `Oban.Job`
+  > from your workers.
+
+  ## Examples
+
+  The first argument for every function must be an `Oban.Config` struct. Many functions pass
+  configuration around as a `conf` key, and it can always be fetched with `Oban.config/1`. This
+  demonstrates fetching the default instance config and querying all jobs:
+
+      Oban
+      |> Oban.config()
+      |> Oban.Repo.all(Oban.Job)
   """
 
-  alias Ecto.{Changeset, Multi, Query, Queryable, Schema}
+  @moduledoc since: "2.2.0"
+
   alias Oban.Config
 
-  @doc "Wraps `c:Ecto.Repo.aggregate/3` and `c:Ecto.Repo.aggregate/4`."
-  @spec aggregate(Config.t(), Ecto.Queryable.t(), :count, opts :: Keyword.t()) :: term | nil
-  @spec aggregate(
-          Config.t(),
-          Ecto.Queryable.t(),
-          :avg | :count | :max | :min | :sum,
-          field :: atom,
-          opts :: Keyword.t()
-        ) :: term | nil
-  @aggregates [:count, :avg, :max, :min, :sum]
-  def aggregate(conf, queryable, aggregate, opts \\ [])
+  @callbacks_without_opts [
+    config: 0,
+    default_options: 1,
+    get_dynamic_repo: 0,
+    in_transaction?: 0,
+    load: 2,
+    put_dynamic_repo: 1,
+    rollback: 1
+  ]
 
-  def aggregate(conf, queryable, aggregate, opts)
-      when aggregate in [:count] and is_list(opts) do
-    with_dynamic_repo(
-      conf,
-      fn -> conf.repo.aggregate(queryable, aggregate, query_opts(conf, opts)) end
-    )
+  @callbacks_with_opts [
+    aggregate: 3,
+    all: 2,
+    checkout: 2,
+    delete!: 2,
+    delete: 2,
+    delete_all: 2,
+    exists?: 2,
+    get!: 3,
+    get: 3,
+    get_by!: 3,
+    get_by: 3,
+    insert!: 2,
+    insert: 2,
+    insert_all: 3,
+    insert_or_update!: 2,
+    insert_or_update: 2,
+    one!: 2,
+    one: 2,
+    preload: 3,
+    reload!: 2,
+    reload: 2,
+    stream: 2,
+    transaction: 2,
+    update!: 2,
+    update: 2,
+    update_all: 3
+  ]
+
+  for {fun, arity} <- @callbacks_without_opts do
+    args = [Macro.var(:conf, __MODULE__) | Macro.generate_arguments(arity, __MODULE__)]
+
+    @doc """
+    Wraps `c:Ecto.Repo.#{fun}/#{arity}` with an additional `Oban.Config` argument.
+    """
+    def unquote(fun)(unquote_splicing(args)) do
+      __dispatch__(unquote(fun), unquote(args))
+    end
   end
 
-  def aggregate(conf, queryable, aggregate, field)
-      when aggregate in @aggregates and is_atom(field) do
-    with_dynamic_repo(
-      conf,
-      fn -> conf.repo.aggregate(queryable, aggregate, field, query_opts(conf, [])) end
-    )
+  for {fun, arity} <- @callbacks_with_opts do
+    args = [Macro.var(:conf, __MODULE__) | Macro.generate_arguments(arity - 1, __MODULE__)]
+
+    @doc """
+    Wraps `c:Ecto.Repo.#{fun}/#{arity}` with an additional `Oban.Config` argument.
+    """
+    def unquote(fun)(unquote_splicing(args), opts \\ []) do
+      __dispatch__(unquote(fun), unquote(args), opts)
+    end
   end
 
-  def aggregate(conf, queryable, aggregate, field, opts)
-      when aggregate in @aggregates and is_atom(field) and is_list(opts) do
-    with_dynamic_repo(
-      conf,
-      fn -> conf.repo.aggregate(queryable, aggregate, field, query_opts(conf, opts)) end
-    )
+  # Manually Defined
+
+  @doc """
+  The default values extracted from `Oban.Config` for use in all queries with options.
+  """
+  @doc since: "2.14.0"
+  def default_options(conf) do
+    [log: conf.log, prefix: conf.prefix, telemetry_options: [oban_conf: conf]]
   end
 
-  @doc "Wraps `c:Ecto.Repo.all/2`."
+  @doc """
+  Wraps `Ecto.Adapters.SQL.Repo.query/4` with an added `Oban.Config` argument.
+  """
   @doc since: "2.2.0"
-  @spec all(Config.t(), Queryable.t(), Keyword.t()) :: [Schema.t()]
-  def all(conf, queryable, opts \\ []) do
-    with_dynamic_repo(
-      conf,
-      fn -> conf.repo.all(queryable, query_opts(conf, opts)) end
-    )
+  def query(conf, statement, params \\ [], opts \\ []) do
+    __dispatch__(:query, [conf, statement, params, opts])
   end
 
-  @doc "Wraps `c:Ecto.Repo.checkout/2`."
+  @doc """
+  Wraps `Ecto.Adapters.SQL.Repo.to_sql/2` with an added `Oban.Config` argument.
+  """
   @doc since: "2.2.0"
-  @spec checkout(Config.t(), (() -> result), Keyword.t()) :: result when result: var
-  def checkout(conf, function, opts \\ []) do
-    with_dynamic_repo(
-      conf,
-      fn -> conf.repo.checkout(function, query_opts(conf, opts)) end
-    )
-  end
-
-  @doc "Wraps `c:Ecto.Repo.config/0`."
-  @doc since: "2.2.0"
-  @spec config(Config.t()) :: Keyword.t()
-  def config(conf), do: with_dynamic_repo(conf, &conf.repo.config/0)
-
-  @doc "Wraps `c:Ecto.Repo.delete/2`."
-  @doc since: "2.4.0"
-  @spec delete(
-          Config.t(),
-          struct_or_changeset :: Schema.t() | Changeset.t(),
-          opts :: Keyword.t()
-        ) :: {:ok, Schema.t()} | {:error, Changeset.t()}
-  def delete(conf, struct_or_changeset, opts \\ []) do
-    with_dynamic_repo(
-      conf,
-      fn -> conf.repo.delete(struct_or_changeset, query_opts(conf, opts)) end
-    )
-  end
-
-  @doc "Wraps `c:Ecto.Repo.delete_all/2`."
-  @doc since: "2.2.0"
-  @spec delete_all(Config.t(), Queryable.t(), Keyword.t()) :: {integer(), nil | [term()]}
-  def delete_all(conf, queryable, opts \\ []) do
-    with_dynamic_repo(
-      conf,
-      fn -> conf.repo.delete_all(queryable, query_opts(conf, opts)) end
-    )
-  end
-
-  @doc "Wraps `c:Ecto.Repo.insert/2`."
-  @doc since: "2.2.0"
-  @spec insert(Config.t(), Schema.t() | Changeset.t(), Keyword.t()) ::
-          {:ok, Schema.t()} | {:error, Changeset.t()}
-  def insert(conf, struct_or_changeset, opts \\ []) do
-    with_dynamic_repo(
-      conf,
-      fn -> conf.repo.insert(struct_or_changeset, query_opts(conf, opts)) end
-    )
-  end
-
-  @doc "Wraps `c:Ecto.Repo.insert_all/3`."
-  @doc since: "2.2.0"
-  @spec insert_all(
-          Config.t(),
-          binary() | {binary(), module()} | module(),
-          [map() | [{atom(), term() | Query.t()}]],
-          Keyword.t()
-        ) :: {integer(), nil | [term()]}
-  def insert_all(conf, schema_or_source, entries, opts \\ []) do
-    with_dynamic_repo(
-      conf,
-      fn -> conf.repo.insert_all(schema_or_source, entries, query_opts(conf, opts)) end
-    )
-  end
-
-  @doc "Wraps `c:Ecto.Repo.one/2`."
-  @doc since: "2.2.0"
-  @spec one(Config.t(), Queryable.t(), Keyword.t()) :: Schema.t() | nil
-  def one(conf, queryable, opts \\ []) do
-    with_dynamic_repo(
-      conf,
-      fn -> conf.repo.one(queryable, query_opts(conf, opts)) end
-    )
-  end
-
-  @doc "Wraps `Ecto.Adapters.SQL.Repo.query/4`."
-  @doc since: "2.2.0"
-  @spec query(Config.t(), String.t(), [term()], Keyword.t()) ::
-          {:ok,
-           %{
-             :rows => nil | [[term()] | binary()],
-             :num_rows => non_neg_integer(),
-             optional(atom()) => any()
-           }}
-          | {:error, Exception.t()}
-  def query(conf, sql, params \\ [], opts \\ []) do
-    with_dynamic_repo(conf, fn -> conf.repo.query(sql, params, query_opts(conf, opts)) end)
-  end
-
-  @doc "Wraps `c:Ecto.Repo.stream/2`"
-  @doc since: "2.9.0"
-  @spec stream(Config.t(), Queryable.t(), Keyword.t()) :: Enum.t()
-  def stream(conf, queryable, opts \\ []) do
-    with_dynamic_repo(conf, fn -> conf.repo.stream(queryable, query_opts(conf, opts)) end)
-  end
-
-  @doc "Wraps `c:Ecto.Repo.transaction/2`."
-  @doc since: "2.2.0"
-  @spec transaction(Config.t(), (... -> any()) | Multi.t(), opts :: Keyword.t()) ::
-          {:ok, any()}
-          | {:error, any()}
-          | {:error, Multi.name(), any(), %{required(Multi.name()) => any()}}
-  def transaction(conf, fun_or_multi, opts \\ []) do
-    with_dynamic_repo(
-      conf,
-      fn -> conf.repo.transaction(fun_or_multi, query_opts(conf, opts)) end
-    )
-  end
-
-  @doc "Wraps `Ecto.Adapters.SQL.Repo.to_sql/2`."
-  @doc since: "2.2.0"
-  @spec to_sql(Config.t(), :all | :update_all | :delete_all, Queryable.t()) ::
-          {String.t(), [term()]}
   def to_sql(conf, kind, queryable) do
-    queryable =
-      case Map.fetch(conf, :prefix) do
-        :error -> queryable
-        {:ok, prefix} -> queryable |> Queryable.to_query() |> Map.put(:prefix, prefix)
+    query =
+      queryable
+      |> Ecto.Queryable.to_query()
+      |> Map.put(:prefix, conf.prefix)
+
+    conf.repo.to_sql(kind, query)
+  end
+
+  defp __dispatch__(name, [%Config{} = conf | args]) do
+    with_dynamic_repo(conf, name, args)
+  end
+
+  defp __dispatch__(name, [%Config{} = conf | args], opts) when is_list(opts) do
+    opts =
+      conf
+      |> default_options()
+      |> Keyword.merge(opts)
+
+    with_dynamic_repo(conf, name, args ++ [opts])
+  end
+
+  defp with_dynamic_repo(%{get_dynamic_repo: fun} = conf, name, args) when is_function(fun, 0) do
+    prev_instance = conf.repo.get_dynamic_repo()
+
+    try do
+      unless in_transaction?(conf, prev_instance) do
+        conf.repo.put_dynamic_repo(fun.())
       end
 
-    conf.repo.to_sql(kind, queryable)
-  end
-
-  @doc "Wraps `c:Ecto.Repo.update/2`."
-  @doc since: "2.2.0"
-  @spec update(Config.t(), Changeset.t(), Keyword.t()) ::
-          {:ok, Schema.t()} | {:error, Changeset.t()}
-  def update(conf, changeset, opts \\ []) do
-    with_dynamic_repo(conf, fn -> conf.repo.update(changeset, query_opts(conf, opts)) end)
-  end
-
-  @doc "Wraps `c:Ecto.Repo.update_all/3`."
-  @doc since: "2.2.0"
-  @spec update_all(Config.t(), Queryable.t(), Keyword.t(), Keyword.t()) ::
-          {integer(), nil | [term()]}
-  def update_all(conf, queryable, updates, opts \\ []) do
-    with_dynamic_repo(
-      conf,
-      fn -> conf.repo.update_all(queryable, updates, query_opts(conf, opts)) end
-    )
-  end
-
-  @doc false
-  @spec with_dynamic_repo(Config.t(), fun()) :: any()
-  def with_dynamic_repo(conf, fun) do
-    case get_dynamic_repo(conf) do
-      nil ->
-        fun.()
-
-      instance ->
-        prev_instance = conf.repo.get_dynamic_repo()
-        maybe_run_in_transaction(conf, fun, instance, prev_instance)
+      apply(conf.repo, name, args)
+    after
+      conf.repo.put_dynamic_repo(prev_instance)
     end
   end
 
-  defp get_dynamic_repo(%{get_dynamic_repo: fun}) when is_function(fun, 0), do: fun.()
-  defp get_dynamic_repo(_conf), do: nil
-
-  defp maybe_run_in_transaction(conf, fun, instance, prev_instance) do
-    unless in_transaction?(conf, prev_instance) do
-      conf.repo.put_dynamic_repo(instance)
-    end
-
-    fun.()
-  after
-    conf.repo.put_dynamic_repo(prev_instance)
+  defp with_dynamic_repo(conf, name, args) do
+    apply(conf.repo, name, args)
   end
 
   defp in_transaction?(conf, instance) when is_pid(instance), do: conf.repo.in_transaction?()
 
   defp in_transaction?(conf, instance) when is_atom(instance) do
     case GenServer.whereis(instance) do
-      pid when is_pid(pid) ->
-        in_transaction?(conf, pid)
-
-      _ ->
-        false
+      pid when is_pid(pid) -> in_transaction?(conf, pid)
+      _ -> false
     end
   end
 
   defp in_transaction?(_, _), do: false
-
-  defp query_opts(conf, opts) do
-    opts
-    |> Keyword.put(:log, conf.log)
-    |> Keyword.put(:prefix, conf.prefix)
-    |> Keyword.put(:telemetry_options, oban_conf: conf)
-  end
 end


### PR DESCRIPTION
Oban.Repo exists as a thin wrapper around a configured Repo instance to automate dynamic repo and default options. Slight inconsistencies between the wrapper's specs and Ecto.Repo's own specs caused dialyzer failures when nothing was genuinely broken. Furthermore, many functions were missing because it was tedious to manually define every wrapper function.

With this patch every Ecto.Repo function, aside from a handful that are only used to manage a Repo instance, are wrapped with code generation that omits any typespecs.

Finally, the moduledocs now include a warning that indicates Oban.Repo is meant for extending Oban, not within applications.

Closes #796