### PR TITLE
Fix syntax error in validate function in Oban.Plugin

### DIFF
--- a/lib/oban/plugin.ex
+++ b/lib/oban/plugin.ex
@@ -21,7 +21,7 @@ defmodule Oban.Plugin do
 
         @impl Oban.Plugin
         def validate(opts) do
-          if is_atom(opts[:mode])
+          if is_atom(opts[:mode]) do
             :ok
           else
             {:error, "expected opts to have a :mode key"}


### PR DESCRIPTION
## Summary

The `@moduledoc` example in `Oban.Plugin` shows how to implement the
behaviour, but the `validate/1` example is not valid Elixir the `if`
expression is missing the `do` keyword:

```elixir
def validate(opts) do
  if is_atom(opts[:mode])     # ← missing `do`
    :ok
  else
    {:error, "expected opts to have a :mode key"}
  end
end
```

Elixir's `if` requires either the block form (`if cond do … else … end`)
or the keyword form (`if cond, do: …, else: …`). Anyone copy-pasting the
example into their own plugin module hits:

```
** (SyntaxError) ... unexpected reserved word: end
```

The `plugin.ex` file itself compiles fine because the broken snippet
lives inside a docstring string literal, so this slipped past CI.

## Fix

Add the missing `do` keyword.