### PR TITLE
Fix migration verification for custom adapters

### DIFF
--- a/lib/oban/migration.ex
+++ b/lib/oban/migration.ex
@@ -272,7 +272,7 @@ defmodule Oban.Migration do
       Ecto.Adapters.Postgres -> Oban.Migrations.Postgres
       Ecto.Adapters.SQLite3 -> Oban.Migrations.SQLite
       Ecto.Adapters.MyXQL -> Oban.Migrations.MyXQL
-      _ -> Keyword.fetch!(repo().config(), :migrator)
+      _ -> Keyword.fetch!(repo.config(), :migrator)
     end
   end
 end

--- a/test/oban/migration_test.exs
+++ b/test/oban/migration_test.exs
@@ -1,0 +1,20 @@
+defmodule Oban.MigrationTest do
+  use ExUnit.Case, async: true
+
+  defmodule CustomAdapter do
+  end
+
+  defmodule CustomMigrator do
+    def current_version, do: 42
+    def migrated_version(_opts), do: 42
+  end
+
+  defmodule CustomRepo do
+    def __adapter__, do: CustomAdapter
+    def config, do: [migrator: CustomMigrator]
+  end
+
+  test "uses the configured custom migrator when verifying migrations" do
+    assert :ok = Oban.Migration.verify_migrated!(repo: CustomRepo)
+  end
+end


### PR DESCRIPTION
## Summary

Use the repo selected from `opts[:repo]` when resolving a configured custom migrator, and cover the migration-verification path with a regression test.

## Motivation

`migrator/1` selects an explicit `:repo`, but the custom-adapter fallback currently ignores that value and calls `Ecto.Migration.repo/0` again:

```elixir
_ -> Keyword.fetch!(repo().config(), :migrator)
```

`Ecto.Migration.repo/0` is only available while an Ecto migration runner is active. Oban's migration verification passes the configured repo explicitly and runs outside that context, so custom adapters with a configured `:migrator` fail before their migrator can be consulted.

Reading `repo.config()` uses the repo that was already selected, matching the built-in adapter branches and allowing migration verification to work for external Ecto adapters.

## Test

The regression test defines a minimal custom adapter, repo, and migrator, then exercises `Oban.Migration.verify_migrated!/1` with the repo passed explicitly.

Locally verified with formatting, warnings-as-errors compilation, the focused regression test, and strict Credo.
