### PR TITLE
Do not start a write transaction when there is nothing to write

### DIFF
--- a/lib/oban/engines/lite.ex
+++ b/lib/oban/engines/lite.ex
@@ -128,9 +128,11 @@ defmodule Oban.Engines.Lite do
 
     staged = Repo.all(conf, select_query)
 
-    Repo.update_all(conf, where(Job, [j], j.id in ^Enum.map(staged, & &1.id)),
-      set: [state: "available"]
-    )
+    unless staged == [] do
+      Repo.update_all(conf, where(Job, [j], j.id in ^Enum.map(staged, & &1.id)),
+        set: [state: "available"]
+      )
+    end
 
     {:ok, staged}
   end
@@ -150,7 +152,9 @@ defmodule Oban.Engines.Lite do
 
     pruned = Repo.all(conf, select_query)
 
-    Repo.delete_all(conf, where(Job, [j], j.id in ^Enum.map(pruned, & &1.id)))
+    unless pruned == [] do
+      Repo.delete_all(conf, where(Job, [j], j.id in ^Enum.map(pruned, & &1.id)))
+    end
 
     {:ok, pruned}
   end

--- a/lib/oban/engines/lite.ex
+++ b/lib/oban/engines/lite.ex
@@ -128,7 +128,7 @@ defmodule Oban.Engines.Lite do
 
     staged = Repo.all(conf, select_query)
 
-    unless staged == [] do
+    if Enum.any?(staged) do
       Repo.update_all(conf, where(Job, [j], j.id in ^Enum.map(staged, & &1.id)),
         set: [state: "available"]
       )
@@ -152,7 +152,7 @@ defmodule Oban.Engines.Lite do
 
     pruned = Repo.all(conf, select_query)
 
-    unless pruned == [] do
+    if Enum.any?(pruned) do
       Repo.delete_all(conf, where(Job, [j], j.id in ^Enum.map(pruned, & &1.id)))
     end
 


### PR DESCRIPTION
The action is a no-op, but SQLite sees this as a write transaction potentially blocking other writers. We should only write when there is something to write.