### PR TITLE
Typo fix in Backoff.exponential/2 documentation

### DIFF
--- a/lib/oban/backoff.ex
+++ b/lib/oban/backoff.ex
@@ -4,7 +4,7 @@ defmodule Oban.Backoff do
   @type jitter_mode :: :inc | :dec | :both
 
   @doc """
-  Calculate an exponential backoff in millseconds for a given attempt.
+  Calculate an exponential backoff in seconds for a given attempt.
 
   By default, the exponent is clamped to a maximum of 10 to prevent unreasonably long delays.
 


### PR DESCRIPTION
Currently `Oban.Backoff.exponential/2` function documentation refers that function calculates backoff in `millseconds` which is not true, as [Engine](https://github.com/sorentwo/oban/blob/b3b2bddf2592561e3136ba5a65c0e8d08a0f98e3/lib/oban/engines/basic.ex#L199) expects to receive backoff in seconds.

This typo introduces confusion in understanding of how `Job.scheduled_at` timestamp is calculated.