### PR TITLE
Use Keyword.fetch for returning custom migrator

### DIFF
--- a/lib/oban/migration.ex
+++ b/lib/oban/migration.ex
@@ -194,7 +194,7 @@ defmodule Oban.Migration do
     case repo().__adapter__() do
       Ecto.Adapters.Postgres -> Oban.Migrations.Postgres
       Ecto.Adapters.SQLite3 -> Oban.Migrations.SQLite
-      _ -> Map.fetch!(repo().config(), :migrator)
+      _ -> Keyword.fetch!(repo().config(), :migrator)
     end
   end
 end


### PR DESCRIPTION
Follow on to: https://github.com/sorentwo/oban/pull/986

When using a custom migrator for MySQL, `repo().config()` returns a keyword list causing:

```
** (BadMapError) expected a map, got: [telemetry_prefix: [:demo_app, :repo], otp_app: :demo_app, timeout: 15000, username: "root", password: "", hostname: "localhost", database: "demo_app_dev", stacktrace: true, show_sensitive_data_on_connection_error: true, pool_size: 10, migrator: Oban.Migrations.MySQL]
    (stdlib 5.0.2) :maps.get(:migrator, [telemetry_prefix: [:demo_app, :repo], otp_app: :demo_app, timeout: 15000, username: "root", password: "", hostname: "localhost", database: "demo_app_dev", stacktrace: true, show_sensitive_data_on_connection_error: true, pool_size: 10, migrator: Oban.Migrations.MySQL])
    /Users/tedgesmith/src/github.com/sourdoughdev/demo_app/priv/repo/migrations/20231119060957_add_oban_jobs_table.exs:1: (file)
```

Switched this to being a `Keyword.fetch!` instead.

```
09:09:56.562 [info] create table if not exists oban_jobs

09:09:56.577 [info] create index oban_jobs_state_255_queue_255_priority_scheduled_at_id_index

09:09:56.585 [info] == Migrated 20231119060957 in 10.0s
```

cc @hamptokr