### PR TITLE
Ensure uniqueness across all args if no keys are specified

### DIFF
--- a/lib/oban/engines/basic.ex
+++ b/lib/oban/engines/basic.ex
@@ -382,10 +382,19 @@ defmodule Oban.Engines.Basic do
   defp unique_field({changeset, field, keys}, acc) when field in [:args, :meta] do
     value = unique_map_values(changeset, field, keys)
 
-    if value == %{} do
-      dynamic([j], fragment("? <@ ?", field(j, ^field), ^value) and ^acc)
-    else
-      dynamic([j], fragment("? @> ?", field(j, ^field), ^value) and ^acc)
+    cond do
+      value == %{} ->
+        dynamic([j], fragment("? <@ ?", field(j, ^field), ^value) and ^acc)
+
+      keys == [] ->
+        dynamic(
+          [j],
+          fragment("? @> ?", field(j, ^field), ^value) and
+            fragment("? <@ ?", field(j, ^field), ^value) and ^acc
+        )
+
+      :else ->
+        dynamic([j], fragment("? @> ?", field(j, ^field), ^value) and ^acc)
     end
   end
 

--- a/lib/oban/engines/basic.ex
+++ b/lib/oban/engines/basic.ex
@@ -393,7 +393,7 @@ defmodule Oban.Engines.Basic do
             fragment("? <@ ?", field(j, ^field), ^value) and ^acc
         )
 
-      :else ->
+      true ->
         dynamic([j], fragment("? @> ?", field(j, ^field), ^value) and ^acc)
     end
   end

--- a/lib/oban/engines/lite.ex
+++ b/lib/oban/engines/lite.ex
@@ -296,10 +296,19 @@ defmodule Oban.Engines.Lite do
             |> Changeset.get_field(field)
             |> map_values(keys)
 
-          if value == %{} do
-            dynamic([j], field(j, ^field) == ^value and ^acc)
-          else
-            dynamic([j], json_contains(field(j, ^field), ^Jason.encode!(value)) and ^acc)
+          cond do
+            value == %{} ->
+              dynamic([j], field(j, ^field) == ^value and ^acc)
+
+            keys == [] ->
+              dynamic(
+                [j],
+                json_contains(field(j, ^field), ^Jason.encode!(value)) and
+                  json_contains(^Jason.encode!(value), field(j, ^field)) and ^acc
+              )
+
+            :else ->
+              dynamic([j], json_contains(field(j, ^field), ^Jason.encode!(value)) and ^acc)
           end
 
         field, acc ->

--- a/lib/oban/engines/lite.ex
+++ b/lib/oban/engines/lite.ex
@@ -301,13 +301,15 @@ defmodule Oban.Engines.Lite do
               dynamic([j], field(j, ^field) == ^value and ^acc)
 
             keys == [] ->
+              encoded = Jason.encode!(value)
+
               dynamic(
                 [j],
-                json_contains(field(j, ^field), ^Jason.encode!(value)) and
-                  json_contains(^Jason.encode!(value), field(j, ^field)) and ^acc
+                json_contains(field(j, ^field), ^encoded) and
+                  json_contains(^encoded, field(j, ^field)) and ^acc
               )
 
-            :else ->
+            true ->
               dynamic([j], json_contains(field(j, ^field), ^Jason.encode!(value)) and ^acc)
           end
 

--- a/test/oban/engine_test.exs
+++ b/test/oban/engine_test.exs
@@ -12,6 +12,13 @@ for engine <- [Oban.Engines.Basic, Oban.Engines.Lite] do
 
     @moduletag lite: engine == Lite
 
+    defmodule MiniUniq do
+      use Oban.Worker, unique: [fields: [:args]]
+
+      @impl Worker
+      def perform(_job), do: :ok
+    end
+
     describe "insert/2" do
       setup :start_supervised_oban
 
@@ -96,13 +103,6 @@ for engine <- [Oban.Engines.Basic, Oban.Engines.Lite] do
 
       @tag :unique
       test "considering empty args distinct from non-empty args", %{name: name} do
-        defmodule MiniUniq do
-          use Oban.Worker, unique: [fields: [:args]]
-
-          @impl Worker
-          def perform(_job), do: :ok
-        end
-
         changeset1 = MiniUniq.new(%{id: 1})
         changeset2 = MiniUniq.new(%{})
 
@@ -116,13 +116,6 @@ for engine <- [Oban.Engines.Basic, Oban.Engines.Lite] do
 
       @tag :unique
       test "considering all args to establish uniqueness", %{name: name} do
-        defmodule MiniUniq do
-          use Oban.Worker, unique: [fields: [:args]]
-
-          @impl Worker
-          def perform(_job), do: :ok
-        end
-
         changeset1 = MiniUniq.new(%{id: 1})
         changeset2 = MiniUniq.new(%{id: 1, extra: :cool_beans})
 


### PR DESCRIPTION
Hello! 

Today I spent a good chunk of time chasing down some weirdness with certain jobs not getting scheduled, and I'm pretty sure this is a bug 🐛 .  In certain cases, the order of job insertion affects  whether or not uniqueness is enforced.  (I noticed this with `Oban.Pro.Engine.Smart` , and that seems to use the same function for determining uniqueness, so if this is an acceptable fix it would be great if it can be fixed there too!)

Given a worker that has `unique: [fields: [:args]]` specified the following happens: inserting A first, and then B results in two separate jobs, as expected. But if you insert B first, and then insert A, it is considered to _not_ be unique compared to B.

```
a = MiniUniq.new(%{id: 1})
b = MiniUniq.new(%{id: 1, extra: :cool_beans})
```

Initially I just wanted to open an issue, but I got curious and figured I might as well try to fix it. There is no Postgres operator to determine if two jsonb fields are exactly equal, so the best way seems to be to use both the `@>` and `<@` operators to ensure that they are completely the same. I'm not very familiar with SQLite, so I extrapolated the same principle into that engine, but there might be a better way.

I added a test that initially confirmed the unexpected behaviour, and now confirms that it is consistent.

Lastly - locally `mix format --check-formatted` failed, but it is only upset by files that have not been changed in this PR, so I'm not sure what the best approach is there.