### PR TITLE
bugfix(cron): handle invalid range expressions

### DIFF
--- a/lib/oban/cron/expression.ex
+++ b/lib/oban/cron/expression.ex
@@ -164,7 +164,7 @@ defmodule Oban.Cron.Expression do
           rmin..rmax
         else
           raise ArgumentError,
-                "left side (#{rmin}) of the range must be lower or equal than right side (#{rmax})"
+                "left side (#{rmin}) of a range must be less than or equal to the right side (#{rmax})"
         end
     end
   end

--- a/lib/oban/cron/expression.ex
+++ b/lib/oban/cron/expression.ex
@@ -110,12 +110,23 @@ defmodule Oban.Cron.Expression do
 
   defp parse_part(part, range) do
     cond do
-      part == "*" -> range
-      part =~ ~r/^\d+$/ -> parse_literal(part)
-      part =~ ~r/^\*\/[1-9]\d?$/ -> parse_step(part, range)
-      part =~ ~r/^\d+(\-\d+)?\/[1-9]\d?$/ -> parse_range_step(part, range)
-      part =~ ~r/^\d+\-\d+$/ -> parse_range(part, range)
-      true -> raise ArgumentError, "unrecognized cron expression: #{part}"
+      part == "*" ->
+        range
+
+      part =~ ~r/^\d+$/ ->
+        parse_literal(part)
+
+      part =~ ~r/^\*\/[1-9]\d?$/ ->
+        parse_step(part, range)
+
+      part =~ ~r/^\d+(\-\d+)?\/[1-9]\d?$/ ->
+        parse_range_step(part, range)
+
+      part =~ ~r/^\d+\-\d+$/ ->
+        parse_range(part, range)
+
+      true ->
+        raise ArgumentError, "unrecognized cron expression: #{part}"
     end
   end
 
@@ -146,7 +157,15 @@ defmodule Oban.Cron.Expression do
         String.to_integer(rall)..Enum.max(max_range)
 
       [rmin, rmax] ->
-        String.to_integer(rmin)..String.to_integer(rmax)
+        rmin = String.to_integer(rmin)
+        rmax = String.to_integer(rmax)
+
+        if rmin <= rmax do
+          rmin..rmax
+        else
+          raise ArgumentError,
+                "left side (#{rmin}) of the range must be lower or equal than right side (#{rmax})"
+        end
     end
   end
 end

--- a/test/oban/cron/expression_test.exs
+++ b/test/oban/cron/expression_test.exs
@@ -44,6 +44,21 @@ defmodule Oban.Cron.ExpressionTest do
       end
     end
 
+    test "parsing range expressions where left side is greater than the right side fails" do
+      expressions = [
+        "9-5 * * * *",
+        "* 4-3 * * *",
+        "* * 27-2 * *",
+        "* * * 11-1 *",
+        "* * * * 6-0",
+        "* * * * SAT-SUN"
+      ]
+
+      for expression <- expressions do
+        assert_raise ArgumentError, fn -> Expr.parse!(expression) end
+      end
+    end
+
     test "parsing non-standard expressions" do
       assert Expr.parse!("0 0 1 1 *") == Expr.parse!("@annually")
       assert Expr.parse!("0 0 1 1 *") == Expr.parse!("@yearly")


### PR DESCRIPTION
This PR should fix those cases where the cron expressions include invalid ranges or at least the cases where the left side is greater than the right one.