### PR TITLE
Bring states-related docs back

### DIFF
--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -282,6 +282,22 @@ defmodule Oban.Job do
 
       iex> Oban.Job.states() -- [:completed, :discarded]
       [:scheduled, :available, :executing, :retryable, :cancelled]
+
+  ## Job State Transitions
+
+  * `:scheduled`—Jobs inserted with `scheduled_at` in the future are `:scheduled`. After the
+    `scheduled_at` time has ellapsed the `Oban.Plugins.Stager` will transition them to `:available`
+  * `:available`—Jobs without a future `scheduled_at` timestamp are inserted as `:available` and may
+    execute immediately
+  * `:executing`—Available jobs may be ran, at which point they are `:executing`
+  * `:retryable`—Jobs that fail and haven't exceeded their max attempts are transitiond to
+    `:retryable` and rescheduled until after a backoff period. Once the backoff has ellapsed the
+    `Oban.Plugins.Stager` will transition them back to `:available`
+  * `:completed`—Jobs that finish executing succesfully are marked `:completed`
+  * `:discarded`—Jobs that fail and exhaust their max attempts, or return a `:discard` tuple during
+    execution, are marked `:discarded`
+  * `:cancelled`—Jobs that are cancelled intentionally
+
   """
   @doc since: "2.1.0"
   def states, do: @unique_states ++ [:discarded, :cancelled]


### PR DESCRIPTION
It seems that the doc added by this [PR](https://github.com/sorentwo/oban/commit/8783852eb7085186b10f753a894b471ee7448e06) is removed by accident.

This PR add it back.