### PR TITLE
Fix documentation links to Oban Pro plugins

### DIFF
--- a/lib/oban/plugins/cron.ex
+++ b/lib/oban/plugins/cron.ex
@@ -9,7 +9,7 @@ defmodule Oban.Plugins.Cron do
   >
   > This plugin only loads the crontab statically, at boot time. To configure cron schedules
   > dynamically at runtime, across your entire cluster, see the `DynamicCron` plugin in [Oban
-  > Pro](https://getoban.pro/docs/pro/dynamic_cron.html).
+  > Pro](https://getoban.pro/docs/pro/Oban.Pro.Plugins.DynamicCron.html).
 
   ## Using the Plugin
 

--- a/lib/oban/plugins/lifeline.ex
+++ b/lib/oban/plugins/lifeline.ex
@@ -14,7 +14,7 @@ defmodule Oban.Plugins.Lifeline do
   >
   > This plugin may transition jobs that are genuinely `executing` and cause duplicate execution.
   > For more accurate rescuing or to rescue jobs that have exhausted retry attempts see the
-  > `DynamicLifeline` plugin in [Oban Pro](https://getoban.pro/docs/pro/dynamic_lifeline.html).
+  > `DynamicLifeline` plugin in [Oban Pro](https://getoban.pro/docs/pro/Oban.Pro.Plugins.DynamicLifeline.html).
 
   ## Using the Plugin
 

--- a/lib/oban/plugins/pruner.ex
+++ b/lib/oban/plugins/pruner.ex
@@ -20,7 +20,7 @@ defmodule Oban.Plugins.Pruner do
   > #### 🌟 DynamicPruner {: .info}
   >
   > To prune on a cron-style schedule, retain jobs by a limit, or provide overrides for specific
-  > queues, workers, and job states; see Oban Pro's [DynamicPruner][dyn].
+  > queues, workers, and job states; see Oban Pro's [DynamicPruner](https://getoban.pro/docs/pro/Oban.Pro.Plugins.DynamicPruner.html).
 
   ## Options
 
@@ -39,8 +39,6 @@ defmodule Oban.Plugins.Pruner do
   * `:pruned_jobs` - the jobs that were deleted from the database
 
   _Note: jobs only include `id`, `queue`, `state`, and `worker` fields._
-
-  [dyn]: https://getoban.pro/docs/pro/dynamic_pruner.html.
   """
 
   @behaviour Oban.Plugin


### PR DESCRIPTION
To make the links less reliant on the module names in Oban Pro, they could also point to `https://getoban.pro/docs/pro/0.13.1/overview.html#plugins`, but they are probably not bound to change any time soon :)