### PR TITLE
Change link caption for `Config Providers`

### DIFF
--- a/guides/release_configuration.md
+++ b/guides/release_configuration.md
@@ -7,8 +7,8 @@ concurrency.
 
 ## Using Config Providers
 
-If you are using Elixir Releases, this is straight forward to do using [Module
-Config Providers][mcp]:
+If you are using Elixir Releases, this is straight forward to do using [Config 
+Providers][mcp]:
 
 
 ```elixir


### PR DESCRIPTION
There's no mention of "Module Config Providers" in `mix release` documentation (`module` in `#module-config-providers` means the anchor refers to the section which is a part of the module docstring).