### PR TITLE
Adds default inserted_at to Testing.perform_job/3

### DIFF
--- a/lib/oban/testing.ex
+++ b/lib/oban/testing.ex
@@ -225,6 +225,7 @@ defmodule Oban.Testing do
       |> Keyword.put_new(:attempt, 1)
       |> Keyword.put_new(:attempted_at, DateTime.utc_now())
       |> Keyword.put_new(:scheduled_at, DateTime.utc_now())
+      |> Keyword.put_new(:inserted_at, DateTime.utc_now())
 
     changeset =
       args

--- a/test/oban/testing_test.exs
+++ b/test/oban/testing_test.exs
@@ -75,13 +75,7 @@ defmodule Oban.TestingTest do
 
     @impl Oban.Worker
     def perform(%Oban.Job{} = job) do
-      result = %{
-        attempted_at: job.attempted_at,
-        scheduled_at: job.scheduled_at,
-        inserted_at: job.inserted_at
-      }
-
-      {:ok, result}
+      {:ok, Map.take(job, ~w(attempted_at inserted_at scheduled_at)a}
     end
   end
 
@@ -192,32 +186,24 @@ defmodule Oban.TestingTest do
     end
 
     test "defaulting timestamp fields to mimic real execution" do
-      assert {:ok,
-              %{
-                attempted_at: %DateTime{},
-                scheduled_at: %DateTime{},
-                inserted_at: %DateTime{}
-              }} = perform_job(TemporalWorker, %{})
+      assert {:ok, result} = perform_job(TemporalWorker, %{})
+
+      assert %{attempted_at: %_{}, inserted_at: %_{}, scheduled_at: %_{}} = result
     end
 
     test "retaining attempted_at, scheduled_at and inserted_at timestamps" do
       time = ~U[2020-02-20 00:00:00.000000Z]
 
-      assert {:ok,
-              %{
-                attempted_at: attempted_at,
-                scheduled_at: scheduled_at,
-                inserted_at: inserted_at
-              }} =
+      assert {:ok, result} =
                perform_job(TemporalWorker, %{},
                  attempted_at: time,
-                 scheduled_at: time,
-                 inserted_at: time
+                 inserted_at: time,
+                 scheduled_at: time
                )
 
-      assert attempted_at == time
-      assert scheduled_at == time
-      assert inserted_at == time
+      assert result.attempted_at == time
+      assert result.inserted_at == time
+      assert result.scheduled_at == time
     end
 
     test "emitting appropriate telemetry events" do

--- a/test/oban/testing_test.exs
+++ b/test/oban/testing_test.exs
@@ -75,7 +75,7 @@ defmodule Oban.TestingTest do
 
     @impl Oban.Worker
     def perform(%Oban.Job{} = job) do
-      {:ok, Map.take(job, ~w(attempted_at inserted_at scheduled_at)a}
+      {:ok, Map.take(job, ~w(attempted_at inserted_at scheduled_at)a)}
     end
   end
 


### PR DESCRIPTION
Hey there! 🖖 

This pull request adds a default `inserted_at` to jobs executed by `Testing.perform_job/3`.

The objective is to make it behave more like a job executed by a regular pipeline - where `inserted_at` will always be populated.

Kudos to @amishpatel1994 