### PR TITLE
Update backoff timing details in worker documentation

### DIFF
--- a/lib/oban/worker.ex
+++ b/lib/oban/worker.ex
@@ -162,8 +162,9 @@ defmodule Oban.Worker do
   When jobs fail they may be retried again in the future using a backoff algorithm. By default the
   backoff is exponential with a fixed padding of 15 seconds and a small amount of jitter. The
   jitter helps to prevent jobs that fail simultaneously from consistently retrying at the same
-  time. With the default backoff behavior and the highest amount of jitter, the 20th attempt will 
-  occur around 6.6 days after the 19th attempt, and a total of 13.3 days after the first attempt.
+  time. With the default backoff behavior and the maximum amount of jitter, the 20th attempt will 
+  occur 6 days and 16 hours after the 19th attempt, and a total of 13 days and 8 hours after 
+  the first attempt.
 
   If the default strategy is too aggressive or otherwise unsuited to your app's workload you can
   define a custom backoff function using the `c:backoff/1` callback.


### PR DESCRIPTION
Based on our conversation in Slack and the following spreadsheet:
<img width="1291" height="444" alt="image" src="https://github.com/user-attachments/assets/6af9b843-6963-4fbc-a631-2f8d9df0886b" />

the spreadsheet shows that:
* the time between the 19th & 20th attempt is 576733.3 seconds (so 6.6 days)
* the time between the first and 20th attempt is 320 hours and 29 minutes (so around 13.3 days). This seems to be consistent with the discarded jobs I have found.