### PR TITLE
Validate no duplicate option is passed to Oban config

### DIFF
--- a/lib/oban/config.ex
+++ b/lib/oban/config.ex
@@ -135,7 +135,7 @@ defmodule Oban.Config do
   """
   @spec validate([Oban.option()]) :: :ok | {:error, String.t()}
   def validate(opts) when is_list(opts) do
-    with :ok <- validate_no_duplicate_option(opts) do
+    with :ok <- validate_unique_opts(opts) do
       opts = normalize(opts)
 
       Validation.validate_schema(opts,
@@ -285,17 +285,14 @@ defmodule Oban.Config do
     end
   end
 
-  defp validate_no_duplicate_option(opts) do
-    opts_keys = Keyword.keys(opts)
-    unique_keys = Enum.uniq(opts_keys)
-    duplicate_keys = Enum.uniq(opts_keys -- unique_keys)
+  defp validate_unique_opts(opts) do
+    keys = Keyword.keys(opts)
+    dupe = keys -- Enum.uniq(keys)
 
-    valid? = Enum.empty?(duplicate_keys)
-
-    if valid? do
+    if Enum.empty?(dupe) do
       :ok
     else
-      {:error, "found duplicate options: #{inspect(duplicate_keys)}"}
+      {:error, "found duplicate options: #{inspect(dupe)}"}
     end
   end
 

--- a/test/oban/config_test.exs
+++ b/test/oban/config_test.exs
@@ -147,15 +147,6 @@ defmodule Oban.ConfigTest do
     end
 
     test "duplicated values are rejected" do
-      assert_valid(plugins: false)
-      assert_valid(plugins: [Pruner])
-
-      assert {:error, "found duplicate options: [:plugins]"} ==
-               Config.validate(plugins: [Pruner], plugins: false)
-
-      assert_valid(peer: false)
-      assert_valid(peer: Oban.Peers.Postgres)
-
       assert {:error, "found duplicate options: [:peer]"} ==
                Config.validate(peer: false, peer: Oban.Peers.Postgres)
 


### PR DESCRIPTION
We ran into an issue recently that an option was passed twice to the Oban configuration by mistake and it ended up causing issues:

```
config :my_app, Oban,
  peer: Oban.Peers.Database,
  ...,
  # This was the desired value, but the first one was read
  peer: false
```
This MR validates that no duplicate option is passed.
