### PR TITLE
Fix duplicate pid accumulation in Notifier.Postgres put_channels/3

### DIFF
--- a/lib/oban/notifiers/postgres.ex
+++ b/lib/oban/notifiers/postgres.ex
@@ -242,7 +242,7 @@ if Code.ensure_loaded?(Postgrex) do
     defp put_channels(state, pid, channels) do
       listener_channels =
         for channel <- channels, reduce: state.channels do
-          acc -> Map.update(acc, channel, [pid], &[pid | &1])
+          acc -> Map.update(acc, channel, [pid], &Enum.uniq([pid | &1]))
         end
 
       %{state | channels: listener_channels}

--- a/test/oban/notifier_test.exs
+++ b/test/oban/notifier_test.exs
@@ -97,6 +97,21 @@ for notifier <- [Oban.Notifiers.Isolated, Oban.Notifiers.PG, Oban.Notifiers.Post
     end
 
     if @notifier == Oban.Notifiers.Postgres do
+      test "repeated listen calls don't duplicate channel entries or deliver multiple notifications" do
+        unboxed_run(fn ->
+          name = start_supervised_oban!(notifier: @notifier)
+
+          :ok = Notifier.listen(name, :signal)
+          :ok = Notifier.listen(name, :signal)
+          :ok = Notifier.listen(name, :signal)
+
+          :ok = Notifier.notify(name, :signal, %{value: "once"})
+
+          assert_receive {:notification, :signal, %{"value" => "once"}}
+          refute_receive {:notification, :signal, _}, 100
+        end)
+      end
+
       defp unboxed_run(fun), do: Sandbox.unboxed_run(Repo, fun)
     else
       defp unboxed_run(fun), do: fun.()


### PR DESCRIPTION
Oban.Sonar calls `Notifier.listen/2` on every ping (every 5s) to recover from Notifier crashes, a change introduced in [v2.21](https://github.com/oban-bg/oban/commit/b7042ce7e86cede452670d8a8d95f6c838042442#diff-c8f1d4dc3f3d39a0703a2eaede00a4b68bb416566c9c8c6e7f0162f7bae64b7dR74-R80)

The **Postgres** notifier's `put_channels/3` appended the caller pid unconditionally on every call with no deduplication check:
    `Map.update(acc, channel, [pid], &[pid | &1])`
    
The listeners map ([put_listener/3](https://github.com/oban-bg/oban/blob/cbd74ab67fc388a7091a0f115199e715e176277e/lib/oban/notifiers/postgres.ex#L225)) correctly deduplicates by pid, but the channels map used for delivery did not. This caused the Sonar pid to accumulate in the sonar channel list at 1 entry per 5s, forever.

After 12 hours a pod accumulates ~8,640 duplicate entries. On every sonar ping, `Notifier.relay/4` iterates the full list and floods the Sonar process with duplicate messages, causing per-pod CPU to grow linearly with pod age.

This PR addresses this by using `Enum.uniq/1` to deduplicate on insert