### PR TITLE
Switch from datetime fragment to binary operator

### DIFF
--- a/lib/oban/engines/lite.ex
+++ b/lib/oban/engines/lite.ex
@@ -248,7 +248,8 @@ defmodule Oban.Engines.Lite do
     query =
       Job
       |> where([j], j.state in ^states)
-      |> where([j], fragment("datetime(?) >= datetime(?)", j.inserted_at, ^since))
+      # |> where([j], fragment("datetime(?) >= datetime(?)", j.inserted_at, ^since))
+      |> where([j], j.inserted_at >= ^since)
       |> where(^dynamic)
       |> limit(1)
 
@@ -280,7 +281,7 @@ defmodule Oban.Engines.Lite do
     end
   end
 
-  defp seconds_from_now(seconds), do: DateTime.add(utc_now(), seconds, :second)
+  defp seconds_from_now(seconds), do: NaiveDateTime.add(utc_now(), seconds, :second)
 
   defp encode_unsaved(job) do
     Jason.encode!(%{

--- a/test/oban/engine_test.exs
+++ b/test/oban/engine_test.exs
@@ -159,6 +159,8 @@ for engine <- [Oban.Engines.Basic, Oban.Engines.Lite] do
         job_2 = insert!(name, %{id: 2}, inserted_at: five_minutes_ago)
         job_3 = insert!(name, %{id: 3}, inserted_at: nine_minutes_ago)
 
+        IO.inspect(@repo.query("SELECT inserted_at, scheduled_at FROM oban_jobs", []))
+
         assert {:ok, job_4} = uniq_insert.(%{id: 1}, 239)
         assert {:ok, job_5} = uniq_insert.(%{id: 2}, 299)
         assert {:ok, job_6} = uniq_insert.(%{id: 3}, 539)


### PR DESCRIPTION
This is a branch to diagnose why a simple `>=` comparison in the unique query doesn't seem to work without explicit `datetime` casting in a fragment.