### PR TITLE
Include cron indicator and expression in meta

### DIFF
--- a/test/oban/plugins/cron_test.exs
+++ b/test/oban/plugins/cron_test.exs
@@ -138,6 +138,21 @@ defmodule Oban.Plugins.CronTest do
     assert [1] == inserted_refs()
   end
 
+  test "cron schedules are injected into the enqueued job's meta" do
+    run_with_opts(
+      crontab: [
+        {"@reboot", Worker, args: worker_args(1)},
+        {"* * * * *", Worker, args: worker_args(2)}
+      ]
+    )
+
+    assert [{true, "* * * * *"}, {true, "@reboot"}] ==
+             Job
+             |> Repo.all()
+             |> Enum.map(fn %{meta: meta} -> {meta["cron"], meta["cron_expr"]} end)
+             |> Enum.sort()
+  end
+
   test "reboot jobs are enqueued on startup" do
     run_with_opts(crontab: [{"@reboot", Worker, args: worker_args(1)}])
 


### PR DESCRIPTION
When the Cron plugin inserts jobs the original, unnormalized cron expression is now stored in a job's meta under the `cron_expr` key. For parity and backward compatibility with Pro's `DynamicCron`, meta also has `cron: true` injected.

Closes #1048

/cc @whatyouhide