### PR TITLE
Explain that pause in queue definition is local only

### DIFF
--- a/guides/learning/defining_queues.md
+++ b/guides/learning/defining_queues.md
@@ -53,7 +53,8 @@ This expanded configuration demonstrates several advanced options:
 ### Paused Queues
 
 When a queue is configured with `paused: true`, it won't process any jobs until explicitly
-started. This is useful for:
+started. Note that this pause will only affect the queue for the local node.
+This is useful for:
 
 * Maintenance periods
 * Controlling when resource-intensive jobs can run


### PR DESCRIPTION
## What
Noted that queue pauses defined in configuration will only affect queues on the local node.
## Why
I'd figure I'd enshrine the answer @sorentwo gave me in this [forum thread](https://elixirforum.com/t/do-pause-semantics-in-oban-queue-configuration-apply-locally-or-globally/74115/2?u=apreifsteck) so that anyone looking for an answer to a similar question could find it right in the docs.