### PR TITLE
Remove pruner from installation guide

### DIFF
--- a/guides/installation.md
+++ b/guides/installation.md
@@ -63,7 +63,6 @@ some base configuration within `config.exs`:
 # config/config.exs
 config :my_app, Oban,
   repo: MyApp.Repo,
-  plugins: [Oban.Plugins.Pruner],
   queues: [default: 10]
 ```
 


### PR DESCRIPTION
Feel free to close this if its presence was intentional, but I am going through these guides for the first time and I was a bit puzzled to see the pruner included in the plugin list in the installation guide. I assume it is not required, and it is covered in the next stage in the [next guide](https://hexdocs.pm/oban/preparing_for_production.html#pruning-jobs)

If it's not required, IMO seems best to not refer to it until there is more explanation of the purpose, since it caused me to switch context out of installing to google it