### PR TITLE
fix: measurements from the Executor process, not parent

### DIFF
--- a/lib/oban/queue/executor.ex
+++ b/lib/oban/queue/executor.ex
@@ -36,7 +36,6 @@ defmodule Oban.Queue.Executor do
     :error,
     :job,
     :meta,
-    :pid,
     :result,
     :snooze,
     :start_mono,
@@ -59,7 +58,6 @@ defmodule Oban.Queue.Executor do
       conf: conf,
       job: %{job | conf: conf},
       meta: event_metadata(conf, job),
-      pid: self(),
       safe: Keyword.get(opts, :safe, true),
       start_mono: System.monotonic_time(),
       start_time: System.system_time()
@@ -323,14 +321,14 @@ defmodule Oban.Queue.Executor do
   defp measurements(exec) do
     %{
       duration: exec.duration,
-      memory: info_for(exec, :memory),
+      memory: info_for(:memory),
       queue_time: exec.queue_time,
-      reductions: info_for(exec, :reductions)
+      reductions: info_for(:reductions)
     }
   end
 
-  defp info_for(%__MODULE__{pid: pid}, item) do
-    case Process.info(pid, item) do
+  defp info_for(item) do
+    case Process.info(self(), item) do
       {^item, value} -> value
       nil -> 0
     end


### PR DESCRIPTION
When Producer starts jobs, it calls `Executor.new` in its own process, before handing it off to `Task.Supervisor.async_nolink` to call `Executor.call`. That means we currently write in the Producer pid, and take measurements from that process.

This was the simplest approach I could think of to have the executor read its own measurements. Did not think it merits a test, but that judgement call is yours to make. 
Thank you so much for Oban! It's a joy to work with and to read.