### PR TITLE
Add missing discard cases to expected test message

### DIFF
--- a/lib/oban/testing.ex
+++ b/lib/oban/testing.ex
@@ -547,7 +547,9 @@ defmodule Oban.Testing do
       - `{:ok, value}`
       - `{:cancel, reason}`
       - `{:error, reason}`
-      - `{:snooze, duration}
+      - `{:discard, reason}`
+      - `{:snooze, duration}`
+      - `:discard`
 
     Instead received:
 


### PR DESCRIPTION
I noticed these were missing in `perform_job` result check