### PR TITLE
Log when jobs don't finish executing within `:shutdown_grace_period`

### DIFF
--- a/lib/oban/queue/supervisor.ex
+++ b/lib/oban/queue/supervisor.ex
@@ -36,9 +36,11 @@ defmodule Oban.Queue.Supervisor do
       |> Keyword.put_new(:dispatch_cooldown, conf.dispatch_cooldown)
 
     watch_opts = [
+      conf_name: conf.name,
       foreman: fore_name,
       name: watch_name,
       producer: prod_name,
+      queue: queue,
       shutdown: conf.shutdown_grace_period
     ]
 

--- a/lib/oban/queue/watchman.ex
+++ b/lib/oban/queue/watchman.ex
@@ -6,20 +6,28 @@ defmodule Oban.Queue.Watchman do
   alias Oban.Queue.Producer
   alias __MODULE__, as: State
 
+  require Logger
+
+  # Give a little extra shutdown time so we can report an unclean shutdown that
+  # might leave orphaned jobs
+  @extra_shutdown_time 250
+
   @type option ::
           {:foreman, GenServer.name()}
+          | {:conf_name, Oban.name()}
           | {:name, module()}
           | {:producer, GenServer.name()}
+          | {:queue, Oban.queue_name()}
           | {:shutdown, timeout()}
 
-  defstruct [:foreman, :producer, :shutdown, interval: 10]
+  defstruct [:foreman, :producer, :queue, :conf_name, :shutdown, interval: 10]
 
   @spec child_spec([option]) :: Supervisor.child_spec()
   def child_spec(opts) do
     shutdown =
       case opts[:shutdown] do
         0 -> :brutal_kill
-        value -> value
+        value when is_integer(value) -> value + @extra_shutdown_time
       end
 
     %{id: __MODULE__, start: {__MODULE__, :start_link, [opts]}, shutdown: shutdown}
@@ -53,15 +61,47 @@ defmodule Oban.Queue.Watchman do
     :ok
   end
 
-  defp wait_for_executing(state) do
+  defp wait_for_executing(state, start_time \\ :erlang.monotonic_time(:millisecond)) do
     case DynamicSupervisor.count_children(state.foreman) do
       %{active: 0} ->
         :ok
 
       _ ->
-        :ok = Process.sleep(state.interval)
+        if shutdown_time_exceeded?(state, :erlang.monotonic_time(:millisecond) - start_time) do
+          print_non_clean_exit_message(state)
+          :ok
+        else
+          :ok = Process.sleep(state.interval)
 
-        wait_for_executing(state)
+          wait_for_executing(state, start_time)
+        end
     end
   end
+
+  defp print_non_clean_exit_message(%State{conf_name: nil}), do: :ok
+
+  defp print_non_clean_exit_message(%State{} = state) do
+    case Oban.check_queue(state.conf_name, queue: state.queue) do
+      %{running: []} ->
+        :ok
+
+      %{running: running_job_ids} ->
+        jobs_message = "(job ids: [#{Enum.join(running_job_ids, ", ")}])"
+
+        Logger.warning(
+          "Oban's :#{state.queue} queue was unable to cleanly shutdown in allotted time " <>
+            "(:shutdown_grace_period was #{state.shutdown}). Remaining job ids: #{jobs_message}"
+        )
+    end
+  catch
+    :exit, reason ->
+      Logger.warning("watchman error reason: #{inspect(reason, pretty: true)}")
+  end
+
+  defp shutdown_time_exceeded?(%State{shutdown: shutdown}, elapsed_time)
+       when is_integer(shutdown) and elapsed_time > shutdown do
+    true
+  end
+
+  defp shutdown_time_exceeded?(_, _), do: false
 end


### PR DESCRIPTION
If jobs take longer than `:shutdown_grace_period` (by default 15 seconds) then they are brutally killed. Log a message when this occurs. The message looks like:

> Oban's :alpha queue was unable to cleanly shutdown in allotted time (:shutdown_grace_period was 10). Remaining job ids: (job ids: [1941])

This is important because the majority of the time in a running you usually want your jobs to finish within the `:shutdown_grace_period` and with this new log message it is now easier to detect when that doesn't happen and which jobs were affected which will allow developers to then improve those jobs so that they finish in time (e.g. by splitting a job into multiple units of work).

I pass through the `conf.name` to `Oban.Queue.Watchman` so that it is able to check the appropriate queue status (which is especially important in the tests). I'm not in love with `conf_name` but I went with it because `name` was already taken. As an aside I think the typespec for `name` is incorrect, it is currently `module()` but it is actually receiving a via tuple like `{:via, Registry, {Oban.Registry, {Oban, {:producer, "alpha"}}}}`

I've added minimal test updates 9enough to verify the new behavior), if this PR looks good then I can make additional updates if needed.