### PR TITLE
Add ErrorTracker to the guides

### DIFF
--- a/guides/preparing_for_production.md
+++ b/guides/preparing_for_production.md
@@ -138,3 +138,7 @@ tools built on `Oban.Telemetry`:
 * [AppSignal](https://docs.appsignal.com/elixir/integrations/oban.html)—The AppSignal for Elixir
   package instruments jobs performed by Oban workers, and collects metrics about your jobs'
   performance.
+
+* [ErrorTracker](https://hex.pm/packages/error_tracker)—An Elixir-based open source error tracking
+  solution that automatically integrates with Oban. It allows you to store and view exceptions on
+  your app without external services. It's powered by Telemetry, Ecto and Phoenix LiveView.

--- a/guides/preparing_for_production.md
+++ b/guides/preparing_for_production.md
@@ -145,6 +145,6 @@ tools built on `Oban.Telemetry`:
   package instruments jobs performed by Oban workers, and collects metrics about your jobs'
   performance.
 
-* [ErrorTracker](https://hex.pm/packages/error_tracker)—An Elixir-based open source error tracking
+* [ErrorTracker](https://hex.pm/packages/error_tracker)—an Elixir-based open source error tracking
   solution that automatically integrates with Oban. It allows you to store and view exceptions on
   your app without external services. It's powered by Telemetry, Ecto and Phoenix LiveView.

--- a/guides/preparing_for_production.md
+++ b/guides/preparing_for_production.md
@@ -90,8 +90,9 @@ sends a message back to the test process).
 You can use exception events to send error reports to Honeybadger, Rollbar, AppSignal, ErroTracker 
 or any other application monitoring platform.
 
-Some libraries automatically handle these events without requiring any extra code on your application. 
-You can take a look at ErrorTracker's [Oban integration](https://github.com/elixir-error-tracker/error-tracker/blob/main/lib/error_tracker/integrations/oban.ex) 
+Some libraries like AppSignal, ErrorTracker or Sentry automatically handle these events without 
+requiring any extra code on your application. You can take a look at ErrorTracker's 
+[Oban integration](https://github.com/elixir-error-tracker/error-tracker/blob/main/lib/error_tracker/integrations/oban.ex) 
 as an example on how to attach to and use `Oban.Telemetry` events.
 
 If you need a custom integration you can add a reporter module that fit your needs. 

--- a/guides/preparing_for_production.md
+++ b/guides/preparing_for_production.md
@@ -87,9 +87,14 @@ Telemetry events can be used to report issues externally to services like Sentry
 Write a handler that sends error notifications to a third party (use a mock, or something that
 sends a message back to the test process).
 
-You can use exception events to send error reports to Honeybadger, Rollbar, AppSignal or any other
-application monitoring platform.
+You can use exception events to send error reports to Honeybadger, Rollbar, AppSignal, ErroTracker 
+or any other application monitoring platform.
 
+Some libraries automatically handle these events without requiring any extra code on your application. 
+You can take a look at ErrorTracker's Oban integration [source code](https://github.com/elixir-error-tracker/error-tracker/blob/main/lib/error_tracker/integrations/oban.ex) 
+as an example on how to attach to and use `Oban.Telemetry` events.
+
+If you need a custom integration you can add a reporter module that fit your needs. 
 Here's an example reporter module for [Sentry](https://hex.pm/packages/sentry):
 
 ```elixir

--- a/guides/preparing_for_production.md
+++ b/guides/preparing_for_production.md
@@ -91,7 +91,7 @@ You can use exception events to send error reports to Honeybadger, Rollbar, AppS
 or any other application monitoring platform.
 
 Some libraries automatically handle these events without requiring any extra code on your application. 
-You can take a look at ErrorTracker's Oban integration [source code](https://github.com/elixir-error-tracker/error-tracker/blob/main/lib/error_tracker/integrations/oban.ex) 
+You can take a look at ErrorTracker's [Oban integration](https://github.com/elixir-error-tracker/error-tracker/blob/main/lib/error_tracker/integrations/oban.ex) 
 as an example on how to attach to and use `Oban.Telemetry` events.
 
 If you need a custom integration you can add a reporter module that fit your needs. 

--- a/guides/preparing_for_production.md
+++ b/guides/preparing_for_production.md
@@ -87,7 +87,7 @@ Telemetry events can be used to report issues externally to services like Sentry
 Write a handler that sends error notifications to a third party (use a mock, or something that
 sends a message back to the test process).
 
-You can use exception events to send error reports to Honeybadger, Rollbar, AppSignal, ErroTracker 
+You can use exception events to send error reports to Honeybadger, Rollbar, AppSignal, ErrorTracker 
 or any other application monitoring platform.
 
 Some libraries like AppSignal, ErrorTracker or Sentry automatically handle these events without 


### PR DESCRIPTION
This change proposal adds [ErrorTracker](https://github.com/elixir-error-tracker/error-tracker) to the guide that lists integrations that use `Oban.Telemetry` to integrate out-of-the-box with Oban.

In the case of the ErrorTracker, it uses Telemetry events to catch and store context and exceptions of Oban jobs executed on the system.