### PR TITLE
Support Oban.insert_all from Stream

### DIFF
--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -42,7 +42,7 @@ defmodule Oban do
   @type option ::
           {:dispatch_cooldown, pos_integer()}
           | {:engine, module()}
-          | {:get_dynamic_repo, nil | (-> pid() | atom())}
+          | {:get_dynamic_repo, nil | (() -> pid() | atom())}
           | {:log, false | Logger.level()}
           | {:name, name()}
           | {:node, String.t()}
@@ -631,6 +631,12 @@ defmodule Oban do
     name
     |> config()
     |> Engine.insert_all_jobs(changesets, opts)
+  end
+
+  def insert_all(name, %Stream{} = stream, opts) when is_list(opts) do
+    name
+    |> config()
+    |> Engine.insert_all_jobs(stream, opts)
   end
 
   def insert_all(%Multi{} = multi, multi_name, changesets) when is_list_or_wrapper(changesets) do

--- a/lib/oban/engine.ex
+++ b/lib/oban/engine.ex
@@ -304,6 +304,7 @@ defmodule Oban.Engine do
   defp expand(fun, changes) when is_function(fun, 1), do: expand(fun.(changes), changes)
   defp expand(%{changesets: changesets}, _), do: expand(changesets, %{})
   defp expand(changesets, _) when is_list(changesets), do: changesets
+  defp expand(%Stream{} = stream, _), do: stream
 
   defp with_span(event, %Config{} = conf, base_meta, fun) do
     base_meta = Map.merge(base_meta, %{conf: conf, engine: conf.engine})

--- a/lib/oban/engines/basic.ex
+++ b/lib/oban/engines/basic.ex
@@ -68,7 +68,8 @@ defmodule Oban.Engines.Basic do
 
   @impl Engine
   def insert_all_jobs(%Config{} = conf, changesets, opts) do
-    jobs = Enum.map(changesets, &Job.to_map/1)
+    # TODO: lazy?
+    jobs = Enum.map(changesets, &Job.to_map/1) |> dbg
     opts = Keyword.merge(opts, on_conflict: :nothing, returning: true)
 
     with {_count, jobs} <- Repo.insert_all(conf, Job, jobs, opts), do: jobs


### PR DESCRIPTION
As discussed in email, here is a WIP for streaming support for `Oban.insert_all`. I came about the changes thus far by TDD. Thus far they seem to be merely ceremonial and without any real improvement.

Specifically, while the interface now support accepting a stream, the library still ultimately converts the stream to an Enum before performing the bulk insert, so I'm skeptical there would be any memory savings as-is based on the original problem we emailed about.

Do you agree?