### PR TITLE
Add support for only: [{job_status}] configuration in Oban.Plugins.Pruner

### DIFF
--- a/lib/oban/engines/basic.ex
+++ b/lib/oban/engines/basic.ex
@@ -150,10 +150,12 @@ defmodule Oban.Engines.Basic do
     limit = Keyword.fetch!(opts, :limit)
     time = DateTime.add(DateTime.utc_now(), -max_age)
 
+    prune_states = Keyword.get(opts, :only, ~w(completed cancelled discarded))
+
     subquery =
       queryable
       |> select([:id, :queue, :state])
-      |> where([j], j.state in ~w(completed cancelled discarded))
+      |> where([j], j.state in ^prune_states)
       |> where([j], not is_nil(j.queue))
       |> where([j], j.scheduled_at < ^time)
       |> limit(^limit)

--- a/test/oban/plugins/pruner_test.exs
+++ b/test/oban/plugins/pruner_test.exs
@@ -17,6 +17,18 @@ defmodule Oban.Plugins.PrunerTest do
       assert :ok = Pruner.validate(limit: 1_000)
     end
 
+    test "validating :only values" do
+      assert {:error, _} = Pruner.validate(only: ["scheduled"])
+      assert {:error, _} = Pruner.validate(only: ["completed", "scheduled"])
+      assert :ok = Pruner.validate(only: ["completed", "cancelled"])
+    end
+
+    test "provides suggestions for :only values" do
+      assert {:error,
+              "Invalid status provided to :only option in pruner. Valid options are: completed, cancelled, discarded"} =
+               Pruner.validate(only: ["completed", "scheduled"])
+    end
+
     test "providing suggestions for unknown options" do
       assert {:error, "unknown option :inter, did you mean :interval?"} =
                Pruner.validate(inter: 1)
@@ -36,6 +48,27 @@ defmodule Oban.Plugins.PrunerTest do
 
       assert_receive {:event, :stop, _, %{plugin: Pruner} = meta}
       assert %{pruned_count: 3, pruned_jobs: [_ | _]} = meta
+
+      assert [id_1] ==
+               Job
+               |> select([j], j.id)
+               |> order_by(asc: :id)
+               |> Repo.all()
+    end
+
+    test "only certain status pruned when specified in config" do
+      TelemetryHandler.attach_events()
+
+      %Job{id: _id_} = insert!(%{}, state: "completed", scheduled_at: seconds_ago(61))
+      %Job{id: _id_} = insert!(%{}, state: "cancelled", scheduled_at: seconds_ago(61))
+      %Job{id: id_1} = insert!(%{}, state: "discarded", scheduled_at: seconds_ago(61))
+
+      start_supervised_oban!(
+        plugins: [{Pruner, interval: 10, max_age: 60, only: ["completed", "cancelled"]}]
+      )
+
+      assert_receive {:event, :stop, _, %{plugin: Pruner} = meta}
+      assert %{pruned_count: 2, pruned_jobs: [_ | _]} = meta
 
       assert [id_1] ==
                Job


### PR DESCRIPTION
Hello!

We've recently adopted Oban (it's great so far, so thanks!) and are looking at ways to manage our dead letter queue for discarded jobs. 

This PR would add the ability to specify which finished status to prune in the Basic Pruner, which would make dead lettering fairly trivial for projects which don't expect massive amounts of discards.