### PR TITLE
Use Logger.warning/2

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,11 +795,11 @@ defmodule MyApp.ObanLogger do
   require Logger
 
   def handle_event([:oban, :job, :start], measure, meta, _) do
-    Logger.warn("[Oban] :started #{meta.worker} at #{measure.system_time}")
+    Logger.warning("[Oban] :started #{meta.worker} at #{measure.system_time}")
   end
 
   def handle_event([:oban, :job, event], measure, meta, _) do
-    Logger.warn("[Oban] #{event} #{meta.worker} ran in #{measure.duration}")
+    Logger.warning("[Oban] #{event} #{meta.worker} ran in #{measure.duration}")
   end
 end
 ```

--- a/lib/oban/peer.ex
+++ b/lib/oban/peer.ex
@@ -103,7 +103,7 @@ defmodule Oban.Peer do
     end
   catch
     :exit, {:timeout, _} = reason ->
-      Logger.warn("""
+      Logger.warning("""
       Oban.Peer.leader?/2 check failed due to #{inspect(reason)}.
       """)
 

--- a/lib/oban/peers/postgres.ex
+++ b/lib/oban/peers/postgres.ex
@@ -104,7 +104,7 @@ defmodule Oban.Peers.Postgres do
   rescue
     error in [Postgrex.Error] ->
       if error.postgres.code == :undefined_table do
-        Logger.warn("""
+        Logger.warning("""
         The `oban_peers` table is undefined and leadership is disabled.
 
         Run migrations up to v11 to restore peer leadership. In the meantime, distributed plugins
@@ -124,7 +124,7 @@ defmodule Oban.Peers.Postgres do
   end
 
   def handle_info(message, state) do
-    Logger.warn("Received unexpected message: #{inspect(message)}")
+    Logger.warning("Received unexpected message: #{inspect(message)}")
 
     {:noreply, state}
   end

--- a/lib/oban/plugins/repeater.ex
+++ b/lib/oban/plugins/repeater.ex
@@ -17,7 +17,7 @@ defmodule Oban.Plugins.Repeater do
 
   @impl Plugin
   def start_link(_opts) do
-    Logger.warn("""
+    Logger.warning("""
     Repeater is deprecated.
 
     Stager automatically forces polling when notifications aren't available. You can safely remove

--- a/lib/oban/queue/executor.ex
+++ b/lib/oban/queue/executor.ex
@@ -303,7 +303,7 @@ defmodule Oban.Queue.Executor do
   end
 
   defp log_warning(%__MODULE__{safe: true, worker: worker}, returned) do
-    Logger.warn(fn ->
+    Logger.warning(fn ->
       """
       Expected #{worker}.perform/1 to return:
 

--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -221,7 +221,7 @@ defmodule Oban.Telemetry do
     require Logger
 
     def handle_event([:oban, :job, :exception], %{duration: duration}, meta, nil) do
-      Logger.warn("[#\{meta.queue}] #\{meta.worker} failed in #\{duration}")
+      Logger.warning("[#\{meta.queue}] #\{meta.worker} failed in #\{duration}")
     end
   end
 


### PR DESCRIPTION
Remove the `Logger.warn/2` in favor of `Logger.warning/2`

Reference: https://hexdocs.pm/logger/main/Logger.html#warn/2