### PR TITLE
Update testing_queues.md to be consistent with installation guide

### DIFF
--- a/guides/testing/testing_queues.md
+++ b/guides/testing/testing_queues.md
@@ -10,8 +10,9 @@ more expressive `Oban.Testing` provides a variety of helpers.
 
 During test runs you don't typically want to execute jobs. Rather, you need
 to verify that the job was enqueued properly. With the recommended test setup
-queues and plugins are disabled, and jobs won't execute at all. The
-`Oban.Testing.assert_enqueued/2` and `Oban.Testing.refute_enqueued/2` helpers
+queues and plugins are disabled, and jobs won't be put into database at all.
+Instead they will be executed immediately within the calling process.
+The `Oban.Testing.assert_enqueued/2` and `Oban.Testing.refute_enqueued/2` helpers
 simplify running queries to check for those `available` or `scheduled` jobs
 sitting in the database.
 

--- a/guides/testing/testing_queues.md
+++ b/guides/testing/testing_queues.md
@@ -10,8 +10,8 @@ more expressive `Oban.Testing` provides a variety of helpers.
 
 During test runs you don't typically want to execute jobs. Rather, you need
 to verify that the job was enqueued properly. With the recommended test setup
-queues and plugins are disabled, and jobs won't be put into database at all.
-Instead they will be executed immediately within the calling process.
+queues and plugins are disabled, and jobs won't be inserted into the database at all.
+Instead, they'll be executed immediately within the calling process.
 The `Oban.Testing.assert_enqueued/2` and `Oban.Testing.refute_enqueued/2` helpers
 simplify running queries to check for those `available` or `scheduled` jobs
 sitting in the database.


### PR DESCRIPTION
look in: https://hexdocs.pm/oban/installation.html

Since by default jobs will be execute in testing mode - however it will be done in inline fashion, hence testing docs are wrong in that manner. This PR correct this.