### PR TITLE
Include jobs on fetch_jobs event metadata

### DIFF
--- a/lib/oban/engine.ex
+++ b/lib/oban/engine.ex
@@ -206,7 +206,8 @@ defmodule Oban.Engine do
   @doc false
   def fetch_jobs(%Config{} = conf, %{} = meta, %{} = running) do
     with_span(:fetch_jobs, conf, fn engine ->
-      engine.fetch_jobs(conf, meta, running)
+      {:ok, {meta, jobs}} = engine.fetch_jobs(conf, meta, running)
+      {:meta, {:ok, {meta, jobs}}, %{jobs: jobs}}
     end)
   end
 

--- a/test/oban/engine_test.exs
+++ b/test/oban/engine_test.exs
@@ -504,7 +504,6 @@ for engine <- [Oban.Engines.Basic, Oban.Engines.Lite] do
         assert_receive {:error, 4}
         assert_receive {:snooze, 5}
 
-
         with_backoff(fn ->
           assert %{state: "completed", completed_at: %_{}} = reload(name, job_1)
           assert %{state: "cancelled", cancelled_at: %_{}} = reload(name, job_2)

--- a/test/support/telemetry_handler.ex
+++ b/test/support/telemetry_handler.ex
@@ -12,6 +12,7 @@ defmodule Oban.TelemetryHandler do
     :plugin,
     [:engine, :insert_job],
     [:engine, :insert_all_jobs],
+    [:engine, :fetch_jobs],
     [:peer, :election]
   ]
 


### PR DESCRIPTION
Hey there! 

In Oban Telemetry documentation is described that  `:stop` events for bulk operations have included the `:jobs` key on metadata events, however, this is not the case. Examining at [`Oban.Engine.fetch_jobs/3`](https://github.com/sorentwo/oban/blob/main/lib/oban/engine.ex#L207) callback implementation, we can see that isn't happing as [others bulk operations](https://github.com/sorentwo/oban/blob/main/lib/oban/engine.ex#L191), so this PR has the goal to fix it. 

To validate this change it was added a simple `assert_receive` at the  "inserting and executing jobs" engine integration test, despite I am not fully confident that is the best approach. 

