### PR TITLE
add Docker compose for tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,3 +38,18 @@ in the future.
 
 See the README for setup. Tests assume a local Postgres; see `test/test_helper.exs` for
 configuration.
+
+### Running databases with Docker
+
+If you'd rather not install Postgres and MySQL on your machine, a `compose.yaml` is included to
+spin up both in containers:
+
+```bash
+docker compose up -d   # start postgres and mysql
+mix test.setup         # create and migrate the test databases
+mix test.ci            # format check, lint, and run the suite
+docker compose down    # stop the containers when you're done
+```
+
+The containers match the versions used in CI and expose the default ports, so the connection URLs
+in `test/test_helper.exs` work without any extra configuration.

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,27 @@
+services:
+  postgres:
+    image: postgres:18.3-alpine
+    environment:
+      POSTGRES_DB: oban_test
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  mysql:
+    image: mysql:9.1
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      MYSQL_DATABASE: oban_test
+    ports:
+      - "3306:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5


### PR DESCRIPTION
While working on #1463, I wanted to run the whole test suite locally, but didn't want to install MySQL, so I prefer to keep those dependencies in Docker containers when I need them for testing.

After finishing the previous work, I thought this might be helpful for other contributors.