### PR TITLE
support arg value serialization impls

### DIFF
--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -250,6 +250,8 @@ defmodule Oban.Job do
   @doc since: "0.1.0"
   @spec new(args(), [option()]) :: changeset()
   def new(args, opts \\ []) when is_map(args) and is_list(opts) do
+    args = serialize_arguments(args)
+
     params =
       opts
       |> Keyword.put(:args, args)
@@ -530,6 +532,12 @@ defmodule Oban.Job do
       else
         {:halt, {:error, key, val}}
       end
+    end)
+  end
+
+  defp serialize_arguments(args) do
+    Map.new(args, fn {key, value} ->
+      {key, Oban.Serializer.serialize(value)}
     end)
   end
 end

--- a/lib/oban/serializer.ex
+++ b/lib/oban/serializer.ex
@@ -1,0 +1,9 @@
+defprotocol Oban.Serializer do
+  @fallback_to_any true
+  @spec serialize(value :: any()) :: any()
+  def serialize(value)
+end
+
+defimpl Oban.Serializer, for: Any do
+  def serialize(value), do: value
+end

--- a/test/oban/job_test.exs
+++ b/test/oban/job_test.exs
@@ -38,6 +38,12 @@ defmodule Oban.JobTest do
       assert Job.new(%{}, worker: Fake, schedule_in: {6, :units}).errors[:schedule_in]
       assert Job.new(%{}, worker: Fake, schedule_in: {6.0, :hours}).errors[:schedule_in]
     end
+
+    test "args are serialized with user-provided protocol implementations" do
+      changeset = Job.new(%{foo: Decimal.new("1.23")}, worker: Fake)
+
+      assert changeset.changes[:args] == %{foo: "1.23"}
+    end
   end
 
   describe "tags with new/2" do

--- a/test/support/decimal_serializer_impl.ex
+++ b/test/support/decimal_serializer_impl.ex
@@ -1,0 +1,4 @@
+defimpl Oban.Serializer, for: Decimal do
+  @spec serialize(Decimal.t()) :: String.t()
+  def serialize(decimal_value), do: Decimal.to_string(decimal_value)
+end


### PR DESCRIPTION
Not 100% sure about this approach, but I need a way to tell Oban how to serialize argument values before encoding storing in JSONB w/ Jason.

Specifically, we are storing `Decimal.t()` values in our Oban Job args, and they are being deserialized as `%{"coef" => 15, "exp" => 1, "sign" => -1}`. Then, in the Oban worker `perform` callback, we have to cast this string-key map back into a Decimal struct. Our preference would be that Decimal args would just be stored as string representations in the database, so we can simply call `Decimal.new/1` on those strings in the `perform` callback (instead of the hacky map casting approach). 

Creating an implementation for `defimpl Jason.Encoder, for: Decimal` doesn't work for us because Jason is used in many places and layers throughout our production application. It doesn't make sense to create a new encode implementation for Decimal since this will apply to the whole application, instead of just Oban.

Context: https://elixir-lang.slack.com/archives/CRDGH1XCM/p1671488236832899