### PR TITLE
Allow unique's period option to take units.

### DIFF
--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -391,8 +391,9 @@ defmodule Oban.Job do
   def valid_unique_opt?({:keys, [_ | _] = keys}), do: Enum.all?(keys, &is_atom/1)
   def valid_unique_opt?({:period, :infinity}), do: true
 
-  def valid_unique_opt?({:period, {period, unit}}),
-    do: is_integer(period) and period > 0 and unit in @valid_period_units
+  def valid_unique_opt?({:period, {period, unit}}) do
+    is_integer(period) and period > 0 and unit in @valid_period_units
+  end
 
   def valid_unique_opt?({:period, period}), do: is_integer(period) and period > 0
   def valid_unique_opt?({:states, [_ | _] = states}), do: states -- states() == []

--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -382,12 +382,18 @@ defmodule Oban.Job do
 
   def cast_period(period), do: period
 
+  @valid_period_units ~w(second seconds minute minutes hour hours day days)a
+
   @doc false
   @spec valid_unique_opt?({:fields | :period | :states, [atom()] | integer()}) :: boolean()
   def valid_unique_opt?({:fields, [_ | _] = fields}), do: fields -- [:meta | @unique_fields] == []
   def valid_unique_opt?({:keys, []}), do: true
   def valid_unique_opt?({:keys, [_ | _] = keys}), do: Enum.all?(keys, &is_atom/1)
   def valid_unique_opt?({:period, :infinity}), do: true
+
+  def valid_unique_opt?({:period, {period, unit}}),
+    do: is_integer(period) and period > 0 and unit in @valid_period_units
+
   def valid_unique_opt?({:period, period}), do: is_integer(period) and period > 0
   def valid_unique_opt?({:states, [_ | _] = states}), do: states -- states() == []
   def valid_unique_opt?({:timestamp, stamp}), do: stamp in ~w(inserted_at scheduled_at)a

--- a/test/oban/job_test.exs
+++ b/test/oban/job_test.exs
@@ -89,6 +89,12 @@ defmodule Oban.JobTest do
              }
     end
 
+    test ":unique will translate period" do
+      changeset = Job.new(%{}, worker: Fake, unique: [period: {1, :hour}])
+
+      assert %{period: 3600} = changeset.changes[:unique]
+    end
+
     test ":unique does not accept other types of values or options" do
       assert Job.new(%{}, worker: Fake, unique: true).errors[:unique]
       assert Job.new(%{}, worker: Fake, unique: []).errors[:unique]

--- a/test/oban/worker_test.exs
+++ b/test/oban/worker_test.exs
@@ -23,7 +23,7 @@ defmodule Oban.WorkerTest do
       max_attempts: @max_attempts,
       priority: 1,
       tags: ["scheduled", "special"],
-      unique: [fields: [:queue, :worker], period: 60, states: [:scheduled]]
+      unique: [fields: [:queue, :worker], period: {1, :minute}, states: [:scheduled]]
 
     @impl Worker
     def perform(%{attempt: attempt}) when attempt > 1, do: attempt


### PR DESCRIPTION
Other parts of oban (e.g. ratelimiting) can take period in the form `{n, unit}` and this is missing from the unique `:period` option, I mentioned this on the Elixir Slack a while back and was encouraged to open an issue about it but I thought I would go one better and create a PR! Totally don't mind if you'd prefer to do this yourself in a different way.