### PR TITLE
Request to rename emitted log attribute for `[:oban, :notifier, :switch]` events.

### DIFF
--- a/lib/oban/engines/basic.ex
+++ b/lib/oban/engines/basic.ex
@@ -150,10 +150,12 @@ defmodule Oban.Engines.Basic do
     limit = Keyword.fetch!(opts, :limit)
     time = DateTime.add(DateTime.utc_now(), -max_age)
 
+    prune_states = Keyword.get(opts, :only, ~w(completed cancelled discarded))
+
     subquery =
       queryable
       |> select([:id, :queue, :state])
-      |> where([j], j.state in ~w(completed cancelled discarded))
+      |> where([j], j.state in ^prune_states)
       |> where([j], not is_nil(j.queue))
       |> where([j], j.scheduled_at < ^time)
       |> limit(^limit)

--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -431,14 +431,14 @@ defmodule Oban.Telemetry do
         :isolated ->
           %{
             event: "notifier:switch",
-            status: status,
+            connectivity_status: status,
             message: "notifier can't receive messages from any nodes, functionality degraded"
           }
 
         :solitary ->
           %{
             event: "notifier:switch",
-            status: status,
+            connectivity_status: status,
             message:
               "notifier only receiving messages from its own node, functionality may be degraded"
           }
@@ -446,7 +446,7 @@ defmodule Oban.Telemetry do
         :clustered ->
           %{
             event: "notifier:switch",
-            status: status,
+            connectivity_status: status,
             message: "notifier is receiving messages from other nodes"
           }
       end

--- a/test/oban/plugins/pruner_test.exs
+++ b/test/oban/plugins/pruner_test.exs
@@ -17,6 +17,18 @@ defmodule Oban.Plugins.PrunerTest do
       assert :ok = Pruner.validate(limit: 1_000)
     end
 
+    test "validating :only values" do
+      assert {:error, _} = Pruner.validate(only: ["scheduled"])
+      assert {:error, _} = Pruner.validate(only: ["completed", "scheduled"])
+      assert :ok = Pruner.validate(only: ["completed", "cancelled"])
+    end
+
+    test "provides suggestions for :only values" do
+      assert {:error,
+              "Invalid status provided to :only option in pruner. Valid options are: completed, cancelled, discarded"} =
+               Pruner.validate(only: ["completed", "scheduled"])
+    end
+
     test "providing suggestions for unknown options" do
       assert {:error, "unknown option :inter, did you mean :interval?"} =
                Pruner.validate(inter: 1)
@@ -36,6 +48,27 @@ defmodule Oban.Plugins.PrunerTest do
 
       assert_receive {:event, :stop, _, %{plugin: Pruner} = meta}
       assert %{pruned_count: 3, pruned_jobs: [_ | _]} = meta
+
+      assert [id_1] ==
+               Job
+               |> select([j], j.id)
+               |> order_by(asc: :id)
+               |> Repo.all()
+    end
+
+    test "only certain status pruned when specified in config" do
+      TelemetryHandler.attach_events()
+
+      %Job{id: _id_} = insert!(%{}, state: "completed", scheduled_at: seconds_ago(61))
+      %Job{id: _id_} = insert!(%{}, state: "cancelled", scheduled_at: seconds_ago(61))
+      %Job{id: id_1} = insert!(%{}, state: "discarded", scheduled_at: seconds_ago(61))
+
+      start_supervised_oban!(
+        plugins: [{Pruner, interval: 10, max_age: 60, only: ["completed", "cancelled"]}]
+      )
+
+      assert_receive {:event, :stop, _, %{plugin: Pruner} = meta}
+      assert %{pruned_count: 2, pruned_jobs: [_ | _]} = meta
 
       assert [id_1] ==
                Job


### PR DESCRIPTION
Hello Again!

This is a small change request to make the default telemetry logger integrate nicer with Datadog.

The logs emitted in response to `[:oban, :notifier, :switch]` events have a `status` field, which is a reserved field for JSON logs with Datadog. The result was that all `:switch` events were being treated as critical logs and raising alerts. I imagine a lot of Oban users use Datadog so I thought it may be worth making this small tweak to avoid conflict.

Thanks,
Luca