### PR TITLE
fix sqlite link in installation.md

### DIFF
--- a/guides/installation.md
+++ b/guides/installation.md
@@ -14,7 +14,7 @@ end
 
 Then run `mix deps.get` to install Oban and its dependencies, including
 [Ecto][ecto] and [Jason][jason]. You'll optionally need to include either
-[Postgrex][postgrex] for use with Postgres, or [EctoSQLite3][sqlite] for
+[Postgrex][postgrex] for use with Postgres, or [EctoSQLite3][ecto_sqlite3] for
 SQLite3.
 
 After the packages are installed you must create a database migration to add the


### PR DESCRIPTION
👋

This PR fixes the reference to point to `ecto_sqlite3` instead of `sqlite` which is undefined: https://github.com/sorentwo/oban/blob/b092e278c1091319fa48d6f9d9b445ffff57edb5/guides/installation.md?plain=1#L111