### PR TITLE
README.md: Update explanatory link for queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ and configuring Oban in your application.
 
 ## Quick Getting Started
 
-  1. [Configure queues](https://hexdocs.pm/oban/Oban.html#module-configuring-queues) and an Ecto repo for Oban to
+  1. [Configure queues](https://hexdocs.pm/oban/defining_queues.html) and an Ecto repo for Oban to
      use:
 
      ```elixir


### PR DESCRIPTION
The current link's hash does not point anywhere in the `Oban` module docs