### PR TITLE
Add partial scheduled_at index for Stager query performance

### DIFF
--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -69,7 +69,7 @@ defmodule MyApp.Repo.Migrations.AddObanJobsTable do
   use Ecto.Migration
 
   def up do
-    Oban.Migration.up(version: 14)
+    Oban.Migration.up(version: 15)
   end
 
   # We specify `version: 1` in `down`, ensuring that we'll roll all the way back down if

--- a/lib/oban/migrations/postgres.ex
+++ b/lib/oban/migrations/postgres.ex
@@ -6,7 +6,7 @@ defmodule Oban.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 14
+  @current_version 15
   @default_prefix "public"
 
   @doc false

--- a/lib/oban/migrations/postgres/v15.ex
+++ b/lib/oban/migrations/postgres/v15.ex
@@ -1,0 +1,20 @@
+defmodule Oban.Migrations.Postgres.V15 do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def up(%{prefix: prefix}) do
+    create_if_not_exists index(:oban_jobs, [:scheduled_at, :id],
+                           name: :oban_jobs_staging_idx,
+                           where: "state IN ('scheduled', 'retryable')",
+                           prefix: prefix
+                         )
+  end
+
+  def down(%{prefix: prefix}) do
+    drop_if_exists index(:oban_jobs, [:scheduled_at, :id],
+                     name: :oban_jobs_staging_idx,
+                     prefix: prefix
+                   )
+  end
+end


### PR DESCRIPTION
## Summary

Adds a partial index to speed up the Stager's query against `oban_jobs` by shipping a new versioned migration (V15) plus the matching `@current_version` bump.

## Why this matters

On large tables the Stager's staging pass degrades into a sequential scan plus sort, which can slow or stall job execution. The reporter in #1462 hit this at ~100k jobs: staging queries got slow enough that jobs stopped being pulled for execution, and they resolved it locally by adding exactly this partial index. Maintainer feedback on the issue confirmed shipping the index in core is acceptable (it is already included by default in oban-py and added by an oban_pro migration).

The Stager stages jobs via `Engine.stage_jobs/3`, whose basic-engine query filters and orders like this:

```elixir
|> where([j], j.state in ~w(scheduled retryable))
|> where([j], j.scheduled_at <= ^DateTime.utc_now())
|> order_by(desc: :scheduled_at, desc: :id)
```

Without a targeted index, Postgres scans every `scheduled`/`retryable` row and sorts to satisfy the `LIMIT`.

## Change

A new versioned migration `Oban.Migrations.Postgres.V15` creates a partial index:

```sql
oban_jobs (scheduled_at, id) WHERE state IN ('scheduled', 'retryable')
```

named `oban_jobs_staging_idx` to match the index the reporter validated locally. The composite `(scheduled_at, id)` key mirrors the staging query's `scheduled_at, id` ordering, so a backward index scan satisfies the full order and stops at the `LIMIT` even when many jobs share a `scheduled_at`. This matches the canonical staging index already shipped in oban-py.

- `up` uses `create_if_not_exists` scoped to the migration `prefix`, so it is idempotent and multi-prefix safe.
- `down` uses `drop_if_exists` with the same name.
- The index is created non-concurrently, consistent with every existing Oban migration (V01/V05/V10) and the transactional versioned-migration path. As discussed in the issue, Oban core has no mechanism for index-only concurrent migrations.

`@current_version` is bumped from 14 to 15 in `Oban.Migrations.Postgres`; the `change/3` dispatcher resolves `V15` dynamically from the version range, so the bump is the only wiring needed. The installation guide's pinned version is updated to 15 to match, keeping the documented new-install path consistent with the required version.

## Testing

`test/oban/migrations/postgres_test.exs` iterates `initial_version()..current_version()`, so bumping to 15 automatically exercises V15 `up` and `down` (including under a non-default prefix). All migration tests pass locally against Postgres.

Fixes #1462
