### PR TITLE
Add primary_key explicitly to SQLite3

### DIFF
--- a/lib/oban/migrations/sqlite.ex
+++ b/lib/oban/migrations/sqlite.ex
@@ -7,7 +7,8 @@ defmodule Oban.Migrations.SQLite do
 
   @impl Oban.Migration
   def up(_opts) do
-    create_if_not_exists table(:oban_jobs) do
+    create_if_not_exists table(:oban_jobs, primary_key: false) do
+      add :id, :bigserial, primary_key: true
       add :state, :text, null: false, default: "available"
       add :queue, :text, null: false, default: "default"
       add :worker, :text, null: false


### PR DESCRIPTION
If a user has configured Ecto's `:migration_primary_key` to something different than bigserial the schema will not be compatible with the way Oban works.

This change doesn't warrant a new migration since either users have Ecto's default resulting in the same change or they don't have Ecto's default in which case Oban isn't functional.