### PR TITLE
Include app name in `:pg` group namespace

### DIFF
--- a/lib/oban/notifiers/pg.ex
+++ b/lib/oban/notifiers/pg.ex
@@ -50,7 +50,7 @@ defmodule Oban.Notifiers.PG do
   @impl Notifier
   def notify(server, channel, payload) do
     with %{conf: conf} <- get_state(server) do
-      pids = :pg.get_members(__MODULE__, conf.prefix)
+      pids = :pg.get_members(__MODULE__, {conf.name, conf.prefix})
 
       for pid <- pids, message <- payload_to_messages(channel, payload) do
         send(pid, message)
@@ -65,7 +65,7 @@ defmodule Oban.Notifiers.PG do
     put_state(state)
 
     :pg.start_link(__MODULE__)
-    :pg.join(__MODULE__, state.conf.prefix, self())
+    :pg.join(__MODULE__, {state.conf.name, state.conf.prefix}, self())
 
     {:ok, state}
   end


### PR DESCRIPTION
We are running 4 separate elixir applications in the same cluster. Each application talks to each other using `:pg`. But each application has its own `Oban` instance running. We were running into issues where other nodes were showing up in the dashboard.

I tried setting just `name: MyApp.Oban` and on the dashboard router helper `oban_name: MyApp.Oban`. This did not work. Locally I made the following changes in my `deps/` directory, recompiled and this seems to do the trick.

If you have a better solution, feel free to close this. I just wanted to bring this up as potential solution.