### PR TITLE
fix: make `t:Oban.Job.replace_by_state_option/0` a keyword item instead of a keyword

### DIFF
--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -63,7 +63,7 @@ defmodule Oban.Job do
           | :worker
         ]
 
-  @type replace_by_state_option :: [
+  @type replace_by_state_option ::
           {:available, [replace_option()]}
           | {:cancelled, [replace_option()]}
           | {:completed, [replace_option()]}
@@ -71,7 +71,6 @@ defmodule Oban.Job do
           | {:executing, [replace_option()]}
           | {:retryable, [replace_option()]}
           | {:scheduled, [replace_option()]}
-        ]
 
   @type schedule_in_option :: pos_integer() | {pos_integer(), time_unit()}
 


### PR DESCRIPTION
According to the usage in the documentation, `replace_by_state_option` should be a keyword item. I believe this may be a mistake.

https://github.com/sorentwo/oban/blob/5668f23fc3dc99e09ac3cced5e8a0f22cffd8552/README.md?plain=1#L546-L553