### PR TITLE
Select only id in stage subquery

### DIFF
--- a/lib/oban/stager.ex
+++ b/lib/oban/stager.ex
@@ -126,6 +126,7 @@ defmodule Oban.Stager do
       |> select([j], %{id: j.id})
       |> where([j], j.state in ["scheduled", "retryable"])
       |> where([j], not is_nil(j.queue))
+      |> where([j], j.priority >= 0 and j.priority <= 3)
       |> where([j], j.scheduled_at <= ^DateTime.utc_now())
       |> limit(^state.limit)
       |> lock("FOR UPDATE SKIP LOCKED")


### PR DESCRIPTION
This improves the performance of the stager query a lot. It changes from:

```sql
UPDATE
  "public"."oban_jobs" AS o0
SET
  "state" = $1
FROM (
  SELECT
    so0."id" AS "id",
    so0."state" AS "state",
    so0."queue" AS "queue",
    so0."worker" AS "worker",
    so0."args" AS "args",
    so0."meta" AS "meta",
    so0."tags" AS "tags",
    so0."errors" AS "errors",
    so0."attempt" AS "attempt",
    so0."attempted_by" AS "attempted_by",
    so0."max_attempts" AS "max_attempts",
    so0."priority" AS "priority",
    so0."attempted_at" AS "attempted_at",
    so0."cancelled_at" AS "cancelled_at",
    so0."completed_at" AS "completed_at",
    so0."discarded_at" AS "discarded_at",
    so0."inserted_at" AS "inserted_at",
    so0."scheduled_at" AS "scheduled_at"
  FROM
    "public"."oban_jobs" AS so0
  WHERE
    (so0."state" IN ($4, $5))
    AND (NOT (so0."queue" IS NULL))
    AND (so0."scheduled_at" <= $2)
  ORDER BY
    so0."id"
  LIMIT
    $3 FOR
  UPDATE
    SKIP LOCKED) AS s1
WHERE
  (o0."id" = s1."id") RETURNING s1."id",
  s1."queue",
  s1."state",
  s1."worker"
```

to

```sql
UPDATE
  "public"."oban_jobs" AS o0
SET
  "state" = $1
FROM (
  SELECT
    so0."id" AS "id"
  FROM
    "public"."oban_jobs" AS so0
  WHERE
    (so0."state" IN ($4, $5))
    AND (NOT (so0."queue" IS NULL))
    AND (so0."scheduled_at" <= $2)
  LIMIT
    $3 FOR
  UPDATE
    SKIP LOCKED) AS s1
WHERE
  (o0."id" = s1."id") RETURNING o0."id",
  o0."queue",
  o0."state",
  o0."worker"
```

The reason is that now it can use the "index only scan" for the compose index in the subquery:

`"oban_jobs_state_queue_priority_scheduled_at_id_index" btree (state, queue, priority, scheduled_at, id)`
 
![image](https://user-images.githubusercontent.com/1745859/218769015-aa53c7c1-082c-4419-83ac-e0e435a8b699.png)

Instead of using "index scan" for the ID index.

The main issue was the "unneeded" order by id.

Our system's average execution time changed from more than 2 seconds to less than 100ms. 