### PR TITLE
Update installation instructions for 2.17

### DIFF
--- a/guides/installation.md
+++ b/guides/installation.md
@@ -7,7 +7,7 @@ dependencies in `mix.exs`:
 # mix.exs
 def deps do
   [
-    {:oban, "~> 2.16"}
+    {:oban, "~> 2.17"}
   ]
 end
 ```
@@ -32,7 +32,7 @@ defmodule MyApp.Repo.Migrations.AddObanJobsTable do
   use Ecto.Migration
 
   def up do
-    Oban.Migration.up(version: 11)
+    Oban.Migration.up(version: 12)
   end
 
   # We specify `version: 1` in `down`, ensuring that we'll roll all the way back down if


### PR DESCRIPTION
Seems like 2.17 got a new schema version, so I updated installation instructions <3

The rationale is that for brand new installations we probably want to "opt-in" for the migration. If that's not the case the instructions might need more complex instructions.