### PR TITLE
feat(migrations): allow a 3rd party migrator to be configured

### DIFF
--- a/lib/oban/migration.ex
+++ b/lib/oban/migration.ex
@@ -194,7 +194,7 @@ defmodule Oban.Migration do
     case repo().__adapter__() do
       Ecto.Adapters.Postgres -> Oban.Migrations.Postgres
       Ecto.Adapters.SQLite3 -> Oban.Migrations.SQLite
-      _ -> repo().config()[:migrator]
+      _ -> Map.fetch!(repo().config(), :migrator)
     end
   end
 end

--- a/lib/oban/migration.ex
+++ b/lib/oban/migration.ex
@@ -194,6 +194,7 @@ defmodule Oban.Migration do
     case repo().__adapter__() do
       Ecto.Adapters.Postgres -> Oban.Migrations.Postgres
       Ecto.Adapters.SQLite3 -> Oban.Migrations.SQLite
+      _ -> repo().config()[:migrator]
     end
   end
 end


### PR DESCRIPTION
Thanks for the wonderful library!

I'm working on an external package that will provide a MySQL adapter for Oban (#836) and I need to be able to override the migrator used. This change will allow a `migrator` key in the Repo's config to allow for that:

```elixir
config :oban_mysql, ObanMySQL.Test.MySQLRepo,
  priv: "test/support/mysql",
  url: System.get_env("DATABASE_URL") || "mysql://root@localhost/oban_mysql_test",
  migrator: ObanMySQL.Migrations.MySQL,
  pool: Ecto.Adapters.SQL.Sandbox
```

If you have a different name suggestion or have a different approach in mind, please let me know! 🙂 

The very very WIP repo is over here: https://github.com/hamptokr/oban_mysql
With this change I was able to get the migrations running and the migration tests passing. I'm just starting to port over the engine and its test suite.