### PR TITLE
Config redesign for first-class features

### DIFF
--- a/guides/advanced/scaling.md
+++ b/guides/advanced/scaling.md
@@ -162,14 +162,13 @@ defmodule MyApp.Repo do
 end
 ```
 
-Then switch the configured `repo`, and use `get_dynamic_repo` to ensure the same repo is used
-within a transaction:
+Then switch the configured `repo`, and use the repo's `dynamic_repo` option to ensure the same
+repo is used within a transaction:
 
 ```diff
  config :my_app, Oban,
 -  repo: MyApp.Repo,
-+  repo: MyApp.ObanRepo,
-+  get_dynamic_repo: {MyApp.Repo, :oban_repo, []}
++  repo: {MyApp.ObanRepo, dynamic_repo: {MyApp.Repo, :oban_repo, []}},
    ...
 ```
 

--- a/guides/advanced/scaling.md
+++ b/guides/advanced/scaling.md
@@ -81,10 +81,8 @@ default, but it accepts a cron-style schedule and you can tweak it to run less f
 
 ```diff
 config :my_app, Oban,
-   plugins: [
-+   {Oban.Plugins.Reindexer, schedule: "@weekly"},
-    …
-   ]
++  reindexer: [schedule: "@weekly"],
+   …
 ```
 
 ## Pruning
@@ -98,10 +96,8 @@ For example, to limit historic jobs to 1 day:
 
 ```diff
  config :my_app, Oban,
-  plugins: [
-+    {Oban.Plugins.Pruner, max_age: 1_day_in_seconds}
-     …
-   ]
++  pruner: [max_age: 1_day_in_seconds],
+   …
 ```
 
 The default auto vacuum settings are conservative and may fall behind on active tables. Dead

--- a/guides/advanced/scaling.md
+++ b/guides/advanced/scaling.md
@@ -96,7 +96,7 @@ For example, to limit historic jobs to 1 day:
 
 ```diff
  config :my_app, Oban,
-+  pruner: [max_age: 1_day_in_seconds],
++  pruner: [max_age: {1, :day}],
    …
 ```
 

--- a/guides/advanced/troubleshooting.md
+++ b/guides/advanced/troubleshooting.md
@@ -18,7 +18,7 @@ There are two mechanisms to mitigate orphans:
 
 ```elixir
 config :my_app, Oban,
-    plugins: [Oban.Plugins.Lifeline],
+    lifeline: [],
     shutdown_grace_period: :timer.seconds(60),
     ...
 ```

--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -103,7 +103,7 @@ Running with Postgres requires using the `Oban.Engines.Basic` engine:
 config :my_app, Oban,
   engine: Oban.Engines.Basic,
   queues: [default: 10],
-  lifeline: [rescue_after: :timer.hours(2)],
+  lifeline: [rescue_after: {2, :hours}],
   pruner: [max_age: {1, :day}],
   repo: MyApp.Repo
 ```
@@ -117,7 +117,7 @@ Running with SQLite3 requires using the `Oban.Engines.Lite` engine:
 config :my_app, Oban,
   engine: Oban.Engines.Lite,
   queues: [default: 10],
-  lifeline: [rescue_after: :timer.hours(2)],
+  lifeline: [rescue_after: {2, :hours}],
   pruner: [max_age: {1, :day}],
   repo: MyApp.Repo
 ```
@@ -131,7 +131,7 @@ Running with MySQL requires using the `Oban.Engines.Dolphin` engine:
 config :my_app, Oban,
   engine: Oban.Engines.Dolphin,
   queues: [default: 10],
-  lifeline: [rescue_after: :timer.hours(2)],
+  lifeline: [rescue_after: {2, :hours}],
   pruner: [max_age: {1, :day}],
   repo: MyApp.Repo
 ```

--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -104,7 +104,7 @@ config :my_app, Oban,
   engine: Oban.Engines.Basic,
   queues: [default: 10],
   lifeline: [rescue_after: :timer.hours(2)],
-  pruner: [max_age: 60 * 60 * 24 * 7],
+  pruner: [max_age: {1, :day}],
   repo: MyApp.Repo
 ```
 
@@ -118,7 +118,7 @@ config :my_app, Oban,
   engine: Oban.Engines.Lite,
   queues: [default: 10],
   lifeline: [rescue_after: :timer.hours(2)],
-  pruner: [max_age: 60 * 60 * 24 * 7],
+  pruner: [max_age: {1, :day}],
   repo: MyApp.Repo
 ```
 
@@ -132,7 +132,7 @@ config :my_app, Oban,
   engine: Oban.Engines.Dolphin,
   queues: [default: 10],
   lifeline: [rescue_after: :timer.hours(2)],
-  pruner: [max_age: 60 * 60 * 24 * 7],
+  pruner: [max_age: {1, :day}],
   repo: MyApp.Repo
 ```
 

--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -103,6 +103,8 @@ Running with Postgres requires using the `Oban.Engines.Basic` engine:
 config :my_app, Oban,
   engine: Oban.Engines.Basic,
   queues: [default: 10],
+  lifeline: [rescue_after: :timer.hours(2)],
+  pruner: [max_age: 60 * 60 * 24 * 7],
   repo: MyApp.Repo
 ```
 
@@ -115,6 +117,8 @@ Running with SQLite3 requires using the `Oban.Engines.Lite` engine:
 config :my_app, Oban,
   engine: Oban.Engines.Lite,
   queues: [default: 10],
+  lifeline: [rescue_after: :timer.hours(2)],
+  pruner: [max_age: 60 * 60 * 24 * 7],
   repo: MyApp.Repo
 ```
 
@@ -127,6 +131,8 @@ Running with MySQL requires using the `Oban.Engines.Dolphin` engine:
 config :my_app, Oban,
   engine: Oban.Engines.Dolphin,
   queues: [default: 10],
+  lifeline: [rescue_after: :timer.hours(2)],
+  pruner: [max_age: 60 * 60 * 24 * 7],
   repo: MyApp.Repo
 ```
 

--- a/guides/introduction/ready_for_production.md
+++ b/guides/introduction/ready_for_production.md
@@ -50,8 +50,7 @@ for 7 days, specified in seconds:
 
 ```elixir
 config :my_app, Oban,
-  plugins: [
-    {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 7},
+  pruner: [max_age: 60 * 60 * 24 * 7],
   ...
 ```
 
@@ -76,8 +75,7 @@ like 30 minutes:
 
 ```elixir
 config :my_app, Oban,
-  plugins: [
-    {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)},
+  lifeline: [rescue_after: :timer.minutes(30)],
   ...
 ```
 

--- a/guides/introduction/ready_for_production.md
+++ b/guides/introduction/ready_for_production.md
@@ -71,11 +71,11 @@ Even with a higher `shutdown_grace_period` it's possible to have orphans if ther
 crash or extra long running jobs.
 
 Consider adding the `Lifeline` plugin and configure it to rescue after a generous period of time,
-like 30 minutes:
+like 1 hour:
 
 ```elixir
 config :my_app, Oban,
-  lifeline: [rescue_after: :timer.minutes(30)],
+  lifeline: [rescue_after: {1, :hour}],
   ...
 ```
 

--- a/guides/introduction/ready_for_production.md
+++ b/guides/introduction/ready_for_production.md
@@ -44,13 +44,13 @@ Job introspection and uniqueness relies on keeping job rows in the database afte
 executed. To prevent the `oban_jobs` table from growing indefinitely, the `Oban.Plugins.Pruner`
 plugin provides out-of-band deletion of `completed`, `cancelled` and `discarded` jobs.
 
-Retaining jobs for 7 days is a good starting point, but depending on throughput, you may wish to
-keep jobs for even longer. Include `Pruner` in the list of plugins and configure it to retain jobs
-for 7 days, specified in seconds:
+Retaining jobs for 1 day is a conservative starting point. Depending on throughput and how long
+you need jobs for introspection or uniqueness, you may wish to keep them longer. Configure the
+`pruner` with a `max_age`, either as a count of seconds or an `Oban.Period` tuple:
 
 ```elixir
 config :my_app, Oban,
-  pruner: [max_age: 60 * 60 * 24 * 7],
+  pruner: [max_age: {1, :day}],
   ...
 ```
 

--- a/guides/learning/isolation.md
+++ b/guides/learning/isolation.md
@@ -168,15 +168,15 @@ isolated. That means that insert/update events will only dispatch new jobs for t
 
 ### Dynamic Repositories
 
-Oban supports [Ecto dynamic repositories][dynamic] through the `:get_dynamic_repo` option. To make
-this work, you need to run a separate Oban instance for each dynamic repo instance. Most often
+Oban supports [Ecto dynamic repositories][dynamic] through the repo's `:dynamic_repo` option. To
+make this work, you need to run a separate Oban instance for each dynamic repo instance. Most often
 it's worth bundling each Oban and repo instance under the same supervisor:
 
 ```elixir
 def start_repo_and_oban(instance_id) do
   children = [
     {MyDynamicRepo, name: nil, url: repo_url(instance_id)},
-    {Oban, name: instance_id, get_dynamic_repo: fn -> repo_pid(instance_id) end}
+    {Oban, name: instance_id, repo: {MyDynamicRepo, dynamic_repo: fn -> repo_pid(instance_id) end}}
   ]
 
   Supervisor.start_link(children, strategy: :one_for_one)

--- a/guides/learning/operational_maintenance.md
+++ b/guides/learning/operational_maintenance.md
@@ -28,7 +28,7 @@ configure a longer retention period by providing a `:max_age` in seconds to the 
 
 ```elixir
 config :my_app, Oban,
-  pruner: [max_age: 5 * 60],
+  pruner: [max_age: {1, :day}],
   # ...
 ```
 

--- a/guides/learning/operational_maintenance.md
+++ b/guides/learning/operational_maintenance.md
@@ -28,7 +28,7 @@ configure a longer retention period by providing a `:max_age` in seconds to the 
 
 ```elixir
 config :my_app, Oban,
-  plugins: [{Oban.Plugins.Pruner, max_age: _5_minutes_in_seconds = 300}],
+  pruner: [max_age: 5 * 60],
   # ...
 ```
 
@@ -69,7 +69,8 @@ To enable automatic index maintenance, add the Reindexer to your Oban configurat
 
 ```elixir
 config :my_app, Oban,
-  plugins: [Oban.Plugins.Pruner, Oban.Plugins.Reindexer],
+  pruner: [],
+  reindexer: [],
   # ...
 ```
 

--- a/guides/learning/periodic_jobs.md
+++ b/guides/learning/periodic_jobs.md
@@ -19,15 +19,14 @@ Here's an example configuration:
 ```elixir
 config :my_app, Oban,
   repo: MyApp.Repo,
-  plugins: [
-    {Oban.Plugins.Cron,
-     crontab: [
-       {"* * * * *", MyApp.MinuteWorker},
-       {"0 * * * *", MyApp.HourlyWorker, args: %{custom: "arg"}},
-       {"0 0 * * *", MyApp.DailyWorker, max_attempts: 1},
-       {"0 12 * * MON", MyApp.MondayWorker, queue: :scheduled, tags: ["mondays"]},
-       {"@daily", MyApp.AnotherDailyWorker}
-     ]}
+  cron: [
+    crontab: [
+      {"* * * * *", MyApp.MinuteWorker},
+      {"0 * * * *", MyApp.HourlyWorker, args: %{custom: "arg"}},
+      {"0 0 * * *", MyApp.DailyWorker, max_attempts: 1},
+      {"0 12 * * MON", MyApp.MondayWorker, queue: :scheduled, tags: ["mondays"]},
+      {"@daily", MyApp.AnotherDailyWorker}
+    ]
   ]
 ```
 

--- a/lib/mix/tasks/oban.install.ex
+++ b/lib/mix/tasks/oban.install.ex
@@ -74,7 +74,18 @@ if Code.ensure_loaded?(Igniter) do
           engine = parse_engine(adapter, opts[:engine])
           notifier = parse_notifier(adapter, opts[:notifier])
 
-          conf_code = [engine: engine, notifier: notifier, queues: [default: 10], repo: repo]
+          conf_code =
+            quote do
+              [
+                engine: unquote(engine),
+                notifier: unquote(notifier),
+                queues: [default: 10],
+                lifeline: [rescue_after: :timer.hours(2)],
+                pruner: [max_age: 60 * 60 * 24 * 7],
+                repo: unquote(repo)
+              ]
+            end
+
           test_code = [testing: :manual]
 
           tree_code =

--- a/lib/mix/tasks/oban.install.ex
+++ b/lib/mix/tasks/oban.install.ex
@@ -80,7 +80,7 @@ if Code.ensure_loaded?(Igniter) do
                 engine: unquote(engine),
                 notifier: unquote(notifier),
                 queues: [default: 10],
-                lifeline: [rescue_after: :timer.hours(2)],
+                lifeline: [rescue_after: {2, :hours}],
                 pruner: [max_age: {1, :day}],
                 repo: unquote(repo)
               ]

--- a/lib/mix/tasks/oban.install.ex
+++ b/lib/mix/tasks/oban.install.ex
@@ -81,7 +81,7 @@ if Code.ensure_loaded?(Igniter) do
                 notifier: unquote(notifier),
                 queues: [default: 10],
                 lifeline: [rescue_after: :timer.hours(2)],
-                pruner: [max_age: 60 * 60 * 24 * 7],
+                pruner: [max_age: {1, :day}],
                 repo: unquote(repo)
               ]
             end

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -84,19 +84,18 @@ defmodule Oban do
           {:cron, feature()}
           | {:dispatch_cooldown, pos_integer()}
           | {:engine, module()}
-          | {:get_dynamic_repo, nil | (-> pid() | atom()) | {module(), atom(), list()}}
+          | {:insert_trigger, boolean()}
           | {:lifeline, feature()}
-          | {:log, false | Logger.level()}
           | {:name, name()}
           | {:node, oban_node()}
           | {:notifier, module() | {module(), Keyword.t()}}
           | {:peer, false | module() | {module(), Keyword.t()}}
-          | {:plugins, false | [module() | {module() | Keyword.t()}]}
+          | {:plugins, false | [module() | {module(), Keyword.t()}]}
           | {:prefix, false | String.t()}
           | {:pruner, feature()}
           | {:queues, false | [{queue_name(), pos_integer() | Keyword.t()}]}
           | {:reindexer, feature()}
-          | {:repo, module()}
+          | {:repo, module() | {module(), Keyword.t()}}
           | {:shutdown_grace_period, non_neg_integer()}
           | {:stage_interval, timeout()}
           | {:testing, :disabled | :inline | :manual}
@@ -370,7 +369,20 @@ defmodule Oban do
 
   These options are required; without them the supervisor won't start:
 
-  * `:repo` — specifies the Ecto repo used to insert and retrieve jobs
+  * `:repo` — specifies the Ecto repo used to insert and retrieve jobs.
+
+    Repo-specific options may be provided as a `{repo, opts}` tuple:
+
+    * `:log` — either `false` to disable logging or a standard log level (`:error`, `:warning`,
+      `:info`, `:debug`, etc.). This determines whether queries are logged, overriding the repo's
+      configured log level. Defaults to `false`, where no queries are logged.
+
+    * `:dynamic_repo` — a zero-arity function or MFA tuple that returns the pid or name of the repo
+      to use for queries, for applications that run with a dynamically configured repo.
+
+    For example, to insert and retrieve jobs without logging queries:
+
+        repo: {MyApp.Repo, log: false}
 
   ### Primary Options
 
@@ -389,10 +401,6 @@ defmodule Oban do
     are also available as an add-on.
 
     Defaults to the `Basic` engine for Postgres.
-
-  * `:log` — either `false` to disable logging or a standard log level (`:error`, `:warning`,
-    `:info`, `:debug`, etc.). This determines whether queries are logged or not; overriding the
-    repo's configured log level. Defaults to `false`, where no queries are logged.
 
   * `:name` — used for supervisor registration, it must be unique across an entire VM instance.
     Defaults to `Oban` when no name is provided.

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -68,14 +68,24 @@ defmodule Oban do
         }
 
   @typedoc """
+  The value accepted by a feature key (`:cron`, `:pruner`, `:lifeline`, `:reindexer`).
+
+  Either `false` to disable, a keyword list of options for the default implementation, or a
+  `{module, options}` tuple to use an alternative implementation.
+  """
+  @type feature :: false | Keyword.t() | {module(), Keyword.t()}
+
+  @typedoc """
   Configuration options for starting an Oban instance.
 
   See `start_link1/` for more information on individual options.
   """
   @type option ::
-          {:dispatch_cooldown, pos_integer()}
+          {:cron, feature()}
+          | {:dispatch_cooldown, pos_integer()}
           | {:engine, module()}
           | {:get_dynamic_repo, nil | (-> pid() | atom()) | {module(), atom(), list()}}
+          | {:lifeline, feature()}
           | {:log, false | Logger.level()}
           | {:name, name()}
           | {:node, oban_node()}
@@ -83,7 +93,9 @@ defmodule Oban do
           | {:peer, false | module() | {module(), Keyword.t()}}
           | {:plugins, false | [module() | {module() | Keyword.t()}]}
           | {:prefix, false | String.t()}
+          | {:pruner, feature()}
           | {:queues, false | [{queue_name(), pos_integer() | Keyword.t()}]}
+          | {:reindexer, feature()}
           | {:repo, module()}
           | {:shutdown_grace_period, non_neg_integer()}
           | {:stage_interval, timeout()}
@@ -409,6 +421,10 @@ defmodule Oban do
     supervisor. Any supervisable module is a valid plugin, i.e. a `GenServer` or an `Agent`. May
     also be set to `false` to disable plugins _and_ disable leadership.
 
+    The most common plugins have dedicated top-level keys (see "Feature Options" below). Prefer
+    those over a raw `:plugins` entry. Configuring the same plugin through both a feature key and
+    `:plugins` raises during validation.
+
   * `:prefix` — the query prefix, or schema, to use for inserting and executing jobs. An
     `oban_jobs` table must exist within the prefix. See the "Prefix Support" section in the module
     documentation for more details.
@@ -426,6 +442,26 @@ defmodule Oban do
   * `:testing` — a mode that controls how an instance is configured for testing. When set to
     `:inline` or `:manual` queues, peers, and plugins are automatically disabled. Defaults to
     `:disabled`, no test mode.
+
+  ### Feature Options
+
+  These keys configure Oban's built-in maintenance plugins. Each accepts a keyword list of options
+  for the plugin, or `false` to disable it. See the linked module for the available options.
+
+  * `:cron` — schedule recurring jobs with a crontab, see `Oban.Plugins.Cron`
+  * `:lifeline` — rescue jobs orphaned when a node shuts down, see `Oban.Plugins.Lifeline`
+  * `:pruner` — delete completed, cancelled, and discarded jobs, see `Oban.Plugins.Pruner`
+  * `:reindexer` — periodically rebuild indexes to combat bloat, see `Oban.Plugins.Reindexer`
+
+  For example, to prune jobs after a week and run a nightly worker:
+
+      cron: [crontab: [{"0 2 * * *", MyApp.NightlyWorker}]],
+      pruner: [max_age: 60 * 60 * 24 * 7]
+
+  Each key also accepts a `{module, options}` tuple to use a specific implementation, such as an
+  Oban Pro plugin:
+
+      cron: {Oban.Pro.Plugins.DynamicCron, [crontab: ...]}
 
   ### Twiddly Options
 

--- a/lib/oban.ex
+++ b/lib/oban.ex
@@ -453,10 +453,10 @@ defmodule Oban do
   * `:pruner` — delete completed, cancelled, and discarded jobs, see `Oban.Plugins.Pruner`
   * `:reindexer` — periodically rebuild indexes to combat bloat, see `Oban.Plugins.Reindexer`
 
-  For example, to prune jobs after a week and run a nightly worker:
+  For example, to prune jobs after a day and run a nightly worker:
 
       cron: [crontab: [{"0 2 * * *", MyApp.NightlyWorker}]],
-      pruner: [max_age: 60 * 60 * 24 * 7]
+      pruner: [max_age: {1, :day}]
 
   Each key also accepts a `{module, options}` tuple to use a specific implementation, such as an
   Oban Pro plugin:

--- a/lib/oban/config.ex
+++ b/lib/oban/config.ex
@@ -13,14 +13,12 @@ defmodule Oban.Config do
   @type t :: %__MODULE__{
           dispatch_cooldown: pos_integer(),
           engine: module(),
-          get_dynamic_repo: nil | (-> pid() | atom()) | {module(), atom(), list()},
           insert_trigger: boolean(),
-          log: false | Logger.level(),
           name: Oban.name(),
           node: String.t(),
           notifier: {module(), Keyword.t()},
           peer: {module(), Keyword.t()},
-          plugins: [module() | {module() | Keyword.t()}],
+          plugins: [module() | {module(), Keyword.t()}],
           prefix: false | String.t(),
           queues: Keyword.t(Keyword.t()),
           repo: module(),
@@ -48,6 +46,7 @@ defmodule Oban.Config do
 
   @cron_keys ~w(crontab timezone)a
   @log_levels ~w(false emergency alert critical error warning warn notice info debug)a
+  @repo_opts [log: :log, dynamic_repo: :get_dynamic_repo]
   @testing_modes ~w(manual inline disabled)a
 
   @feature_plugins [
@@ -130,7 +129,7 @@ defmodule Oban.Config do
       iex> Oban.Config.validate(name: Oban)
       :ok
 
-      iex> Oban.Config.validate(name: Oban, log: false)
+      iex> Oban.Config.validate(name: Oban, prefix: "private")
       :ok
 
       iex> Oban.Config.validate(node: {:not, :binary})
@@ -334,77 +333,33 @@ defmodule Oban.Config do
 
   defp normalize(opts) do
     opts
-    |> crontab_to_plugin()
-    |> features_to_plugins()
+    |> normalize_repo()
     |> normalize_notifier()
     |> normalize_peer()
-    |> Keyword.put_new(:node, node_name())
-    |> Keyword.update(:queues, [], &normalize_queues/1)
-    |> Keyword.update(:plugins, [], &normalize_plugins/1)
+    |> normalize_stager()
+    |> normalize_queues()
+    |> normalize_plugins()
     |> Keyword.delete(:circuit_backoff)
-    |> stager_to_interval()
+    |> Keyword.put_new(:node, node_name())
     |> Enum.reject(&(&1 in @renamed_modules))
   end
 
-  defp crontab_to_plugin(opts) do
-    case {opts[:plugins], opts[:crontab]} do
-      {plugins, [_ | _]} when is_list(plugins) or is_nil(plugins) ->
-        {cron_opts, base_opts} = Keyword.split(opts, @cron_keys)
-
-        plugin = {Oban.Plugins.Cron, cron_opts}
-
-        Keyword.update(base_opts, :plugins, [plugin], &[plugin | &1])
+  defp normalize_repo(opts) do
+    case Keyword.get(opts, :repo) do
+      {repo, repo_opts} when is_atom(repo) and is_list(repo_opts) ->
+        opts
+        |> Keyword.put(:repo, repo)
+        |> merge_repo_opts(repo_opts)
 
       _ ->
-        Keyword.drop(opts, @cron_keys)
+        opts
     end
   end
 
-  defp features_to_plugins(opts) do
-    Enum.reduce(@feature_plugins, opts, fn {key, module}, opts ->
-      feature_to_plugin(opts, key, module)
+  defp merge_repo_opts(opts, repo_opts) do
+    Enum.reduce(repo_opts, opts, fn {key, value}, opts ->
+      Keyword.put(opts, Keyword.get(@repo_opts, key, key), value)
     end)
-  end
-
-  defp feature_to_plugin(opts, key, module) do
-    case Keyword.fetch(opts, key) do
-      :error ->
-        opts
-
-      {:ok, false} ->
-        Keyword.delete(opts, key)
-
-      {:ok, value} ->
-        plugin = normalize_feature(value, module)
-
-        opts
-        |> Keyword.delete(key)
-        |> Keyword.update(:plugins, [plugin], &[plugin | &1])
-    end
-  end
-
-  defp normalize_feature({module, opts}, _default) when is_atom(module), do: {module, opts}
-  defp normalize_feature(opts, module), do: {module, opts}
-
-  defp stager_to_interval(opts) do
-    cond do
-      Keyword.has_key?(opts, :poll_interval) ->
-        opts
-        |> Keyword.put_new(:stage_interval, opts[:poll_interval])
-        |> Keyword.delete(:poll_interval)
-
-      Keyword.keyword?(opts[:plugins]) ->
-        {stager_opts, opts} = pop_in(opts, [:plugins, Oban.Stager])
-
-        if is_list(stager_opts) and Keyword.has_key?(stager_opts, :interval) do
-          Keyword.put_new(opts, :stage_interval, stager_opts[:interval])
-        else
-          opts
-        end
-
-      true ->
-        opts
-    end
   end
 
   defp normalize_notifier(opts) do
@@ -438,24 +393,92 @@ defmodule Oban.Config do
     end
   end
 
-  defp normalize_queues(queues) when is_list(queues) do
-    for {name, value} <- queues do
-      opts = if is_integer(value), do: [limit: value], else: value
+  defp normalize_stager(opts) do
+    cond do
+      Keyword.has_key?(opts, :poll_interval) ->
+        opts
+        |> Keyword.put_new(:stage_interval, opts[:poll_interval])
+        |> Keyword.delete(:poll_interval)
 
-      {name, opts}
+      Keyword.keyword?(opts[:plugins]) ->
+        {stager_opts, opts} = pop_in(opts, [:plugins, Oban.Stager])
+
+        if is_list(stager_opts) and Keyword.has_key?(stager_opts, :interval) do
+          Keyword.put_new(opts, :stage_interval, stager_opts[:interval])
+        else
+          opts
+        end
+
+      true ->
+        opts
     end
   end
 
-  defp normalize_queues(queues), do: queues || []
+  defp normalize_queues(opts) do
+    Keyword.update(opts, :queues, [], fn
+      queues when is_list(queues) ->
+        for {name, value} <- queues do
+          opts = if is_integer(value), do: [limit: value], else: value
+
+          {name, opts}
+        end
+
+      queues ->
+        queues || []
+    end)
+  end
 
   # Manually specified plugins will be overwritten by auto-specified plugins unless we reverse the
   # plugin list. The order doesn't matter as they are supervised one-for-one.
-  defp normalize_plugins(plugins) when is_list(plugins) do
-    plugins
-    |> Enum.map(&if is_atom(&1), do: {&1, []}, else: &1)
-    |> Enum.reverse()
-    |> Enum.uniq()
+  defp normalize_plugins(opts) do
+    opts
+    |> normalize_crontab()
+    |> normalize_features()
+    |> Keyword.update(:plugins, [], fn
+      plugins when is_list(plugins) ->
+        plugins
+        |> Enum.map(&if is_atom(&1), do: {&1, []}, else: &1)
+        |> Enum.reverse()
+        |> Enum.uniq()
+
+      plugins ->
+        plugins || []
+    end)
   end
 
-  defp normalize_plugins(plugins), do: plugins || []
+  defp normalize_crontab(opts) do
+    case {opts[:plugins], opts[:crontab]} do
+      {plugins, [_ | _]} when is_list(plugins) or is_nil(plugins) ->
+        {cron_opts, base_opts} = Keyword.split(opts, @cron_keys)
+
+        plugin = {Oban.Plugins.Cron, cron_opts}
+
+        Keyword.update(base_opts, :plugins, [plugin], &[plugin | &1])
+
+      _ ->
+        Keyword.drop(opts, @cron_keys)
+    end
+  end
+
+  defp normalize_features(opts) do
+    Enum.reduce(@feature_plugins, opts, fn {key, module}, opts ->
+      case Keyword.fetch(opts, key) do
+        :error ->
+          opts
+
+        {:ok, false} ->
+          Keyword.delete(opts, key)
+
+        {:ok, value} ->
+          plugin = normalize_feature(value, module)
+
+          opts
+          |> Keyword.delete(key)
+          |> Keyword.update(:plugins, [plugin], &[plugin | &1])
+      end
+    end)
+  end
+
+  defp normalize_feature({module, opts}, _default) when is_atom(module), do: {module, opts}
+  defp normalize_feature(opts, module), do: {module, opts}
 end

--- a/lib/oban/config.ex
+++ b/lib/oban/config.ex
@@ -48,8 +48,16 @@ defmodule Oban.Config do
 
   @cron_keys ~w(crontab timezone)a
   @log_levels ~w(false emergency alert critical error warning warn notice info debug)a
-  @renamed [{:engine, Oban.Queue.BasicEngine}, {:notifier, {Oban.PostgresNotifier, []}}]
   @testing_modes ~w(manual inline disabled)a
+
+  @feature_plugins [
+    cron: Oban.Plugins.Cron,
+    pruner: Oban.Plugins.Pruner,
+    lifeline: Oban.Plugins.Lifeline,
+    reindexer: Oban.Plugins.Reindexer
+  ]
+
+  @renamed_modules [{:engine, Oban.Queue.BasicEngine}, {:notifier, {Oban.PostgresNotifier, []}}]
 
   @doc """
   Generate a Config struct after normalizing and verifying Oban options.
@@ -218,7 +226,9 @@ defmodule Oban.Config do
   # Validation
 
   defp validate_plugins(plugins) do
-    Validation.validate(:plugins, plugins, &validate_plugin/1)
+    with :ok <- validate_unique_plugins(plugins) do
+      Validation.validate(:plugins, plugins, &validate_plugin/1)
+    end
   end
 
   defp validate_plugin(plugin) when not is_tuple(plugin), do: validate_plugin({plugin, []})
@@ -302,11 +312,30 @@ defmodule Oban.Config do
     end
   end
 
+  defp validate_unique_plugins(plugins) when is_list(plugins) do
+    modules =
+      Enum.map(plugins, fn
+        {module, _opts} -> module
+        module -> module
+      end)
+
+    dupe = modules -- Enum.uniq(modules)
+
+    if Enum.empty?(dupe) do
+      :ok
+    else
+      {:error, "found duplicate plugins: #{inspect(dupe)}"}
+    end
+  end
+
+  defp validate_unique_plugins(_plugins), do: :ok
+
   # Normalization
 
   defp normalize(opts) do
     opts
     |> crontab_to_plugin()
+    |> features_to_plugins()
     |> normalize_notifier()
     |> normalize_peer()
     |> Keyword.put_new(:node, node_name())
@@ -314,7 +343,7 @@ defmodule Oban.Config do
     |> Keyword.update(:plugins, [], &normalize_plugins/1)
     |> Keyword.delete(:circuit_backoff)
     |> stager_to_interval()
-    |> Enum.reject(&(&1 in @renamed))
+    |> Enum.reject(&(&1 in @renamed_modules))
   end
 
   defp crontab_to_plugin(opts) do
@@ -330,6 +359,32 @@ defmodule Oban.Config do
         Keyword.drop(opts, @cron_keys)
     end
   end
+
+  defp features_to_plugins(opts) do
+    Enum.reduce(@feature_plugins, opts, fn {key, module}, opts ->
+      feature_to_plugin(opts, key, module)
+    end)
+  end
+
+  defp feature_to_plugin(opts, key, module) do
+    case Keyword.fetch(opts, key) do
+      :error ->
+        opts
+
+      {:ok, false} ->
+        Keyword.delete(opts, key)
+
+      {:ok, value} ->
+        plugin = normalize_feature(value, module)
+
+        opts
+        |> Keyword.delete(key)
+        |> Keyword.update(:plugins, [plugin], &[plugin | &1])
+    end
+  end
+
+  defp normalize_feature({module, opts}, _default) when is_atom(module), do: {module, opts}
+  defp normalize_feature(opts, module), do: {module, opts}
 
   defp stager_to_interval(opts) do
     cond do

--- a/lib/oban/config.ex
+++ b/lib/oban/config.ex
@@ -141,11 +141,11 @@ defmodule Oban.Config do
 
   Validating plugin options:
 
-      iex> Oban.Config.validate(plugins: [{Oban.Plugins.Pruner, max_age: 60}])
+      iex> Oban.Config.validate(plugins: [{Oban.Plugins.Pruner, max_age: {1, :day}}])
       :ok
 
       iex> Oban.Config.validate(plugins: [{Oban.Plugins.Pruner, max_age: 0}])
-      {:error, "invalid value for :plugins, expected :max_age to be a positive integer, got: 0"}
+      {:error, "invalid value for :plugins, expected :max_age to be a positive integer or {amount, unit} tuple, got: 0"}
   """
   @spec validate([Oban.option()]) :: :ok | {:error, String.t()}
   def validate(opts) when is_list(opts) do

--- a/lib/oban/period.ex
+++ b/lib/oban/period.ex
@@ -88,4 +88,25 @@ defmodule Oban.Period do
   def to_seconds({value, unit}) when unit in ~w(day days)a, do: value * 24 * 60 * 60
   def to_seconds({value, unit}) when unit in ~w(week weeks)a, do: value * 24 * 60 * 60 * 7
   def to_seconds(seconds) when is_seconds(seconds), do: seconds
+
+  @doc """
+  Convert a period to milliseconds.
+
+  Unlike `to_seconds/1`, a bare integer is considered milliseconds and returned unchanged; only
+  unit tuples are expanded.
+
+  ## Examples
+
+      iex> Oban.Period.to_milliseconds(1000)
+      1000
+
+      iex> Oban.Period.to_milliseconds({1, :second})
+      1000
+
+      iex> Oban.Period.to_milliseconds({2, :minutes})
+      120_000
+  """
+  @spec to_milliseconds(t()) :: pos_integer()
+  def to_milliseconds({_value, _unit} = period), do: to_seconds(period) * 1000
+  def to_milliseconds(milliseconds) when is_seconds(milliseconds), do: milliseconds
 end

--- a/lib/oban/plugins/cron.ex
+++ b/lib/oban/plugins/cron.ex
@@ -17,15 +17,14 @@ defmodule Oban.Plugins.Cron do
 
   ```elixir
   config :my_app, Oban,
-    plugins: [
-      {Oban.Plugins.Cron,
-       crontab: [
-         {"* * * * *", MyApp.MinuteWorker},
-         {"0 * * * *", MyApp.HourlyWorker, args: %{custom: "arg"}},
-         {"0 0 * * *", MyApp.DailyWorker, max_attempts: 1},
-         {"0 12 * * MON", MyApp.MondayWorker, queue: :scheduled, tags: ["mondays"]},
-         {"@daily", MyApp.AnotherDailyWorker}
-       ]}
+    cron: [
+      crontab: [
+        {"* * * * *", MyApp.MinuteWorker},
+        {"0 * * * *", MyApp.HourlyWorker, args: %{custom: "arg"}},
+        {"0 0 * * *", MyApp.DailyWorker, max_attempts: 1},
+        {"0 12 * * MON", MyApp.MondayWorker, queue: :scheduled, tags: ["mondays"]},
+        {"@daily", MyApp.AnotherDailyWorker}
+      ]
     ]
   ```
 

--- a/lib/oban/plugins/lifeline.ex
+++ b/lib/oban/plugins/lifeline.ex
@@ -18,7 +18,7 @@ defmodule Oban.Plugins.Lifeline do
 
   ## Using the Plugin
 
-  Rescue orphaned jobs that are still `executing` after the default of 60 minutes:
+  Rescue orphaned jobs that are still `executing` after the default of 1 hour:
 
       config :my_app, Oban,
         lifeline: [],
@@ -27,15 +27,16 @@ defmodule Oban.Plugins.Lifeline do
   Override the default period to rescue orphans after a more aggressive period of 5 minutes:
 
       config :my_app, Oban,
-        lifeline: [rescue_after: :timer.minutes(5)],
+        lifeline: [rescue_after: {5, :minutes}],
         ...
 
   ## Options
 
   * `:interval` — the number of milliseconds between rescue attempts. The default is `60_000ms`.
 
-  * `:rescue_after` — the maximum amount of time, in milliseconds, that a job may execute before
-  being rescued. 60 minutes by default, and rescuing is performed once a minute.
+  * `:rescue_after` — the maximum amount of time a job may execute before being rescued, as either
+    an integer number of milliseconds or an `Oban.Period` tuple like `{1, :hour}`. 1 hour
+    by default, and rescuing is performed once a minute.
 
   ## Instrumenting with Telemetry
 
@@ -53,7 +54,7 @@ defmodule Oban.Plugins.Lifeline do
 
   use GenServer
 
-  alias Oban.{Engine, Job, Peer, Plugin, Repo, Validation}
+  alias Oban.{Engine, Job, Peer, Period, Plugin, Repo, Validation}
   alias __MODULE__, as: State
 
   require Logger
@@ -61,7 +62,7 @@ defmodule Oban.Plugins.Lifeline do
   @type option ::
           Plugin.option()
           | {:interval, timeout()}
-          | {:rescue_after, pos_integer()}
+          | {:rescue_after, Period.t()}
 
   defstruct [
     :conf,
@@ -79,7 +80,13 @@ defmodule Oban.Plugins.Lifeline do
   def start_link(opts) do
     {name, opts} = Keyword.pop(opts, :name)
 
-    GenServer.start_link(__MODULE__, struct!(State, opts), name: name)
+    state = struct!(State, opts)
+
+    GenServer.start_link(
+      __MODULE__,
+      %{state | rescue_after: Period.to_milliseconds(state.rescue_after)},
+      name: name
+    )
   end
 
   @impl Plugin
@@ -88,7 +95,7 @@ defmodule Oban.Plugins.Lifeline do
       conf: :any,
       name: :any,
       interval: :pos_integer,
-      rescue_after: :pos_integer
+      rescue_after: :period
     )
   end
 

--- a/lib/oban/plugins/lifeline.ex
+++ b/lib/oban/plugins/lifeline.ex
@@ -21,13 +21,13 @@ defmodule Oban.Plugins.Lifeline do
   Rescue orphaned jobs that are still `executing` after the default of 60 minutes:
 
       config :my_app, Oban,
-        plugins: [Oban.Plugins.Lifeline],
+        lifeline: [],
         ...
 
   Override the default period to rescue orphans after a more aggressive period of 5 minutes:
 
       config :my_app, Oban,
-        plugins: [{Oban.Plugins.Lifeline, rescue_after: :timer.minutes(5)}],
+        lifeline: [rescue_after: :timer.minutes(5)],
         ...
 
   ## Options

--- a/lib/oban/plugins/pruner.ex
+++ b/lib/oban/plugins/pruner.ex
@@ -22,10 +22,10 @@ defmodule Oban.Plugins.Pruner do
         pruner: [],
         ...
 
-  Override the default options to prune jobs after 5 minutes:
+  Override the default options to prune jobs after 1 day:
 
       config :my_app, Oban,
-        pruner: [max_age: 300],
+        pruner: [max_age: {1, :day}],
         ...
 
   ## Options
@@ -36,7 +36,8 @@ defmodule Oban.Plugins.Pruner do
     request timeouts. Applications that steadily generate more than 10k jobs a minute should
     increase this value.
 
-  * `:max_age` — the number of seconds after which a job may be pruned. Defaults to 60s.
+  * `:max_age` — how long to keep jobs before they may be pruned, as either an integer number of
+    seconds or an `Oban.Period` tuple like `{1, :day}`. Defaults to 60s.
 
   ## Instrumenting with Telemetry
 
@@ -51,7 +52,7 @@ defmodule Oban.Plugins.Pruner do
 
   use GenServer
 
-  alias Oban.{Engine, Job, Peer, Plugin, Repo, Validation}
+  alias Oban.{Engine, Job, Peer, Period, Plugin, Repo, Validation}
   alias __MODULE__, as: State
 
   require Logger
@@ -60,7 +61,7 @@ defmodule Oban.Plugins.Pruner do
           Plugin.option()
           | {:interval, pos_integer()}
           | {:limit, pos_integer()}
-          | {:max_age, pos_integer()}
+          | {:max_age, Period.t()}
 
   defstruct [
     :conf,
@@ -79,7 +80,11 @@ defmodule Oban.Plugins.Pruner do
   def start_link(opts) do
     {name, opts} = Keyword.pop(opts, :name)
 
-    GenServer.start_link(__MODULE__, struct!(State, opts), name: name)
+    state = struct!(State, opts)
+
+    GenServer.start_link(__MODULE__, %{state | max_age: Period.to_seconds(state.max_age)},
+      name: name
+    )
   end
 
   @impl Plugin
@@ -89,7 +94,7 @@ defmodule Oban.Plugins.Pruner do
       name: :any,
       interval: :pos_integer,
       limit: :pos_integer,
-      max_age: :pos_integer
+      max_age: :period
     )
   end
 

--- a/lib/oban/plugins/pruner.ex
+++ b/lib/oban/plugins/pruner.ex
@@ -19,13 +19,13 @@ defmodule Oban.Plugins.Pruner do
   jobs older than the default of 60 seconds:
 
       config :my_app, Oban,
-        plugins: [Oban.Plugins.Pruner],
+        pruner: [],
         ...
 
   Override the default options to prune jobs after 5 minutes:
 
       config :my_app, Oban,
-        plugins: [{Oban.Plugins.Pruner, max_age: 300}],
+        pruner: [max_age: 300],
         ...
 
   ## Options

--- a/lib/oban/plugins/reindexer.ex
+++ b/lib/oban/plugins/reindexer.ex
@@ -13,14 +13,14 @@ defmodule Oban.Plugins.Reindexer do
   By default, the plugin will reindex once a day, at midnight UTC:
 
       config :my_app, Oban,
-        plugins: [Oban.Plugins.Reindexer],
+        reindexer: [],
         ...
 
   To run on a different schedule you can provide a cron expression. For example, you could use the
   `"@weekly"` shorthand to run once a week on Sunday:
 
       config :my_app, Oban,
-        plugins: [{Oban.Plugins.Reindexer, schedule: "@weekly"}],
+        reindexer: [schedule: "@weekly"],
         ...
 
   ## Options

--- a/lib/oban/validation.ex
+++ b/lib/oban/validation.ex
@@ -2,6 +2,9 @@ defmodule Oban.Validation do
   @moduledoc false
 
   alias Oban.Cron.Expression
+  alias Oban.Period
+
+  require Period
 
   @type validator ::
           ({atom(), term()} ->
@@ -221,6 +224,16 @@ defmodule Oban.Validation do
 
       true ->
         :ok
+    end
+  end
+
+  defp validate_type(:period, key, val) do
+    if Period.is_valid_period(val) and Period.to_seconds(val) > 0 do
+      :ok
+    else
+      {:error,
+       "expected #{inspect(key)} to be a positive integer or {amount, unit} tuple, " <>
+         "got: #{inspect(val)}"}
     end
   end
 

--- a/test/mix/tasks/oban.install_test.exs
+++ b/test/mix/tasks/oban.install_test.exs
@@ -50,6 +50,8 @@ defmodule Mix.Tasks.Oban.InstallTest do
         |   engine: Oban.Engines.Basic,
         |   notifier: Oban.Notifiers.Postgres,
         |   queues: [default: 10],
+        |   lifeline: [rescue_after: :timer.hours(2)],
+        |   pruner: [max_age: 60 * 60 * 24 * 7],
         |   repo: Oban.Test.Repo
       """)
       |> assert_has_patch("config/test.exs", """
@@ -96,6 +98,8 @@ defmodule Mix.Tasks.Oban.InstallTest do
         |   engine: Oban.Engines.Basic,
         |   notifier: Oban.Notifiers.Postgres,
         |   queues: [default: 10],
+        |   lifeline: [rescue_after: :timer.hours(2)],
+        |   pruner: [max_age: 60 * 60 * 24 * 7],
         |   repo: Oban.Test.Repo
       """)
       |> assert_has_patch("config/test.exs", """
@@ -146,6 +150,8 @@ defmodule Mix.Tasks.Oban.InstallTest do
         |   engine: Oban.Engines.Lite,
         |   notifier: Oban.Notifiers.PG,
         |   queues: [default: 10],
+        |   lifeline: [rescue_after: :timer.hours(2)],
+        |   pruner: [max_age: 60 * 60 * 24 * 7],
         |   repo: Oban.Test.LiteRepo
       """)
     end
@@ -209,6 +215,8 @@ defmodule Mix.Tasks.Oban.InstallTest do
         |   engine: Oban.Engines.Basic,
         |   notifier: Oban.Notifiers.Postgres,
         |   queues: [default: 10],
+        |   lifeline: [rescue_after: :timer.hours(2)],
+        |   pruner: [max_age: 60 * 60 * 24 * 7],
         |   repo: Oban.Test.Repo
       """)
     end

--- a/test/mix/tasks/oban.install_test.exs
+++ b/test/mix/tasks/oban.install_test.exs
@@ -51,7 +51,7 @@ defmodule Mix.Tasks.Oban.InstallTest do
         |   notifier: Oban.Notifiers.Postgres,
         |   queues: [default: 10],
         |   lifeline: [rescue_after: :timer.hours(2)],
-        |   pruner: [max_age: 60 * 60 * 24 * 7],
+        |   pruner: [max_age: {1, :day}],
         |   repo: Oban.Test.Repo
       """)
       |> assert_has_patch("config/test.exs", """
@@ -99,7 +99,7 @@ defmodule Mix.Tasks.Oban.InstallTest do
         |   notifier: Oban.Notifiers.Postgres,
         |   queues: [default: 10],
         |   lifeline: [rescue_after: :timer.hours(2)],
-        |   pruner: [max_age: 60 * 60 * 24 * 7],
+        |   pruner: [max_age: {1, :day}],
         |   repo: Oban.Test.Repo
       """)
       |> assert_has_patch("config/test.exs", """
@@ -151,7 +151,7 @@ defmodule Mix.Tasks.Oban.InstallTest do
         |   notifier: Oban.Notifiers.PG,
         |   queues: [default: 10],
         |   lifeline: [rescue_after: :timer.hours(2)],
-        |   pruner: [max_age: 60 * 60 * 24 * 7],
+        |   pruner: [max_age: {1, :day}],
         |   repo: Oban.Test.LiteRepo
       """)
     end
@@ -216,7 +216,7 @@ defmodule Mix.Tasks.Oban.InstallTest do
         |   notifier: Oban.Notifiers.Postgres,
         |   queues: [default: 10],
         |   lifeline: [rescue_after: :timer.hours(2)],
-        |   pruner: [max_age: 60 * 60 * 24 * 7],
+        |   pruner: [max_age: {1, :day}],
         |   repo: Oban.Test.Repo
       """)
     end

--- a/test/mix/tasks/oban.install_test.exs
+++ b/test/mix/tasks/oban.install_test.exs
@@ -50,7 +50,7 @@ defmodule Mix.Tasks.Oban.InstallTest do
         |   engine: Oban.Engines.Basic,
         |   notifier: Oban.Notifiers.Postgres,
         |   queues: [default: 10],
-        |   lifeline: [rescue_after: :timer.hours(2)],
+        |   lifeline: [rescue_after: {2, :hours}],
         |   pruner: [max_age: {1, :day}],
         |   repo: Oban.Test.Repo
       """)
@@ -98,7 +98,7 @@ defmodule Mix.Tasks.Oban.InstallTest do
         |   engine: Oban.Engines.Basic,
         |   notifier: Oban.Notifiers.Postgres,
         |   queues: [default: 10],
-        |   lifeline: [rescue_after: :timer.hours(2)],
+        |   lifeline: [rescue_after: {2, :hours}],
         |   pruner: [max_age: {1, :day}],
         |   repo: Oban.Test.Repo
       """)
@@ -150,7 +150,7 @@ defmodule Mix.Tasks.Oban.InstallTest do
         |   engine: Oban.Engines.Lite,
         |   notifier: Oban.Notifiers.PG,
         |   queues: [default: 10],
-        |   lifeline: [rescue_after: :timer.hours(2)],
+        |   lifeline: [rescue_after: {2, :hours}],
         |   pruner: [max_age: {1, :day}],
         |   repo: Oban.Test.LiteRepo
       """)
@@ -215,7 +215,7 @@ defmodule Mix.Tasks.Oban.InstallTest do
         |   engine: Oban.Engines.Basic,
         |   notifier: Oban.Notifiers.Postgres,
         |   queues: [default: 10],
-        |   lifeline: [rescue_after: :timer.hours(2)],
+        |   lifeline: [rescue_after: {2, :hours}],
         |   pruner: [max_age: {1, :day}],
         |   repo: Oban.Test.Repo
       """)

--- a/test/oban/config_test.exs
+++ b/test/oban/config_test.exs
@@ -13,6 +13,10 @@ defmodule Oban.ConfigTest do
     def config, do: []
   end
 
+  defmodule FakePlugin do
+    def init(opts), do: {:ok, opts}
+  end
+
   describe "validate/1" do
     test "legacy :circuit_backoff option is ignored" do
       assert_valid(circuit_backoff: 10)
@@ -146,6 +150,16 @@ defmodule Oban.ConfigTest do
       assert {:error, "unknown option :nam, did you mean :name?"} = Config.validate(nam: :web)
     end
 
+    test "a plugin configured more than once is rejected" do
+      refute_valid(plugins: [Pruner, {Pruner, max_age: 60}])
+      refute_valid(pruner: [max_age: 60], plugins: [Pruner])
+      refute_valid(cron: [crontab: [{"* * * * *", Worker}]], plugins: [Cron])
+      refute_valid(cron: [crontab: []], crontab: [{"* * * * *", Worker}])
+
+      assert_valid(pruner: [max_age: 60], plugins: [Cron])
+      assert_valid(plugins: [Pruner, Cron])
+    end
+
     test "duplicated values are rejected" do
       assert {:error, "found duplicate options: [:peer]"} ==
                Config.validate(peer: false, peer: Oban.Peers.Postgres)
@@ -210,6 +224,34 @@ defmodule Oban.ConfigTest do
       assert %{stage_interval: 1_000} = conf(poll_interval: :infinity, stage_interval: 1_000)
       assert %{stage_interval: 1_000} = conf(plugins: [Oban.Stager])
       assert %{stage_interval: 2_000} = conf(plugins: [{Oban.Stager, interval: 2_000}])
+    end
+
+    test "translating top-level feature keys into plugin usage" do
+      assert has_plugin?(Cron, cron: [crontab: [{"* * * * *", Worker}]])
+      assert has_plugin?(Pruner, pruner: [max_age: 60])
+      assert has_plugin?(Oban.Plugins.Lifeline, lifeline: [rescue_after: 60_000])
+      assert has_plugin?(Oban.Plugins.Reindexer, reindexer: [])
+
+      refute has_plugin?(Pruner, pruner: false)
+      refute has_plugin?(Pruner, [])
+    end
+
+    test "pinning an explicit module through a feature key" do
+      assert %Config{plugins: plugins} = conf(pruner: {FakePlugin, max_age: 60})
+
+      assert {FakePlugin, [max_age: 60]} in plugins
+    end
+
+    test "passing feature key options through to the plugin" do
+      assert %Config{plugins: plugins} = conf(pruner: [max_age: 60])
+
+      assert {Pruner, [max_age: 60]} in plugins
+    end
+
+    test ":testing in :manual mode suppresses top-level feature keys" do
+      conf = conf(pruner: [max_age: 60], cron: [crontab: []], testing: :manual)
+
+      assert %{plugins: [], stage_interval: :infinity} = conf
     end
 
     test "translating :peer false to the disabled module" do

--- a/test/oban/config_test.exs
+++ b/test/oban/config_test.exs
@@ -39,17 +39,24 @@ defmodule Oban.ConfigTest do
       assert_valid(insert_trigger: false)
     end
 
-    test ":log is validated as `false` or a valid log level" do
-      refute_valid(log: 1)
-      refute_valid(log: "false")
-      refute_valid(log: nil)
+    test ":repo accepts log and dynamic_repo options in the tuple form" do
+      refute_valid(repo: {SomeRepo, log: 1})
+      refute_valid(repo: {SomeRepo, log: :nothing})
+      refute_valid(repo: {SomeRepo, log: true})
+      refute_valid(repo: {SomeRepo, dynamic_repo: :nope})
+
+      assert_valid(repo: {SomeRepo, log: false})
+      assert_valid(repo: {SomeRepo, log: :alert})
+      assert_valid(repo: {SomeRepo, log: :debug})
+      assert_valid(repo: {SomeRepo, dynamic_repo: fn -> SomeRepo end})
+    end
+
+    test "top-level :log and :get_dynamic_repo remain valid for backward compatibility" do
       refute_valid(log: :nothing)
-      refute_valid(log: true)
 
       assert_valid(log: false)
-      assert_valid(log: :warning)
-      assert_valid(log: :alert)
       assert_valid(log: :debug)
+      assert_valid(get_dynamic_repo: fn -> SomeRepo end)
     end
 
     test ":notifier is validated as a notifier module" do
@@ -144,10 +151,8 @@ defmodule Oban.ConfigTest do
     end
 
     test "alternatives are suggested for unknown options when they match" do
-      assert {:error, "unknown option :queue, did you mean :queues?"} =
-               Config.validate(queue: false)
-
-      assert {:error, "unknown option :nam, did you mean :name?"} = Config.validate(nam: :web)
+      assert {:error, "unknown option :queue, did you mean :queues?"} = validate(queue: false)
+      assert {:error, "unknown option :nam, did you mean :name?"} = validate(nam: :web)
     end
 
     test "a plugin configured more than once is rejected" do
@@ -162,10 +167,10 @@ defmodule Oban.ConfigTest do
 
     test "duplicated values are rejected" do
       assert {:error, "found duplicate options: [:peer]"} ==
-               Config.validate(peer: false, peer: Oban.Peers.Postgres)
+               validate(peer: false, peer: Oban.Peers.Postgres)
 
       assert {:error, "found duplicate options: [:peer, :plugins]"} ==
-               Config.validate(
+               validate(
                  peer: false,
                  peer: Oban.Peers.Postgres,
                  plugins: [Pruner],
@@ -292,17 +297,23 @@ defmodule Oban.ConfigTest do
   end
 
   defp refute_valid(opts) do
-    assert {:error, _reason} = Config.validate(opts)
+    assert {:error, _reason} = validate(opts)
   end
 
   defp assert_valid(opts) do
-    assert :ok = Config.validate(opts)
+    assert :ok = validate(opts)
   end
 
   defp conf(opts) do
     opts
-    |> Keyword.put(:repo, Repo)
+    |> Keyword.put_new(:repo, Repo)
     |> Config.new()
+  end
+
+  defp validate(opts) do
+    opts
+    |> Keyword.put_new(:repo, Repo)
+    |> Config.validate()
   end
 
   def has_plugin?(plugin, opts) do

--- a/test/oban/period_test.exs
+++ b/test/oban/period_test.exs
@@ -1,0 +1,5 @@
+defmodule Oban.PeriodTest do
+  use Oban.Case, async: true
+
+  doctest Oban.Period
+end

--- a/test/oban/plugins/pruner_test.exs
+++ b/test/oban/plugins/pruner_test.exs
@@ -17,6 +17,14 @@ defmodule Oban.Plugins.PrunerTest do
       assert :ok = Pruner.validate(limit: 1_000)
     end
 
+    test "validating max_age as a period tuple" do
+      assert {:error, _} = Pruner.validate(max_age: {0, :days})
+      assert {:error, _} = Pruner.validate(max_age: {1, :eon})
+
+      assert :ok = Pruner.validate(max_age: {1, :day})
+      assert :ok = Pruner.validate(max_age: {2, :weeks})
+    end
+
     test "providing suggestions for unknown options" do
       assert {:error, "unknown option :inter, did you mean :interval?"} =
                Pruner.validate(inter: 1)
@@ -51,6 +59,20 @@ defmodule Oban.Plugins.PrunerTest do
                |> select([j], j.id)
                |> order_by(asc: :id)
                |> Repo.all()
+    end
+
+    test "a period tuple max_age is normalized to seconds" do
+      TelemetryHandler.attach_events()
+
+      %Job{id: _id_} = insert_historical("completed", :completed_at, 61, 61)
+      %Job{id: kept} = insert_historical("completed", :completed_at, 59, 59)
+
+      name = start_supervised_oban!(plugins: [{Pruner, interval: 10, max_age: {1, :minute}}])
+
+      assert_receive {:event, :stop, _, %{plugin: Pruner, conf: %{name: ^name}} = meta}
+      assert %{pruned_count: 1} = meta
+
+      assert [kept] == Job |> select([j], j.id) |> Repo.all()
     end
   end
 end


### PR DESCRIPTION
This was originally planned for Oban 3.0, but we realized it could be done in a backward-compatible way and avoid the need for breaking config changes entirely. This more closely matches how configuration is done in `oban-py`, and emphasizes that much of this functionality is essential for proper operation rather than an optional "plugin".

In this PR we redesign how maintenance plugins are configured, along with how `repo` is configured at the top level:

- Add top level support for `cron`, `pruner`, `lifeline`, `reindexer` keys that remap to plugins options
- Configure `repo` options with a tuple, e.g. `{Repo, log: false, dynamic_repo: …}` and soft-deprecate the top-level `log` and `get_dynamic_repo` options
- Support the period, e.g. `{1, :day}`, format for `max_age` in the pruner
- Update the installer task to set conservative `lifeline` and `pruner` options by default

All docs, types, and guides are updated to promote the new syntax. For comparison, here is configuration before:

```elixir
config :my_app, Oban,
  repo: MyApp.Repo,
  log: false,
  queues: [default: 10],
  plugins: [
    {Oban.Plugins.Cron, crontab: [{"0 2 * * *", MyApp.NightlyWorker}]},
    {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 7},
    {Oban.Plugins.Lifeline, rescue_after: :timer.hours(2)},
    Oban.Plugins.Reindexer
  ]
 ```

And here it is afterwards:

```elixir
config :my_app, Oban,
  cron: [crontab: [{"0 2 * * *", MyApp.NightlyWorker}]],
  lifeline: [rescue_after: {2, :hours}],
  pruner: [max_age: {1, :day}],
  queues: [default: 10],
  reindexer: [],
  repo: {MyApp.Repo, log: false},
  ```
  
  Addresses several items in #849