### PR TITLE
Tweak README to reflect conflict? flag changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,8 +520,10 @@ You can use the `:conflict?` field to customize responses after insert:
 case Oban.insert(changeset) do
   {:ok, %Job{id: nil, conflict?: true}} ->
     {:error, :failed_to_acquire_lock}
+
   {:ok, %Job{conflict?: true}} ->
     {:error, :job_already_exists}
+
   result ->
     result
 end

--- a/README.md
+++ b/README.md
@@ -517,8 +517,13 @@ otherwise it is `false`.
 You can use the `:conflict?` field to customize responses after insert:
 
 ```elixir
-with {:ok, %Job{conflict?: true}} <- Oban.insert(changeset) do
-  {:error, :job_already_exists}
+case Oban.insert(changeset) do
+  {:ok, %Job{id: nil, conflict?: true}} ->
+    {:error, :failed_to_acquire_lock}
+  {:ok, %Job{conflict?: true}} ->
+    {:error, :job_already_exists}
+  result ->
+    result
 end
 ```
 


### PR DESCRIPTION
Since `Oban.insert` changed its behaviour regarding the conflict? when failing to acquire the respective advisory lock the README should reflect that.

I'm not entirely sure how to phrase some additional advice to elaborate the internals, especially the fact that there is no guarantee that a job is inserted while it somehow feels like it.

It may also be a good idea to underline issues when using a [Repeatable Read Isolation Level](https://www.postgresql.org/docs/current/transaction-iso.html#XACT-REPEATABLE-READ) because Oban will be unable to _see_ conflicting jobs originating from concurrent transactions.