### PR TITLE
Add 'Oban.Telemetry.detach_default_logger/0'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,10 +67,6 @@ and `worker` details. Even bulk operations such as `insert_all_jobs`, `cancel_al
 
 See the [2.14 upgrade guide](v2-14.html) for step-by-step instructions (all two of them).
 
-## v2.14.2 — Unreleased
-
-- [Oban.Telemetry] - Add `Oban.Telemetry.detach_default_logger/0`
-
 ## v2.14.1 — 2023-01-26
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@ and `worker` details. Even bulk operations such as `insert_all_jobs`, `cancel_al
 
 See the [2.14 upgrade guide](v2-14.html) for step-by-step instructions (all two of them).
 
+## v2.14.2 — Unreleased
+
+- [Oban.Telemetry] - Add `Oban.Telemetry.detach_default_logger/0`
+
 ## v2.14.1 — 2023-01-26
 
 ### Bug Fixes

--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -235,7 +235,7 @@ defmodule Oban.Telemetry do
 
   require Logger
 
-  @handlerID "oban-default-logger"
+  @handler_id "oban-default-logger"
 
   @doc """
   Attaches a default structured JSON Telemetry handler for logging.
@@ -297,7 +297,7 @@ defmodule Oban.Telemetry do
       |> Keyword.put_new(:encode, true)
       |> Keyword.put_new(:level, :info)
 
-    :telemetry.attach_many(@handlerID, events, &__MODULE__.handle_event/4, opts)
+    :telemetry.attach_many(@handler_id, events, &__MODULE__.handle_event/4, opts)
   end
 
   @doc """
@@ -307,7 +307,7 @@ defmodule Oban.Telemetry do
   @doc since: "2.14.2"
   @spec detach_default_logger() :: :ok | {:error, :not_found}
   def detach_default_logger do
-    :telemetry.detach(@handlerID)
+    :telemetry.detach(@handler_id)
   end
 
   @doc false

--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -301,10 +301,20 @@ defmodule Oban.Telemetry do
   end
 
   @doc """
-  Undoes `Oban.Telemetry.attach_default_logger/1`; detaches the attached
-  logger.
+  Undoes `Oban.Telemetry.attach_default_logger/1` by detaching the attached logger.
+
+  ## Examples
+
+  Detach a previously attached logger:
+
+      :ok = Oban.Telemetry.attach_default_logger()
+      :ok = Oban.Telemetry.detach_default_logger()
+
+  Attempt to detach when a logger wasn't attached:
+
+      {:error, :not_found} = Oban.Telemetry.detach_default_logger()
   """
-  @doc since: "2.14.2"
+  @doc since: "2.15.0"
   @spec detach_default_logger() :: :ok | {:error, :not_found}
   def detach_default_logger do
     :telemetry.detach(@handler_id)

--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -235,6 +235,8 @@ defmodule Oban.Telemetry do
 
   require Logger
 
+  @handlerID "oban-default-logger"
+
   @doc """
   Attaches a default structured JSON Telemetry handler for logging.
 
@@ -295,7 +297,17 @@ defmodule Oban.Telemetry do
       |> Keyword.put_new(:encode, true)
       |> Keyword.put_new(:level, :info)
 
-    :telemetry.attach_many("oban-default-logger", events, &__MODULE__.handle_event/4, opts)
+    :telemetry.attach_many(@handlerID, events, &__MODULE__.handle_event/4, opts)
+  end
+
+  @doc """
+  Undoes `Oban.Telemetry.attach_default_logger/1`; detaches the attached
+  logger.
+  """
+  @doc since: "2.14.2"
+  @spec detach_default_logger() :: :ok | {:error, :not_found}
+  def detach_default_logger do
+    :telemetry.detach(@handlerID)
   end
 
   @doc false


### PR DESCRIPTION
My specific use case for this is to cut down noise when running `priv/repo/seeds.exs` in my app, but it seems generally useful to have.