### PR TITLE
Improve the documentation around job state changes

### DIFF
--- a/lib/oban/worker.ex
+++ b/lib/oban/worker.ex
@@ -55,12 +55,15 @@ defmodule Oban.Worker do
 
   The value returned from `c:perform/1` can control whether the job is a success or a failure:
 
-  * `:ok` or `{:ok, value}` — the job is successful; for success tuples the `value` is ignored
+  * `:ok` or `{:ok, value}` — the job is successful; for success tuples the `value` is ignored.
+    The job is marked as `completed`.
 
   * `{:cancel, reason}` — cancel executing the job and stop retrying it. An error is recorded
-    using the optional `reason`, though the job is still successful.
+    using the optional `reason`. The job is marked as `cancelled`.
 
-  * `{:error, error}` — the job failed, record the error and schedule a retry if possible
+  * `{:error, error}` — the job failed, record the error. If `max_attempt`
+    has not been reached already, a retry is scheduled and the job is marked as `retryable`.
+    Otherwise, no retry is scheduled and the job is marked as `discarded`.
 
   * `{:snooze, seconds}` — mark the job as `snoozed` and schedule it to run again `seconds` in the
     future. See [Snoozing](#module-snoozing-jobs) for more details.


### PR DESCRIPTION
Attempt to improve the documentation around job state changes by providing a bit more information on what happens to the job's `state` depending on the value returned from `c:perform/1`.