### PR TITLE
Remove reference to Stager

### DIFF
--- a/lib/oban/peers/global.ex
+++ b/lib/oban/peers/global.ex
@@ -3,7 +3,7 @@ defmodule Oban.Peers.Global do
   A cluster based peer that coordinates through a distributed registry.
 
   Leadership is coordinated through global locks. It requires a functional distributed Erlang
-  cluster, without one global plugins (Cron, Lifeline, Stager, etc.) will not function correctly.
+  cluster, without one global plugins (Cron, Lifeline, etc.) will not function correctly.
 
   ## Usage
 


### PR DESCRIPTION
It was removed in 2.14 - https://hexdocs.pm/oban/v2-14.html#remove-repeater-and-stager-plugins