### PR TITLE
Add transaction_retry config option

### DIFF
--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -88,6 +88,7 @@ defmodule Oban do
           | {:shutdown_grace_period, non_neg_integer()}
           | {:stage_interval, timeout()}
           | {:testing, :disabled | :inline | :manual}
+          | {:transaction_retry, boolean()}
 
   @typedoc """
   Options for draining jobs from a queue.
@@ -426,6 +427,11 @@ defmodule Oban do
   * `:testing` — a mode that controls how an instance is configured for testing. When set to
     `:inline` or `:manual` queues, peers, and plugins are automatically disabled. Defaults to
     `:disabled`, no test mode.
+
+  * `:transaction_retry` — whether to automatically retry internal transactions on database errors
+    such as connection loss or deadlocks. Set to `false` to disable retries, which is useful when
+    calling `Oban.insert/2` inside an existing transaction to prevent retries from masking errors
+    within savepoints. Defaults to `true`.
 
   ### Twiddly Options
 

--- a/lib/oban/config.ex
+++ b/lib/oban/config.ex
@@ -26,7 +26,8 @@ defmodule Oban.Config do
           repo: module(),
           shutdown_grace_period: non_neg_integer(),
           stage_interval: timeout(),
-          testing: :disabled | :inline | :manual
+          testing: :disabled | :inline | :manual,
+          transaction_retry: boolean()
         }
 
   defstruct dispatch_cooldown: 5,
@@ -44,7 +45,8 @@ defmodule Oban.Config do
             repo: nil,
             shutdown_grace_period: :timer.seconds(15),
             stage_interval: :timer.seconds(1),
-            testing: :disabled
+            testing: :disabled,
+            transaction_retry: true
 
   @cron_keys ~w(crontab timezone)a
   @log_levels ~w(false emergency alert critical error warning warn notice info debug)a
@@ -154,7 +156,8 @@ defmodule Oban.Config do
         repo: {:module, [config: 0]},
         shutdown_grace_period: :non_neg_integer,
         stage_interval: :timeout,
-        testing: {:enum, @testing_modes}
+        testing: {:enum, @testing_modes},
+        transaction_retry: :boolean
       )
     end
   end

--- a/lib/oban/repo.ex
+++ b/lib/oban/repo.ex
@@ -152,6 +152,10 @@ defmodule Oban.Repo do
     transaction(conf, fun_or_multi, opts, 1)
   end
 
+  defp transaction(%Config{transaction_retry: false} = conf, fun_or_multi, opts, _attempt) do
+    __dispatch__(:transaction, [conf, fun_or_multi], opts)
+  end
+
   defp transaction(conf, fun_or_multi, opts, attempt) do
     __dispatch__(:transaction, [conf, fun_or_multi], opts)
   rescue

--- a/test/oban/config_test.exs
+++ b/test/oban/config_test.exs
@@ -139,6 +139,14 @@ defmodule Oban.ConfigTest do
       assert_valid(testing: :disabled)
     end
 
+    test ":transaction_retry is validated as a boolean" do
+      refute_valid(transaction_retry: nil)
+      refute_valid(transaction_retry: :enabled)
+
+      assert_valid(transaction_retry: true)
+      assert_valid(transaction_retry: false)
+    end
+
     test "alternatives are suggested for unknown options when they match" do
       assert {:error, "unknown option :queue, did you mean :queues?"} =
                Config.validate(queue: false)


### PR DESCRIPTION
See https://github.com/oban-bg/oban/pull/1432, https://elixirforum.com/t/unexplained-rollback-after-2-21-upgrade/74812/8

Even after fixing the root cause the previous error, we are still seeing generic `:rollback` results from transactions with Oban operations. We'd prefer to allow the underlying error cause to bubble up which doesn't seem to be possible with the transaction retry behavior. This adds an option to disable, defaulting to true in order to preserve existing behavior.

I didn't see any tests for actual retry behavior so I just added one for config.