### PR TITLE
Automatically retry transactions with backoff

### DIFF
--- a/lib/oban/migrations/postgres/v08.ex
+++ b/lib/oban/migrations/postgres/v08.ex
@@ -7,12 +7,12 @@ defmodule Oban.Migrations.Postgres.V08 do
     alter table(:oban_jobs, prefix: prefix) do
       add_if_not_exists(:discarded_at, :utc_datetime_usec)
       add_if_not_exists(:priority, :integer)
-      add_if_not_exists(:tags, {:array, :string})
+      add_if_not_exists(:tags, {:array, :text})
     end
 
     alter table(:oban_jobs, prefix: prefix) do
       modify :priority, :integer, default: 0
-      modify :tags, {:array, :string}, default: []
+      modify :tags, {:array, :text}, default: []
     end
 
     drop_if_exists index(:oban_jobs, [:queue, :state, :scheduled_at, :id], prefix: prefix)


### PR DESCRIPTION
Avoid both expected an unexpected database errors by automatically retrying transactions. Some operations, such as serialization and lock not available errors, are likely to occur during standard use depending on how a database is configured. Other errors happen infrequently due to pool contention or flickering connections, and those should also be retried for increased safety.

This change is applied to `Oban.Repo.transaction/3` itself, so it will apply to every location that uses transactions.