### PR TITLE
fix: set `successful` state in default unique options

### DIFF
--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -234,7 +234,7 @@ defmodule Oban.Job do
     fields: ~w(args queue worker)a,
     keys: [],
     period: 60,
-    states: ~w(scheduled available executing retryable completed)a,
+    states: :successful,
     timestamp: :inserted_at
   }
 

--- a/test/oban/job_test.exs
+++ b/test/oban/job_test.exs
@@ -101,7 +101,7 @@ defmodule Oban.JobTest do
                fields: [:args, :queue, :worker],
                keys: [],
                period: 60,
-               states: ~w(scheduled available executing retryable completed)a,
+               states: ~w(suspended scheduled available executing retryable completed)a,
                timestamp: :inserted_at
              }
     end

--- a/test/oban/job_test.exs
+++ b/test/oban/job_test.exs
@@ -101,7 +101,7 @@ defmodule Oban.JobTest do
                fields: [:args, :queue, :worker],
                keys: [],
                period: 60,
-               states: ~w(suspended scheduled available executing retryable completed)a,
+               states: ~w(suspended available scheduled executing retryable completed)a,
                timestamp: :inserted_at
              }
     end


### PR DESCRIPTION
The documentation says that the default `states` value is `:successful` for `unique` options, which includes the recent `suspended` state, but the implementation doesn't reflect that.

This commit should align the implementation with the documentation.