### PR TITLE
Fix the Instrumentation link in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,7 +711,7 @@ the following keys:
 * `attempt` The attempt number when the error occurred
 * `error` A formatted error message and stacktrace
 
-See the [Instrumentation](#Instrumentation-and-Logging) docs for an example of
+See the [Instrumentation](#instrumentation-error-reporting-and-logging) docs for an example of
 integrating with external error reporting systems.
 
 ### Limiting Retries


### PR DESCRIPTION
Currently the link doesn't point to the correct section