### PR TITLE
fix: type spec on unique field

### DIFF
--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -31,7 +31,7 @@ defmodule Oban.Job do
           | :week
           | :weeks
 
-  @type unique_field :: [:args | :meta | :queue | :worker]
+  @type unique_field :: :args | :meta | :queue | :worker
 
   @type unique_period :: pos_integer() | {pos_integer(), time_unit()} | :infinity
 


### PR DESCRIPTION
I noticed that when implementing the `Oban.Job.new/2` callback, specifying a list of unique fields caused a "No local return" warning:

```elixir
defmodule MyApp do
  use Oban.Worker

  @impl true
  def new(args, _opts) do
    # Function new/2 has no local return.ElixirLS Dialyzer
    Oban.Job.new(args, worker: __MODULE__, unique: [fields: [:args], keys: [:id]])
  end

end
```

This appears related to the `Oban.Job.unique_field` type being a list type, which is then wrapped again in the `@type unique_option :: {:fields, [unique_field()]} | ...` type.

For consistency, I removed the list spec in the `unique_field` type rather than the `unique_option` type.