### PR TITLE
Update the @callback of Oban.Peer.leader? to match spec

### DIFF
--- a/lib/oban/peer.ex
+++ b/lib/oban/peer.ex
@@ -65,7 +65,7 @@ defmodule Oban.Peer do
   @doc """
   Check whether the current peer instance leads the cluster.
   """
-  @callback leader?(pid()) :: boolean()
+  @callback leader?(Config.t() | GenServer.server()) :: boolean()
 
   @doc """
   Check whether the current instance leads the cluster.


### PR DESCRIPTION
This was giving me some mocking trouble via Hammox, the spec and implementation expect an Oban.Config or GenServer.name. 