### PR TITLE
Clarifications in the `perform/1` callback documentation

### DIFF
--- a/lib/oban/worker.ex
+++ b/lib/oban/worker.ex
@@ -387,9 +387,10 @@ defmodule Oban.Worker do
   @doc """
   The `c:perform/1` function is called to execute a job.
 
-  Each `c:perform/1` function should return `:ok` or a success tuple. When the return is an error
-  tuple, an uncaught exception or a throw then the error is recorded and the job may be retried if
-  there are any attempts remaining.
+  Each `c:perform/1` function should return a `t:result/0` value (see that type's documentation
+  for details on what each does). When the return is an error tuple, an exception is not rescued,
+  or a throw is not caught then the error is recorded and the job may be retried if there are
+  any attempts remaining.
 
   > #### `args` Are Stored as JSON {: .info}
   >


### PR DESCRIPTION
The documentation for `perform/1` seemed potentially out of date since it didn't imply that there was any case other that ok / error results, raises, and throws (not mentioning snooze, discard, etc...)

Hopefully my link to the `result/0` type works.  I tried following the [ExDocs documentation](https://hexdocs.pm/ex_doc/readme.html#auto-linking)

As I was testing, I realized that you treat an `:error` return as a success, which feels wrong since that is a common result returned in functions (and often people just return whatever their functions return, for better or worse, which is why, I imagine, you treat any unexpected values as success 😉 ). I guess you need a `reason` and maybe treating it like `{:error, nil}` isn't enough?