### PR TITLE
Request to rename [:oban, :notifier, :switch] emitted log attribute `status` to `connectivity_status`

### DIFF
--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -431,14 +431,14 @@ defmodule Oban.Telemetry do
         :isolated ->
           %{
             event: "notifier:switch",
-            status: status,
+            connectivity_status: status,
             message: "notifier can't receive messages from any nodes, functionality degraded"
           }
 
         :solitary ->
           %{
             event: "notifier:switch",
-            status: status,
+            connectivity_status: status,
             message:
               "notifier only receiving messages from its own node, functionality may be degraded"
           }
@@ -446,7 +446,7 @@ defmodule Oban.Telemetry do
         :clustered ->
           %{
             event: "notifier:switch",
-            status: status,
+            connectivity_status: status,
             message: "notifier is receiving messages from other nodes"
           }
       end


### PR DESCRIPTION
Hello Again!

This is a small change request to make the default telemetry logger integrate nicer with Datadog.

The logs emitted in response to [:oban, :notifier, :switch] events have a status field, which is a reserved field for JSON logs with Datadog. The result was that all :switch events were being treated as critical logs and raising alerts. I imagine a lot of Oban users use Datadog so I thought it may be worth making this small tweak to avoid conflict.

Thanks,
Luca