### PR TITLE
fix read-before-write-completes race condition

### DIFF
--- a/test/oban/engine_test.exs
+++ b/test/oban/engine_test.exs
@@ -825,8 +825,10 @@ for engine <- [Oban.Engines.Basic, Oban.Engines.Lite, Oban.Engines.Dolphin] do
         assert_receive {:started, 1}
         refute_receive {:ok, 1}, 20
 
-        assert %Job{state: "retryable", errors: [%{"error" => error}]} = reload(name, job)
-        assert error == "** (Oban.TimeoutError) Oban.Integration.Worker timed out after 5ms"
+        with_backoff(fn ->
+          assert %Job{state: "retryable", errors: [%{"error" => error}]} = reload(name, job)
+          assert error == "** (Oban.TimeoutError) Oban.Integration.Worker timed out after 5ms"
+        end)
       end
 
       test "applying custom backoff after uncaught exits", %{name: name} do


### PR DESCRIPTION
Fixes the CI failure noted here: https://github.com/oban-bg/oban/actions/runs/27444385716/job/81125837067?pr=1464#step:13:20

```console
  1) test integration failing jobs that exceed the worker's timeout (Oban.Engines.Dolphin.Test)
Error:      test/oban/engine_test.exs:822
     match (=) failed
     code:  assert %Job{state: "retryable", errors: [%{"error" => error}]} = reload(name, job)
     left:  %Oban.Job{state: "retryable", errors: [%{"error" => error}]}
     right: %Oban.Job{
              __meta__: #Ecto.Schema.Metadata<:loaded, "oban_jobs">,
              id: 22,
              state: "executing",
              queue: "alpha",
              worker: "Oban.Integration.Worker",
              args: %{
                "bin_pid" => "g1h3DW5vbm9kZUBub2hvc3QAABbFAAAAAAAAAAA=",
                "ref" => 1,
                "sleep" => 20,
                "timeout" => 5
              },
              meta: %{},
              tags: [],
              errors: [],
              attempt: 1,
              attempted_by: ["runnervm1li68",
               "5bd1d880-d363-4325-91ad-252c533fa08e"],
              max_attempts: 20,
              priority: 0,
              attempted_at: ~U[2026-06-12 21:36:40.493568Z],
              cancelled_at: nil,
              completed_at: nil,
              discarded_at: nil,
              inserted_at: ~U[2026-06-12 21:36:40.486720Z],
              scheduled_at: ~U[2026-06-12 21:36:40.486720Z],
              conf: nil,
              conflict?: false,
              replace: nil,
              unique: nil,
              unsaved_error: nil
            }
     stacktrace:
       test/oban/engine_test.exs:828: (test)
```