### PR TITLE
Fixing possible issue with basic engine

### DIFF
--- a/lib/oban/engines/basic.ex
+++ b/lib/oban/engines/basic.ex
@@ -91,6 +91,7 @@ defmodule Oban.Engines.Basic do
       |> select([:id])
       |> where([j], j.state == "available")
       |> where([j], j.queue == ^meta.queue)
+      |> where([j, _], j.attempt < j.max_attempts)
       |> order_by(asc: :priority, asc: :scheduled_at, asc: :id)
       |> limit(^demand)
       |> lock("FOR UPDATE SKIP LOCKED")
@@ -107,7 +108,6 @@ defmodule Oban.Engines.Basic do
       |> with_cte("subset", as: ^subset_query, materialized: true)
       |> join(:inner, [j], x in fragment(~s("subset")), on: true)
       |> where([j, x], j.id == x.id)
-      |> where([j, _], j.attempt < j.max_attempts)
       |> select([j, _], j)
 
     updates = [


### PR DESCRIPTION
Hi, first of all, thank you for a great software.
We encountered a bug, when we have 10+ jobs have their `attempts` 1 with a `max_attempts` also equals to 1.
We double checked a lifeline plugin, but this jobs was forever stuck in `available` with 1 attempt and 1 max_attempt.

Due to current way how jobs retrieved in Engine there is a possibility, that some queue can be stuck forever.
There is a possible fix for this (i will try to investigate why do we have a problem with Lifeline)