### PR TITLE
Add `:interval` to `t:Oban.Plugins.Pruner.option/0`

### DIFF
--- a/lib/oban/plugins/pruner.ex
+++ b/lib/oban/plugins/pruner.ex
@@ -49,6 +49,7 @@ defmodule Oban.Plugins.Pruner do
 
   @type option ::
           Plugin.option()
+          | {:interval, pos_integer()}
           | {:limit, pos_integer()}
           | {:max_age, pos_integer()}
 


### PR DESCRIPTION
The `:interval` option is documented but is missing from `t:Oban.Plugins.Pruner.option/0` type spec.