### PR TITLE
Add note about Lite being an available engine

### DIFF
--- a/lib/oban/engine.ex
+++ b/lib/oban/engine.ex
@@ -5,11 +5,12 @@ defmodule Oban.Engine do
   Engines are responsible for all non-plugin database interaction, from inserting through
   executing jobs.
 
-  Oban ships with two Engine implementations:
+  Oban ships with three Engine implementations:
 
   1. `Basic` — The default engine for development, production, and manual testing mode.
   2. `Inline` — Designed specifically for testing, it executes jobs immediately, in-memory, as
      they are inserted.
+  3. `Lite` - The engine for running Oban using SQLite3.
 
   > #### 🌟 SmartEngine {: .info}
   >


### PR DESCRIPTION
I was perusing the documentation for an unrelated reason and noticed that the new engine isn't documented in this one place. I added it for you. 👍 

Thanks for Oban we're migrating some of our jobs to it and it's a massive improvement over what we currently are using!