### PR TITLE
Add support for module/list validation

### DIFF
--- a/lib/oban/validation.ex
+++ b/lib/oban/validation.ex
@@ -93,6 +93,14 @@ defmodule Oban.Validation do
     end
   end
 
+  defp validate_type(:module, key, val) do
+    if is_atom(val) do
+      :ok
+    else
+      {:error, "expected #{inspect(key)} to be an atom (module), got: #{inspect(val)}"}
+    end
+  end
+
   defp validate_type({:behaviour, module}, key, {val, opts}) do
     with :ok <- validate_type({:behaviour, module}, key, val) do
       if Keyword.keyword?(opts) do
@@ -167,6 +175,14 @@ defmodule Oban.Validation do
 
   defp validate_type({:list, _type}, key, val) do
     {:error, "expected #{inspect(key)} to be a list, got: #{inspect(val)}"}
+  end
+
+  defp validate_type(:list, key, val) do
+    if is_list(val) do
+      :ok
+    else
+      {:error, "expected #{inspect(key)} to be a list, got: #{inspect(val)}"}
+    end
   end
 
   defp validate_type(:mfa, key, {module, func, args})


### PR DESCRIPTION
These are used in Batch operations and result in errors without the validation type. Module is simply checked as an atom, and list is checked without digging into the subtype of the list.

# Bug Report

Pro stack trace cut off:

```elixir
** (ArgumentError) unknown schema type: :module
     code: EnqueueTrackedBatchesWorker.process(%Oban.Job{
     stacktrace:
       (oban 2.23.0) lib/oban/validation.ex:298: Oban.Validation.validate_type/3
       (oban 2.23.0) lib/oban/validation.ex:37: anonymous fn/3 in Oban.Validation.validate_schema/2
       (elixir 1.18.4) lib/enum.ex:4968: Enumerable.List.reduce/3
       (elixir 1.18.4) lib/enum.ex:2600: Enum.reduce_while/3
       (oban 2.23.0) lib/oban/validation.ex:50: Oban.Validation.validate_schema!/2
```

```elixir
** (ArgumentError) unknown schema type: :list
     code: EnqueueTrackedBatchesWorker.process(%Oban.Job{
     stacktrace:
       (oban 2.23.0) lib/oban/validation.ex:306: Oban.Validation.validate_type/3
       (oban 2.23.0) lib/oban/validation.ex:37: anonymous fn/3 in Oban.Validation.validate_schema/2
       (elixir 1.18.4) lib/enum.ex:4968: Enumerable.List.reduce/3
       (elixir 1.18.4) lib/enum.ex:2600: Enum.reduce_while/3
       (oban 2.23.0) lib/oban/validation.ex:50: Oban.Validation.validate_schema!/2
```