### PR TITLE
Accept period durations in plugins

### DIFF
--- a/lib/oban/plugins/lifeline.ex
+++ b/lib/oban/plugins/lifeline.ex
@@ -32,7 +32,8 @@ defmodule Oban.Plugins.Lifeline do
 
   ## Options
 
-  * `:interval` — the number of milliseconds between rescue attempts. The default is `60_000ms`.
+  * `:interval` — the time between rescue attempts, as either an integer number of milliseconds
+    or an `Oban.Period` tuple like `{1, :minute}`. The default is `60_000ms`.
 
   * `:rescue_after` — the maximum amount of time a job may execute before being rescued, as either
     an integer number of milliseconds or an `Oban.Period` tuple like `{1, :hour}`. 1 hour
@@ -61,7 +62,7 @@ defmodule Oban.Plugins.Lifeline do
 
   @type option ::
           Plugin.option()
-          | {:interval, timeout()}
+          | {:interval, Period.t()}
           | {:rescue_after, Period.t()}
 
   defstruct [
@@ -82,11 +83,13 @@ defmodule Oban.Plugins.Lifeline do
 
     state = struct!(State, opts)
 
-    GenServer.start_link(
-      __MODULE__,
-      %{state | rescue_after: Period.to_milliseconds(state.rescue_after)},
-      name: name
-    )
+    state = %{
+      state
+      | interval: Period.to_milliseconds(state.interval),
+        rescue_after: Period.to_milliseconds(state.rescue_after)
+    }
+
+    GenServer.start_link(__MODULE__, state, name: name)
   end
 
   @impl Plugin
@@ -94,7 +97,7 @@ defmodule Oban.Plugins.Lifeline do
     Validation.validate_schema(opts,
       conf: :any,
       name: :any,
-      interval: :pos_integer,
+      interval: :period,
       rescue_after: :period
     )
   end

--- a/lib/oban/plugins/pruner.ex
+++ b/lib/oban/plugins/pruner.ex
@@ -30,7 +30,8 @@ defmodule Oban.Plugins.Pruner do
 
   ## Options
 
-  * `:interval` — the number of milliseconds between pruning attempts. The default is `30_000ms`.
+  * `:interval` — the time between pruning attempts, as either an integer number of milliseconds
+    or an `Oban.Period` tuple like `{30, :seconds}`. The default is `30_000ms`.
 
   * `:limit` — the maximum number of jobs to prune at one time. The default is 10,000 to prevent
     request timeouts. Applications that steadily generate more than 10k jobs a minute should
@@ -59,7 +60,7 @@ defmodule Oban.Plugins.Pruner do
 
   @type option ::
           Plugin.option()
-          | {:interval, pos_integer()}
+          | {:interval, Period.t()}
           | {:limit, pos_integer()}
           | {:max_age, Period.t()}
 
@@ -82,9 +83,13 @@ defmodule Oban.Plugins.Pruner do
 
     state = struct!(State, opts)
 
-    GenServer.start_link(__MODULE__, %{state | max_age: Period.to_seconds(state.max_age)},
-      name: name
-    )
+    state = %{
+      state
+      | interval: Period.to_milliseconds(state.interval),
+        max_age: Period.to_seconds(state.max_age)
+    }
+
+    GenServer.start_link(__MODULE__, state, name: name)
   end
 
   @impl Plugin
@@ -92,7 +97,7 @@ defmodule Oban.Plugins.Pruner do
     Validation.validate_schema(opts,
       conf: :any,
       name: :any,
-      interval: :pos_integer,
+      interval: :period,
       limit: :pos_integer,
       max_age: :period
     )

--- a/lib/oban/plugins/reindexer.ex
+++ b/lib/oban/plugins/reindexer.ex
@@ -30,7 +30,9 @@ defmodule Oban.Plugins.Reindexer do
 
     * `:schedule` — a cron expression that controls when to reindex. Defaults to `"@midnight"`.
 
-    * `:timeout` - time in milliseconds to wait for each query call to finish. Defaults to 15 seconds.
+    * `:timeout` - the time to wait for each query call to finish, as either an integer number of
+      milliseconds, `:infinity`, or an `Oban.Period` tuple like `{15, :seconds}`. Defaults to 15
+      seconds.
 
     * `:timezone` — which timezone to use when evaluating the schedule. To use a timezone other than
       the default of "Etc/UTC" you *must* have a timezone database like [tz][tz] installed and
@@ -43,7 +45,7 @@ defmodule Oban.Plugins.Reindexer do
 
   use GenServer
 
-  alias Oban.{Cron, Peer, Plugin, Repo, Validation}
+  alias Oban.{Cron, Peer, Period, Plugin, Repo, Validation}
   alias __MODULE__, as: State
 
   require Logger
@@ -53,7 +55,7 @@ defmodule Oban.Plugins.Reindexer do
           | {:indexes, [String.t()]}
           | {:schedule, String.t()}
           | {:timezone, Calendar.time_zone()}
-          | {:timeout, timeout()}
+          | {:timeout, timeout() | Period.t()}
 
   defstruct [
     :conf,
@@ -72,8 +74,15 @@ defmodule Oban.Plugins.Reindexer do
   def start_link(opts) do
     {name, opts} = Keyword.pop(opts, :name)
 
-    GenServer.start_link(__MODULE__, struct!(State, opts), name: name)
+    state = struct!(State, opts)
+
+    GenServer.start_link(__MODULE__, %{state | timeout: normalize_timeout(state.timeout)},
+      name: name
+    )
   end
+
+  defp normalize_timeout(:infinity), do: :infinity
+  defp normalize_timeout(timeout), do: Period.to_milliseconds(timeout)
 
   @impl Plugin
   def validate(opts) do
@@ -82,7 +91,7 @@ defmodule Oban.Plugins.Reindexer do
       name: :any,
       indexes: {:list, :string},
       schedule: :schedule,
-      timeout: :timeout,
+      timeout: {:or, [:timeout, :period]},
       timezone: :timezone
     )
   end

--- a/test/oban/plugins/lifeline_test.exs
+++ b/test/oban/plugins/lifeline_test.exs
@@ -14,6 +14,14 @@ defmodule Oban.Plugins.LifelineTest do
       assert :ok = Lifeline.validate(rescue_after: :timer.minutes(30))
     end
 
+    test "validating interval and rescue_after as period tuples" do
+      assert {:error, _} = Lifeline.validate(interval: {0, :seconds})
+      assert {:error, _} = Lifeline.validate(rescue_after: {1, :eon})
+
+      assert :ok = Lifeline.validate(interval: {1, :minute})
+      assert :ok = Lifeline.validate(rescue_after: {30, :minutes})
+    end
+
     test "providing suggestions for unknown options" do
       assert {:error, "unknown option :inter, did you mean :interval?"} =
                Lifeline.validate(inter: 1)

--- a/test/oban/plugins/pruner_test.exs
+++ b/test/oban/plugins/pruner_test.exs
@@ -17,6 +17,14 @@ defmodule Oban.Plugins.PrunerTest do
       assert :ok = Pruner.validate(limit: 1_000)
     end
 
+    test "validating interval as a period tuple" do
+      assert {:error, _} = Pruner.validate(interval: {0, :seconds})
+      assert {:error, _} = Pruner.validate(interval: {1, :eon})
+
+      assert :ok = Pruner.validate(interval: {30, :seconds})
+      assert :ok = Pruner.validate(interval: {1, :minute})
+    end
+
     test "validating max_age as a period tuple" do
       assert {:error, _} = Pruner.validate(max_age: {0, :days})
       assert {:error, _} = Pruner.validate(max_age: {1, :eon})

--- a/test/oban/plugins/reindexer_test.exs
+++ b/test/oban/plugins/reindexer_test.exs
@@ -30,11 +30,15 @@ defmodule Oban.Plugins.ReindexerTest do
       assert :ok = Reindexer.validate(timezone: "America/Chicago")
     end
 
-    test "validating that :timeout is a non negative integer" do
+    test "validating that :timeout is a non negative integer, :infinity, or a period tuple" do
       assert {:error, _} = Reindexer.validate(timeout: "")
       assert {:error, _} = Reindexer.validate(timeout: -1)
+      assert {:error, _} = Reindexer.validate(timeout: {0, :seconds})
+      assert {:error, _} = Reindexer.validate(timeout: {1, :eon})
 
       assert :ok = Reindexer.validate(timeout: :timer.minutes(1))
+      assert :ok = Reindexer.validate(timeout: :infinity)
+      assert :ok = Reindexer.validate(timeout: {15, :seconds})
     end
 
     test "providing suggestions for unknown options" do


### PR DESCRIPTION
This PR extends previous work to accept period durations in more Plugin user-facing options.

In essence, now we accept period durations in the `interval` option from `Pruner` and `Lifeline` plugins, and `period` in the `Reindexer` plugin.

Assisted-by: Claude:claude-4-8-opus