### PR TITLE
Adds disable_sonar option to skip Sonar for insert-only instances

### DIFF
--- a/lib/oban/config.ex
+++ b/lib/oban/config.ex
@@ -11,6 +11,7 @@ defmodule Oban.Config do
   alias Oban.Validation
 
   @type t :: %__MODULE__{
+          disable_sonar: boolean(),
           dispatch_cooldown: pos_integer(),
           engine: module(),
           get_dynamic_repo: nil | (-> pid() | atom()) | {module(), atom(), list()},
@@ -29,7 +30,8 @@ defmodule Oban.Config do
           testing: :disabled | :inline | :manual
         }
 
-  defstruct dispatch_cooldown: 5,
+  defstruct disable_sonar: false,
+            dispatch_cooldown: 5,
             engine: Oban.Engines.Basic,
             get_dynamic_repo: nil,
             insert_trigger: true,
@@ -139,6 +141,7 @@ defmodule Oban.Config do
       opts = normalize(opts)
 
       Validation.validate_schema(opts,
+        disable_sonar: :boolean,
         dispatch_cooldown: :pos_integer,
         engine: {:behaviour, Oban.Engine},
         get_dynamic_repo: {:or, [:falsy, {:function, 0}, :mfa]},

--- a/lib/oban/sonar.ex
+++ b/lib/oban/sonar.ex
@@ -1,5 +1,33 @@
 defmodule Oban.Sonar do
-  @moduledoc false
+  @moduledoc """
+  Monitors cluster connectivity by exchanging periodic pings over the notifier.
+
+  Sonar maintains a view of which nodes are active in the cluster and reports
+  the instance's connectivity status (`:isolated`, `:solitary`, or `:clustered`)
+  via telemetry events. It opens a persistent listener on the notifier and sends
+  a `pg_notify` ping every 5 seconds by default.
+
+  ## Disabling Sonar
+
+  Insert-only Oban instances — those configured with `peer: false`, `queues: []`,
+  and `plugins: []` — exist solely to enqueue jobs for a separate processing app.
+  In these cases Sonar is unnecessary overhead: it holds an open notifier
+  connection and emits pings that no one consumes.
+
+  Rather than misusing `testing: :manual` (which has side effects on
+  `Oban.Config.get_engine/1`), you can explicitly disable Sonar on insert-only instances:
+
+      Oban.start_link(
+        repo: MyApp.Repo,
+        peer: false,
+        queues: [],
+        plugins: [],
+        disable_sonar: true
+      )
+
+  When `disable_sonar` is `true`, `start_link/1` returns `:ignore` and no Sonar
+  process is started.
+  """
 
   use GenServer
 
@@ -23,7 +51,7 @@ defmodule Oban.Sonar do
 
     conf = Keyword.fetch!(opts, :conf)
 
-    if conf.testing != :disabled do
+    if conf.testing != :disabled or conf.disable_sonar do
       :ignore
     else
       GenServer.start_link(__MODULE__, struct!(State, opts), name: name)

--- a/test/oban/config_test.exs
+++ b/test/oban/config_test.exs
@@ -11,6 +11,14 @@ defmodule Oban.ConfigTest do
       assert_valid(circuit_backoff: 10)
     end
 
+    test ":disable_sonar is validated as a boolean" do
+      refute_valid(disable_sonar: nil)
+      refute_valid(disable_sonar: 1)
+
+      assert_valid(disable_sonar: true)
+      assert_valid(disable_sonar: false)
+    end
+
     test ":engine is validated as an engine module" do
       refute_valid(engine: nil)
       refute_valid(engine: Repo)

--- a/test/oban/sonar_test.exs
+++ b/test/oban/sonar_test.exs
@@ -3,6 +3,14 @@ defmodule Oban.SonarTest do
 
   alias Oban.{Notifier, Registry, Sonar}
 
+  describe "start_link/1" do
+    test "sonar is disabled when disable_sonar is true" do
+      name = start_supervised_oban!(disable_sonar: true)
+
+      assert Registry.whereis(name, Sonar) == nil
+    end
+  end
+
   describe "integration" do
     setup do
       :telemetry_test.attach_event_handlers(self(), [[:oban, :notifier, :switch]])


### PR DESCRIPTION
Insert-only Oban instances in umbrella apps (configured with `peer: false, queues: [], plugins: []`) exist solely to enqueue jobs for a separate processing app. Sonar still starts unconditionally on these instances, opening a persistent notifier connection and sending pg_notify pings every 5 seconds. At scale this wastes database connections and generates unnecessary traffic that no one consumes.

## Solution
Add a disable_sonar boolean option to Oban.Config (defaulting to false). When true, Sonar.start_link/1 returns :ignore and no Sonar process is started — the same mechanism already used when testing is :inline or :manual.

```
Oban.start_link(
  repo: MyApp.Repo,
  peer: false,
  queues: [],
  plugins: [],
  disable_sonar: true
)
```
