### PR TITLE
Update upgrade guide to reference the new down migration in version 12

### DIFF
--- a/guides/upgrading/v2.17.md
+++ b/guides/upgrading/v2.17.md
@@ -37,7 +37,7 @@ use Ecto.Migration
 
 def up, do: Oban.Migrations.up(version: 12)
 
-def down, do: Oban.Migrations.down(version: 11)
+def down, do: Oban.Migrations.down(version: 12)
 ```
 
 If you have multiple Oban instances, or use an alternate prefix, you'll need to run the migration


### PR DESCRIPTION
Noticed this when implementing an upgrade, looks like there is indeed a down migration for version 12 - I believe this is just a typo.